### PR TITLE
[SWY-18] Scaffold Set List Details page UI

### DIFF
--- a/data-relationship-diagram.drawio
+++ b/data-relationship-diagram.drawio
@@ -1,0 +1,851 @@
+<mxfile host="app.diagrams.net" modified="2024-06-05T21:33:39.177Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36" etag="kC9NX5NgflyJUd2KdFPp" version="24.4.14" type="device">
+  <diagram id="R2lEEEUBdFMjLlhIrx00" name="Page-1">
+    <mxGraphModel dx="2683" dy="1124" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0" extFonts="Permanent Marker^https://fonts.googleapis.com/css?family=Permanent+Marker">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-2" value="Songs" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;shadow=0;swimlaneLine=1;rounded=0;swimlaneFillColor=default;" parent="1" vertex="1">
+          <mxGeometry x="-120" y="400" width="180.00000000000045" height="240" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-3" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" parent="C-vyLk0tnHw3VtMMgP7b-2" vertex="1">
+          <mxGeometry y="30" width="180.00000000000045" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-4" value="PK" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;" parent="C-vyLk0tnHw3VtMMgP7b-3" vertex="1">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-5" value="songId" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;" parent="C-vyLk0tnHw3VtMMgP7b-3" vertex="1">
+          <mxGeometry x="30" width="150.00000000000045" height="30" as="geometry">
+            <mxRectangle width="150.00000000000045" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-6" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="C-vyLk0tnHw3VtMMgP7b-2" vertex="1">
+          <mxGeometry y="60" width="180.00000000000045" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-7" value="" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;" parent="C-vyLk0tnHw3VtMMgP7b-6" vertex="1">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-8" value="name" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;" parent="C-vyLk0tnHw3VtMMgP7b-6" vertex="1">
+          <mxGeometry x="30" width="150.00000000000045" height="30" as="geometry">
+            <mxRectangle width="150.00000000000045" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-9" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" parent="C-vyLk0tnHw3VtMMgP7b-2" vertex="1">
+          <mxGeometry y="90" width="180.00000000000045" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-10" value="FK" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;" parent="C-vyLk0tnHw3VtMMgP7b-9" vertex="1">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-11" value="keyId" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;" parent="C-vyLk0tnHw3VtMMgP7b-9" vertex="1">
+          <mxGeometry x="30" width="150.00000000000045" height="30" as="geometry">
+            <mxRectangle width="150.00000000000045" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-23" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="C-vyLk0tnHw3VtMMgP7b-2">
+          <mxGeometry y="120" width="180.00000000000045" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-24" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-23">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-25" value="tempo" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-23">
+          <mxGeometry x="30" width="150.00000000000045" height="30" as="geometry">
+            <mxRectangle width="150.00000000000045" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-30" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="C-vyLk0tnHw3VtMMgP7b-2">
+          <mxGeometry y="150" width="180.00000000000045" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-31" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-30">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-32" value="createdAt" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-30">
+          <mxGeometry x="30" width="150.00000000000045" height="30" as="geometry">
+            <mxRectangle width="150.00000000000045" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-33" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="C-vyLk0tnHw3VtMMgP7b-2">
+          <mxGeometry y="180" width="180.00000000000045" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-34" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-33">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-35" value="createdBy" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-33">
+          <mxGeometry x="30" width="150.00000000000045" height="30" as="geometry">
+            <mxRectangle width="150.00000000000045" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-27" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="C-vyLk0tnHw3VtMMgP7b-2">
+          <mxGeometry y="210" width="180.00000000000045" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-28" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-27">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-29" value="notes string" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-27">
+          <mxGeometry x="30" width="150.00000000000045" height="30" as="geometry">
+            <mxRectangle width="150.00000000000045" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-211" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="C-vyLk0tnHw3VtMMgP7b-2" source="C-vyLk0tnHw3VtMMgP7b-9" target="C-vyLk0tnHw3VtMMgP7b-9">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-212" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="C-vyLk0tnHw3VtMMgP7b-2" source="7d9tw_-okUDQ7UmOcaIx-23" target="7d9tw_-okUDQ7UmOcaIx-23">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-9" value="Users" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="-120" y="800" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-10" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-9">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-11" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-10">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-12" value="userID" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-10">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-13" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-9">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-14" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-13">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-15" value="email" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-13">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-16" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-9">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-17" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-16">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-18" value="firstName" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-16">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-19" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-9">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-20" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-19">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-21" value="lastName" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-19">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-36" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERoneToMany;startArrow=ERmandOne;rounded=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-10" target="7d9tw_-okUDQ7UmOcaIx-33">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="60" y="750" as="sourcePoint" />
+            <mxPoint x="129.99999999999955" y="534.9999999999998" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="170" y="750" />
+              <mxPoint x="240" y="630" />
+              <mxPoint x="260" y="540" />
+              <mxPoint x="-210" y="640" />
+              <mxPoint x="220" y="650" />
+              <mxPoint x="160" y="640" />
+              <mxPoint x="-240" y="610" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-67" value="SongTags" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="-120" y="180" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-68" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-67">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-69" value="&lt;span style=&quot;font-weight: normal;&quot;&gt;FK&lt;/span&gt;" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-68">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-70" value="&lt;span style=&quot;font-weight: 400;&quot;&gt;tagId&lt;/span&gt;" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-68">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-71" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-67">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-72" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-71">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-73" value="songId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-71">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-74" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-67">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-75" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-74">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-76" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-74">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-77" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-67">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-78" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-77">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-79" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-77">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-80" value="Tags" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="200" y="180" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-81" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-80">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-82" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-81">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-83" value="tagId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-81">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-84" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-80">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-85" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-84">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-86" value="tag" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-84">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-87" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-80">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-88" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-87">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-89" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-87">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-90" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-80">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-91" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-90">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-92" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-90">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-95" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;" edge="1" parent="1" source="C-vyLk0tnHw3VtMMgP7b-3" target="7d9tw_-okUDQ7UmOcaIx-71">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="490" y="530" as="sourcePoint" />
+            <mxPoint x="590" y="430" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-96" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-81" target="7d9tw_-okUDQ7UmOcaIx-68">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="490" y="530" as="sourcePoint" />
+            <mxPoint x="590" y="430" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-100" value="Organisations" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="500" y="800" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-101" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-100">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-102" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-101">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-103" value="organisationId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-101">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-104" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-100">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-105" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-104">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-106" value="name" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-104">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-107" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-100">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-108" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-107">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-109" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-107">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-110" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-100">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-111" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-110">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-112" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-110">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-113" value="OrganisationMembers" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="210" y="800" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-114" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-113">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-115" value="&lt;span style=&quot;font-weight: normal;&quot;&gt;FK&lt;/span&gt;" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-114">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-116" value="&lt;span style=&quot;font-weight: normal;&quot;&gt;organisationId&lt;/span&gt;" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-114">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-117" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-113">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-118" value="&lt;span style=&quot;font-weight: normal;&quot;&gt;FK&lt;/span&gt;" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;fontStyle=1" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-117">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-119" value="userId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-117">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-120" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-113">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-121" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-120">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-122" value="permissionTypeId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-120">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-123" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-113">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-124" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-123">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-125" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-123">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-126" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-10" target="7d9tw_-okUDQ7UmOcaIx-117">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="490" y="810" as="sourcePoint" />
+            <mxPoint x="590" y="710" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-127" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERoneToMany;startArrow=ERmandOne;rounded=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-101" target="7d9tw_-okUDQ7UmOcaIx-114">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="490" y="810" as="sourcePoint" />
+            <mxPoint x="590" y="710" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-128" value="Sets" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="800" y="400" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-129" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-128">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-130" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-129">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-131" value="setId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-129">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-132" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-128">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-133" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-132">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-134" value="eventTypeId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-132">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-135" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-128">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-136" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-135">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-137" value="date" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-135">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-138" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-128">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-139" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-138">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-140" value="notes" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-138">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-141" value="EventTypes" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="1070" y="400" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-142" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-141">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-143" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-142">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-144" value="eventTypeId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-142">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-145" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-141">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-146" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-145">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-147" value="event" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-145">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-148" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-141">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-149" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-148">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-150" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-148">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-151" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-141">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-152" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-151">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-153" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-151">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-154" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-142" target="7d9tw_-okUDQ7UmOcaIx-132">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="710" y="710" as="sourcePoint" />
+            <mxPoint x="810" y="610" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-155" value="PermissionTypes" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="210" y="1010" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-156" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-155">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-157" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-156">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-158" value="permissionTypeId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-156">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-159" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-155">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-160" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-159">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-161" value="permission" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-159">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-162" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-155">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-163" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-162">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-164" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-162">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-165" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-155">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-166" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-165">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-167" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-165">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-168" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;exitX=1;exitY=0.631;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-156" target="7d9tw_-okUDQ7UmOcaIx-120">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="490" y="1080" as="sourcePoint" />
+            <mxPoint x="590" y="980" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-169" value="SetSections" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="500" y="400" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-170" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-169">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-171" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-170">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-172" value="setSectionId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-170">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-173" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-169">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-174" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-173">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-175" value="setId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-173">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-176" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-169">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-177" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-176">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-178" value="positon" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-176">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-179" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-169">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-180" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-179">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-181" value="sectionTypeId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-179">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-182" value="sectionTypes" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="500" y="600" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-183" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-182">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-184" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-183">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-185" value="sectionTypeId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-183">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-186" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-182">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-187" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-186">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-188" value="section" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-186">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-189" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-182">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-190" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-189">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-191" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-189">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-192" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-182">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-193" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-192">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-194" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-192">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-195" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-183" target="7d9tw_-okUDQ7UmOcaIx-179">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="580" y="740" as="sourcePoint" />
+            <mxPoint x="680" y="640" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-196" value="Keys" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="-390" y="400" width="180" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-197" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-196">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-198" value="PK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-197">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-199" value="keyId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-197">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-200" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-196">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-201" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-200">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-202" value="key" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-200">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-203" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-196">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-204" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-203">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-205" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-203">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-206" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-196">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-207" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-206">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-208" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-206">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-209" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-197" target="C-vyLk0tnHw3VtMMgP7b-9">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="-390" y="740" as="sourcePoint" />
+            <mxPoint x="-290" y="640" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-210" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;exitX=-0.007;exitY=0.671;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-129" target="7d9tw_-okUDQ7UmOcaIx-173">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="890" y="630" as="sourcePoint" />
+            <mxPoint x="760" y="600" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-213" value="SetSectionSongs" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;html=1;" vertex="1" parent="1">
+          <mxGeometry x="200" y="400" width="180" height="150.00000000000023" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-214" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-213">
+          <mxGeometry y="30" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-215" value="&lt;span style=&quot;font-weight: normal;&quot;&gt;FK&lt;/span&gt;" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-214">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-216" value="&lt;span style=&quot;font-weight: normal;&quot;&gt;setSectionId&lt;/span&gt;" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-214">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-217" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-213">
+          <mxGeometry y="60" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-218" value="FK" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-217">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-219" value="songId" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-217">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-220" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-213">
+          <mxGeometry y="90" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-221" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-220">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-222" value="position" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-220">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-223" value="" style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;fillColor=none;collapsible=0;dropTarget=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-213">
+          <mxGeometry y="120" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-224" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;editable=1;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-223">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-225" value="" style="shape=partialRectangle;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;overflow=hidden;whiteSpace=wrap;html=1;" vertex="1" parent="7d9tw_-okUDQ7UmOcaIx-223">
+          <mxGeometry x="30" width="150" height="30" as="geometry">
+            <mxRectangle width="150" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-226" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;" edge="1" parent="1" source="C-vyLk0tnHw3VtMMgP7b-3" target="7d9tw_-okUDQ7UmOcaIx-217">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="380" y="700" as="sourcePoint" />
+            <mxPoint x="480" y="600" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7d9tw_-okUDQ7UmOcaIx-227" value="" style="edgeStyle=entityRelationEdgeStyle;fontSize=12;html=1;endArrow=ERzeroToMany;startArrow=ERmandOne;rounded=0;" edge="1" parent="1" source="7d9tw_-okUDQ7UmOcaIx-170" target="7d9tw_-okUDQ7UmOcaIx-214">
+          <mxGeometry width="100" height="100" relative="1" as="geometry">
+            <mxPoint x="380" y="700" as="sourcePoint" />
+            <mxPoint x="480" y="600" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.5",
     "@t3-oss/env-nextjs": "^0.10.1",
     "@tanstack/react-query": "^5.39.0",
     "@trpc/client": "next",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@phosphor-icons/react':
+        specifier: ^2.1.5
+        version: 2.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@t3-oss/env-nextjs':
         specifier: ^0.10.1
         version: 0.10.1(typescript@5.4.5)(zod@3.23.8)
@@ -778,6 +781,13 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@phosphor-icons/react@2.1.5':
+    resolution: {integrity: sha512-B7vRm/w+P/+eavWZP5CB5Ul0ffK4Y7fpd/auWKuGvm+8pVgAJzbOK8O0s+DqzR+TwWkh5pHtJTuoAtaSvgCPzg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4091,6 +4101,11 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@phosphor-icons/react@2.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/app/[organization]/layout.tsx
+++ b/src/app/[organization]/layout.tsx
@@ -1,4 +1,5 @@
 import { startCase } from "@/lib/string";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 const ORGANIZATION_WHITELIST = ["demo", "stoneway"];
@@ -21,7 +22,8 @@ export default function DashboardLayout({
   return (
     <main className="container px-4 pb-16">
       <nav className="flex h-[60px] items-center text-slate-700">
-        Sanbi // {organizationName}
+        Sanbi //{" "}
+        <Link href={`/${params.organization}`}>{organizationName}</Link>
       </nav>
       {children}
     </main>

--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -5,8 +5,13 @@ import {
   SetListCardSection,
   SongItem,
 } from "@/modules/SetlistCard";
+import Link from "next/link";
 
-export default async function Dashboard() {
+export default async function Dashboard({
+  params,
+}: {
+  params: { organization: string };
+}) {
   return (
     <div className="flex min-w-full max-w-xs flex-col justify-center">
       <header className="pb-2">
@@ -20,28 +25,30 @@ export default async function Dashboard() {
         <a className="text-xs text-slate-900">See all</a>
       </section>
       <div className="flex flex-col gap-4">
-        <SetListCard>
-          <SetListCardHeader
-            date="2024-08-14"
-            type="Sunday Service"
-            numberOfSongs={5}
-          />
-          <SetListCardBody>
-            <SetListCardSection title="Worship">
-              <SongItem index={1} songKey="B" name="In My Place" />
-              <SongItem index={2} songKey="A" name="Such An Awesome God" />
-              <SongItem
-                index={3}
-                songKey="G"
-                name="I Love You Lord / What A Beautiful Name (mash up)"
-              />
-              <SongItem index={4} songKey="A" name="God Over Everything" />
-            </SetListCardSection>
-            <SetListCardSection title="Prayer Time">
-              <SongItem index={5} songKey="B" name="Son Of Suffering" />
-            </SetListCardSection>
-          </SetListCardBody>
-        </SetListCard>
+        <Link href={`/${params.organization}/sets/demo`}>
+          <SetListCard>
+            <SetListCardHeader
+              date="2024-08-14"
+              type="Sunday Service"
+              numberOfSongs={5}
+            />
+            <SetListCardBody>
+              <SetListCardSection title="Worship">
+                <SongItem index={1} songKey="B" name="In My Place" />
+                <SongItem index={2} songKey="A" name="Such An Awesome God" />
+                <SongItem
+                  index={3}
+                  songKey="G"
+                  name="I Love You Lord / What A Beautiful Name (mash up)"
+                />
+                <SongItem index={4} songKey="A" name="God Over Everything" />
+              </SetListCardSection>
+              <SetListCardSection title="Prayer Time">
+                <SongItem index={5} songKey="B" name="Son Of Suffering" />
+              </SetListCardSection>
+            </SetListCardBody>
+          </SetListCard>
+        </Link>
         <SetListCard>
           <SetListCardHeader
             date="2024-08-07"

--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -1,3 +1,4 @@
+import { PageTitle } from "@/components";
 import {
   SetListCard,
   SetListCardBody,
@@ -14,10 +15,7 @@ export default async function Dashboard({
 }) {
   return (
     <div className="flex min-w-full max-w-xs flex-col justify-center">
-      <header className="pb-2">
-        <h1 className="mb-1 text-2xl font-bold">Upcoming sets</h1>
-        <h2 className="text-xs text-slate-500">3 sets</h2>
-      </header>
+      <PageTitle title="Upcoming sets" details="3 sets" />
       <section className="flex justify-between py-2">
         <select>
           <option value="This week">This week</option>

--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -6,6 +6,7 @@ import {
   SetListCardSection,
   SongItem,
 } from "@/modules/SetlistCard";
+import { CardList } from "@/modules/SetlistCard/components/CardList";
 import Link from "next/link";
 
 export default async function Dashboard({
@@ -22,7 +23,7 @@ export default async function Dashboard({
         </select>
         <a className="text-xs text-slate-900">See all</a>
       </section>
-      <div className="flex flex-col gap-4">
+      <CardList>
         <Link href={`/${params.organization}/sets/demo`}>
           <SetListCard>
             <SetListCardHeader
@@ -96,7 +97,7 @@ export default async function Dashboard({
             </SetListCardSection>
           </SetListCardBody>
         </SetListCard>
-      </div>
+      </CardList>
     </div>
   );
 }

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -53,7 +53,7 @@ export default async function SetListPage({
         <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
           <header className="flex flex-col gap-2">
             <div className="flex justify-between">
-              <h3 className="text-base font-semibold">Lord's Supper</h3>
+              <h3 className="text-base font-semibold">Lord&apos;s Supper</h3>
               <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
                 ...
               </button>

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,5 +1,6 @@
 import { PageTitle } from "@/components";
 import { SetListCardBody, SongItem } from "@/modules/SetlistCard";
+import { CardList } from "@/modules/SetlistCard/components/CardList";
 import { DotsThree } from "@phosphor-icons/react/dist/ssr";
 
 export default async function SetListPage({
@@ -22,7 +23,7 @@ export default async function SetListPage({
           <DotsThree className="text-slate-900" size={12} />
         </button>
       </section>
-      <div className="flex flex-col gap-4">
+      <CardList gap="gap-8">
         <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
           <header className="flex flex-col gap-2">
             <div className="flex justify-between">
@@ -91,7 +92,7 @@ export default async function SetListPage({
             </div>
           </SetListCardBody>
         </div>
-      </div>
+      </CardList>
     </div>
   );
 }

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,4 +1,5 @@
 import { SetListCardBody, SongItem } from "@/modules/SetlistCard";
+import { DotsThree } from "@phosphor-icons/react/dist/ssr";
 
 export default async function SetListPage({
   params,
@@ -17,7 +18,7 @@ export default async function SetListPage({
           Add notes
         </button>
         <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
-          ...
+          <DotsThree className="text-slate-900" size={12} />
         </button>
       </section>
       <div className="flex flex-col gap-4">
@@ -26,7 +27,7 @@ export default async function SetListPage({
             <div className="flex justify-between">
               <h3 className="text-base font-semibold">Worship</h3>
               <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
-                ...
+                <DotsThree className="text-slate-900" size={12} />
               </button>
             </div>
             <hr className="bg-slate-100" />
@@ -55,7 +56,7 @@ export default async function SetListPage({
             <div className="flex justify-between">
               <h3 className="text-base font-semibold">Lord&apos;s Supper</h3>
               <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
-                ...
+                <DotsThree className="text-slate-900" size={12} />
               </button>
             </div>
             <hr className="bg-slate-100" />
@@ -71,7 +72,7 @@ export default async function SetListPage({
             <div className="flex justify-between">
               <h3 className="text-base font-semibold">Prayer</h3>
               <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
-                ...
+                <DotsThree className="text-slate-900" size={12} />
               </button>
             </div>
             <hr className="bg-slate-100" />

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,18 +1,19 @@
+import { PageTitle } from "@/components";
 import { SetListCardBody, SongItem } from "@/modules/SetlistCard";
 import { DotsThree } from "@phosphor-icons/react/dist/ssr";
 
 export default async function SetListPage({
-  params,
+  params: _params,
 }: {
   params: { setId: string };
 }) {
   return (
     <div className="flex min-w-full max-w-xs flex-col justify-center gap-6">
-      <header className="flex flex-col gap-1 pb-2">
-        <h1 className="text-2xl font-bold">August 07</h1>
-        <h2 className="text-base text-slate-700">Discipleship Community</h2>
-        <p className="text-xs text-slate-500">8 songs</p>
-      </header>
+      <PageTitle
+        title="August 07"
+        subtitle="Discipleship Community"
+        details="8 songs"
+      />
       <section className="flex justify-between gap-2">
         <button className="w-full rounded border border-slate-300 px-3 text-xs font-semibold text-slate-700">
           Add notes

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,0 +1,95 @@
+import { SetListCardBody, SongItem } from "@/modules/SetlistCard";
+
+export default async function SetListPage({
+  params,
+}: {
+  params: { setId: string };
+}) {
+  return (
+    <div className="flex min-w-full max-w-xs flex-col justify-center gap-6">
+      <header className="flex flex-col gap-1 pb-2">
+        <h1 className="text-2xl font-bold">August 07</h1>
+        <h2 className="text-base text-slate-700">Discipleship Community</h2>
+        <p className="text-xs text-slate-500">8 songs</p>
+      </header>
+      <section className="flex justify-between gap-2">
+        <button className="w-full rounded border border-slate-300 px-3 text-xs font-semibold text-slate-700">
+          Add notes
+        </button>
+        <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
+          ...
+        </button>
+      </section>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
+          <header className="flex flex-col gap-2">
+            <div className="flex justify-between">
+              <h3 className="text-base font-semibold">Worship</h3>
+              <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
+                ...
+              </button>
+            </div>
+            <hr className="bg-slate-100" />
+          </header>
+          <SetListCardBody>
+            <div className="flex flex-col gap-3">
+              <SongItem
+                index={1}
+                songKey="B"
+                name="In My Place"
+                notes="Play in the key of B to make it easier for the backup vocalist to harmonize with."
+              />
+              <SongItem index={2} songKey="A" name="Such An Awesome God" />
+              <SongItem
+                index={3}
+                songKey="G"
+                name="I Love You Lord / What A Beautiful Name (mash up)"
+                notes="Song is best with only vocals, guitar, and keys. Feels powerful with only vocals on the last chorus."
+              />
+              <SongItem index={4} songKey="A" name="God Over Everything" />
+            </div>
+          </SetListCardBody>
+        </div>
+        <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
+          <header className="flex flex-col gap-2">
+            <div className="flex justify-between">
+              <h3 className="text-base font-semibold">Lord's Supper</h3>
+              <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
+                ...
+              </button>
+            </div>
+            <hr className="bg-slate-100" />
+          </header>
+          <SetListCardBody>
+            <div className="flex flex-col gap-3">
+              <SongItem index={5} songKey="B" name="Son Of Suffering" />
+            </div>
+          </SetListCardBody>
+        </div>
+        <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
+          <header className="flex flex-col gap-2">
+            <div className="flex justify-between">
+              <h3 className="text-base font-semibold">Prayer</h3>
+              <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
+                ...
+              </button>
+            </div>
+            <hr className="bg-slate-100" />
+          </header>
+          <SetListCardBody>
+            <div className="flex flex-col gap-3">
+              <SongItem index={6} songKey="B" name="Draw Me Close To You" />
+              <SongItem index={7} songKey="A" name="Romans 2:4" />
+              <SongItem
+                index={8}
+                songKey="G"
+                name="Only Jesus"
+                notes="Skip the tag if not playing with full band."
+              />
+            </div>
+          </SetListCardBody>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -1,6 +1,11 @@
 export type PageTitleProps = {
+  /** title */
   title: string;
+
+  /** subtitle */
   subtitle?: string;
+
+  /** small text under title/subtitle */
   details?: string;
 };
 
@@ -9,7 +14,6 @@ export const PageTitle: React.FC<PageTitleProps> = ({
   subtitle,
   details,
 }) => {
-  // something
   return (
     <header className="flex flex-col gap-1 pb-2">
       <h1 className="text-2xl font-bold">{title}</h1>

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -1,0 +1,22 @@
+export type PageTitleProps = {
+  title: string;
+  subtitle?: string;
+  details?: string;
+};
+
+export const PageTitle: React.FC<PageTitleProps> = ({
+  title,
+  subtitle,
+  details,
+}) => {
+  // something
+  return (
+    <header className="flex flex-col gap-1 pb-2">
+      <h1 className="text-2xl font-bold">{title}</h1>
+      {subtitle ? (
+        <h2 className="text-base text-slate-700">{subtitle}</h2>
+      ) : null}
+      {details ? <p className="text-xs text-slate-500">{details}</p> : null}
+    </header>
+  );
+};

--- a/src/components/PageTitle/index.ts
+++ b/src/components/PageTitle/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageTitle";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageTitle";

--- a/src/modules/SetlistCard/components/CardList/CardList.tsx
+++ b/src/modules/SetlistCard/components/CardList/CardList.tsx
@@ -1,0 +1,10 @@
+export type CardListProps = {
+  gap?: string;
+};
+
+export const CardList: React.FC<React.PropsWithChildren<CardListProps>> = ({
+  gap = "gap-4",
+  children,
+}) => {
+  return <div className={`flex flex-col ${gap}`}>{children}</div>;
+};

--- a/src/modules/SetlistCard/components/CardList/CardList.tsx
+++ b/src/modules/SetlistCard/components/CardList/CardList.tsx
@@ -1,4 +1,5 @@
 export type CardListProps = {
+  /** spacing between cards - uses TailwindCSS values - https://tailwindcss.com/docs/gap  */
   gap?: string;
 };
 

--- a/src/modules/SetlistCard/components/CardList/index.ts
+++ b/src/modules/SetlistCard/components/CardList/index.ts
@@ -1,0 +1,1 @@
+export * from "./CardList";

--- a/src/modules/SetlistCard/components/SetListCard/SetListCard.tsx
+++ b/src/modules/SetlistCard/components/SetListCard/SetListCard.tsx
@@ -1,7 +1,6 @@
 export const SetListCard: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
-  // something
   return (
     <div className="min-w-full rounded border border-slate-200 p-4 shadow">
       {children}

--- a/src/modules/SetlistCard/components/SetListCardBody/SetListCardBody.tsx
+++ b/src/modules/SetlistCard/components/SetListCardBody/SetListCardBody.tsx
@@ -1,6 +1,5 @@
 export const SetListCardBody: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
-  // something
   return <div className="flex flex-col gap-y-3">{children}</div>;
 };

--- a/src/modules/SetlistCard/components/SetListCardSection/SetListCardSection.tsx
+++ b/src/modules/SetlistCard/components/SetListCardSection/SetListCardSection.tsx
@@ -5,8 +5,6 @@ export type SetListCardSectionProps = {
 export const SetListCardSection: React.FC<
   React.PropsWithChildren<SetListCardSectionProps>
 > = ({ title, children }) => {
-  // something
-
   return (
     <section>
       <h3 className="mb-2 text-[10px] uppercase text-slate-500">{title}</h3>

--- a/src/modules/SetlistCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetlistCard/components/SongItem/SongItem.tsx
@@ -7,9 +7,17 @@ export type SongItemProps = {
 
   /** name of song */
   name: string;
+
+  /** song notes */
+  notes?: string;
 };
 
-export const SongItem: React.FC<SongItemProps> = ({ index, songKey, name }) => {
+export const SongItem: React.FC<SongItemProps> = ({
+  index,
+  songKey,
+  name,
+  notes,
+}) => {
   // something
 
   return (
@@ -17,11 +25,18 @@ export const SongItem: React.FC<SongItemProps> = ({ index, songKey, name }) => {
       <p className="h-[18px] w-[18px] flex-none text-right text-xs/[18px] text-slate-400">
         {index}.
       </p>
-      <div className="items-top flex gap-2">
-        <p className="flex h-4 w-4 flex-none place-content-center rounded bg-slate-200">
-          {songKey}
-        </p>
-        <p className="text-slate-900">{name}</p>
+      <div className="flex flex-col gap-2">
+        <div className="items-top flex gap-2">
+          <p className="flex h-4 w-4 flex-none place-content-center rounded bg-slate-200">
+            {songKey}
+          </p>
+          <p className="text-slate-900">{name}</p>
+        </div>
+        {notes ? (
+          <p className="text-[10px]/[16px] font-normal text-slate-700">
+            {notes}
+          </p>
+        ) : null}
       </div>
     </div>
   );

--- a/src/modules/SetlistCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetlistCard/components/SongItem/SongItem.tsx
@@ -18,8 +18,6 @@ export const SongItem: React.FC<SongItemProps> = ({
   name,
   notes,
 }) => {
-  // something
-
   return (
     <div className="flex gap-3 text-xs font-semibold">
       <p className="h-[18px] w-[18px] flex-none text-right text-xs/[18px] text-slate-400">


### PR DESCRIPTION
## Background
This PR is to scaffold out the set list details page UI with dummy data

![SWY-18--after](https://github.com/justaddcl/sanbi/assets/20213406/8af81538-8d01-4cbd-83f6-0136b24ea9d3)

## What's Changed
[Dependencies]
- Added `phosphor-icons`

[Pages]
- Added the `[organization]/sets/[setId]` route page

[Components]
- General components
  - Added `PageTitle` component
- `SetListCard` module
  - Added `CardList` component
  - Updated `SongItem` to take `notes`

[Misc]
- Added database ERD

## How to test
1. Run the PR locally and navigate to the `/stoneway` route
2. Click on the first set on the dashboard and ensure that the app navigates to `/stoneway/sets/demo`
3. Ensure the UI matches the screenshot above