### PR TITLE
[SWY-20] Create reusable Text component and styles

### DIFF
--- a/src/app/[organization]/layout.tsx
+++ b/src/app/[organization]/layout.tsx
@@ -1,4 +1,4 @@
-import { startCase } from "@/lib/string";
+import { startCase } from "@lib/string";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,5 +1,6 @@
-import { PageTitle } from "@/components";
 import { CardList, SetListCardBody, SongItem } from "@/modules/SetListCard";
+import { PageTitle } from "@components/PageTitle";
+import { Text } from "@components/Text";
 import { DotsThree } from "@phosphor-icons/react/dist/ssr";
 import Link from "next/link";
 
@@ -27,7 +28,9 @@ export default async function SetListPage({
         <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
           <header className="flex flex-col gap-2">
             <div className="flex justify-between">
-              <h3 className="text-base font-semibold">Worship</h3>
+              <Text asElement="h3" style="header-medium-semibold">
+                Worship
+              </Text>
               <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
                 <DotsThree className="text-slate-900" size={12} />
               </button>
@@ -58,7 +61,9 @@ export default async function SetListPage({
         <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
           <header className="flex flex-col gap-2">
             <div className="flex justify-between">
-              <h3 className="text-base font-semibold">Lord&apos;s Supper</h3>
+              <Text asElement="h3" style="header-medium-semibold">
+                Lord&apos;s Supper
+              </Text>
               <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
                 <DotsThree className="text-slate-900" size={12} />
               </button>
@@ -74,7 +79,9 @@ export default async function SetListPage({
         <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
           <header className="flex flex-col gap-2">
             <div className="flex justify-between">
-              <h3 className="text-base font-semibold">Prayer</h3>
+              <Text asElement="h3" style="header-medium-semibold">
+                Prayer
+              </Text>
               <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
                 <DotsThree className="text-slate-900" size={12} />
               </button>

--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -1,13 +1,16 @@
-import { Badge, PageTitle, SongKey } from "@/components";
-import { CardList, PlayHistoryItem, ResourceCard } from "@/modules/SetListCard";
+import { Badge } from "@components/Badge";
+import { PageTitle } from "@components/PageTitle";
+import { SongKey } from "@components/SongKey";
+import { Text } from "@components/Text";
+import { CardList, PlayHistoryItem, ResourceCard } from "@modules/SetListCard";
 import {
+  ClockCounterClockwise,
   DotsThree,
   Heart,
   ListPlus,
-  MusicNotesSimple,
-  ClockCounterClockwise,
-  TagSimple,
   Metronome,
+  MusicNotesSimple,
+  TagSimple,
 } from "@phosphor-icons/react/dist/ssr";
 
 export default async function SetListPage({
@@ -20,7 +23,7 @@ export default async function SetListPage({
       <PageTitle title="In My Place" />
       <section>
         {/* FIXME: refactor definition list into reusable components */}
-        <dl className="text-xs text-slate-700">
+        <dl>
           <dt className="mb-[2px] flex items-center gap-1 text-[8px]/[12px] uppercase text-slate-500">
             <MusicNotesSimple className="text-slate-400" size={8} />
             <span>Preferred Key</span>
@@ -33,9 +36,16 @@ export default async function SetListPage({
             <span>Last Played</span>
           </dt>
           <dd className="[&:not(:last-child)]:mb-2">
-            <span className="">One week ago</span>
-            <span className="text-slate-500"> for </span>
-            <span className="">Sunday service</span>
+            <Text asElement="span" style="body-small" color="slate-700">
+              One week ago
+            </Text>
+            <Text asElement="span" style="body-small" color="slate-500">
+              {" "}
+              for{" "}
+            </Text>
+            <Text asElement="span" style="body-small" color="slate-700">
+              Sunday service
+            </Text>
           </dd>
           <dt className="flex items-center gap-1 text-[8px]/[12px] uppercase text-slate-500">
             <TagSimple className="text-slate-400" size={8} />
@@ -49,20 +59,32 @@ export default async function SetListPage({
             <Metronome className="text-slate-400" size={8} />
             <span>Tempo</span>
           </dt>
-          <dd className="[&:not(:last-child)]:mb-2">Slow</dd>
+          <dd className="[&:not(:last-child)]:mb-2">
+            <Text asElement="span" style="body-small" color="slate-700">
+              Slow
+            </Text>
+          </dd>
         </dl>
       </section>
       <section className="flex flex-col gap-4 text-xs">
-        <h3 className="font-semibold text-slate-500">Notes</h3>
-        <p className="text-slate-900">
+        <Text asElement="h3" style="header-small-semibold">
+          Notes
+        </Text>
+        <Text style="body-small">
           Play in the key of B to make it easier for the backup vocalist to
           harmonize with.
-        </p>
+        </Text>
       </section>
       <section className="flex justify-between gap-2">
-        <button className="flex w-full items-center justify-center gap-2 rounded border border-slate-300 px-3 text-xs font-semibold text-slate-700">
+        <button className="flex w-full items-center justify-center gap-2 rounded border border-slate-300 px-3 text-slate-700">
           <ListPlus size={12} />
-          Add to set
+          <Text
+            asElement="span"
+            style="header-small-semibold"
+            color="slate-700"
+          >
+            Add to set
+          </Text>
         </button>
         <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
           <Heart className="text-slate-900" size={12} />
@@ -76,7 +98,9 @@ export default async function SetListPage({
         <div className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow">
           <header className="flex flex-col gap-2">
             <div className="flex justify-between">
-              <h3 className="text-base font-semibold">Resources</h3>
+              <Text asElement="h3" style="header-medium-semibold">
+                Resources
+              </Text>
               <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
                 <DotsThree className="text-slate-900" size={12} />
               </button>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,11 +1,12 @@
+import { Text } from "@components/Text";
 export type BadgeProps = {
   label: string;
 };
 
 export const Badge: React.FC<BadgeProps> = ({ label }) => {
   return (
-    <span className="rounded bg-slate-200 px-2 py-1 text-slate-900">
+    <Text style="body-small" className="rounded bg-slate-200 px-2 py-1">
       {label}
-    </span>
+    </Text>
   );
 };

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -1,3 +1,5 @@
+import { Text } from "@components/Text";
+
 export type PageTitleProps = {
   /** title */
   title: string;
@@ -16,11 +18,20 @@ export const PageTitle: React.FC<PageTitleProps> = ({
 }) => {
   return (
     <header className="flex flex-col gap-1 pb-2">
-      <h1 className="text-2xl font-bold">{title}</h1>
+      {/* <h1 className="text-2xl font-bold">{title}</h1> */}
+      <Text asElement="h1" style="header-large">
+        {title}
+      </Text>
       {subtitle ? (
-        <h2 className="text-base text-slate-700">{subtitle}</h2>
+        <Text asElement="h2" style="header-medium" className="leading-tight">
+          {subtitle}
+        </Text>
       ) : null}
-      {details ? <p className="text-xs text-slate-500">{details}</p> : null}
+      {details ? (
+        <Text asElement="h3" style="header-small">
+          {details}
+        </Text>
+      ) : null}
     </header>
   );
 };

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -18,20 +18,19 @@ export const PageTitle: React.FC<PageTitleProps> = ({
 }) => {
   return (
     <header className="flex flex-col gap-1 pb-2">
-      {/* <h1 className="text-2xl font-bold">{title}</h1> */}
       <Text asElement="h1" style="header-large">
         {title}
       </Text>
-      {subtitle ? (
+      {subtitle && (
         <Text asElement="h2" style="header-medium" className="leading-tight">
           {subtitle}
         </Text>
-      ) : null}
-      {details ? (
+      )}
+      {details && (
         <Text asElement="h3" style="header-small">
           {details}
         </Text>
-      ) : null}
+      )}
     </header>
   );
 };

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -94,7 +94,6 @@ export const Text: React.FC<React.PropsWithChildren<TextProps>> = ({
   children,
 }) => {
   const HtmlElement = asElement;
-  console.log(HtmlElement);
 
   const propertyValues: Record<MappedTwProperties, string | undefined> = {
     fontWeight,

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,0 +1,120 @@
+import { mapTwFontClass } from "@lib/styles";
+import {
+  type FontWeight,
+  type TypographyStyle,
+  type MappedTwProperties,
+  mappedTwProperties,
+} from "@lib/styles/typography";
+
+type TextProps = {
+  /**
+   * Allows you to specify this component's HTML element
+   *
+   * - - -
+   *
+   * Default: `p`
+   */
+  asElement?: "h1" | "h2" | "h3" | "h4" | "p" | "span";
+
+  /** A space-delimited list of class names to pass along to a child element. */
+  className?: string;
+
+  /** Which typography style should the text use? */
+  style?: TypographyStyle;
+
+  /**
+   * The font size of the text according to our pre-defined css variables.
+   *
+   * __Heading__
+   * - `H1 24px` | `H2 16px`
+   *
+   * __Body__
+   * - `body-small 12px`
+   *
+   * __Small__
+   * - `Small 10px`
+   *
+   * - - -
+   *
+   * Default: `base (16px)`
+   */
+  fontSize?: string;
+
+  /**
+   * Sets how thick or thin characters in text should be displayed.
+   * This will override any of typography style presets
+   *
+   * - - -
+   *
+   * Default: `regular`
+   */
+  fontWeight?: FontWeight;
+
+  /**
+   * Specifies the height of a line of text using Tailwind CSS values
+   *
+   * - `tight 125%` | `normal 150%`
+   *
+   * - - -
+   *
+   * Default: `normal (150%)`
+   */
+  lineHeight?: string;
+
+  /**
+   * Specifies the color of text using to Tailwind CSS colors.
+   *
+   * - - -
+   *
+   * Default: `slate-900`
+   */
+  color?: string;
+
+  /**
+   * Specifies letter spacing using Tailwind CSS values.
+   *
+   * - `tighter -0.05em` | `tight -0.025em%`
+   *
+   * - - -
+   *
+   * Default: `normal`
+   */
+  letterSpacing?: string;
+};
+
+export const Text: React.FC<React.PropsWithChildren<TextProps>> = ({
+  asElement = "p",
+  style,
+  className,
+  fontWeight,
+  fontSize,
+  lineHeight,
+  letterSpacing,
+  color,
+  children,
+}) => {
+  const HtmlElement = asElement;
+  console.log(HtmlElement);
+
+  const propertyValues: Record<MappedTwProperties, string | undefined> = {
+    fontWeight,
+    fontSize,
+    lineHeight,
+    letterSpacing,
+    color,
+  };
+
+  const fontStyleClasses = mappedTwProperties
+    .map((property) =>
+      mapTwFontClass(property, { style, propValue: propertyValues[property] }),
+    )
+    .join(" ");
+
+  return (
+    <HtmlElement
+      className={`${fontStyleClasses}${className ? ` ${className}` : ""}`}
+    >
+      {children}
+    </HtmlElement>
+  );
+};

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,0 +1,1 @@
+export * from "./Text";

--- a/src/lib/styles/__tests__/mapTwFontClass.test.ts
+++ b/src/lib/styles/__tests__/mapTwFontClass.test.ts
@@ -1,0 +1,53 @@
+import { mapTwFontClass } from "../mapTwFontClass";
+import {
+  type MappedTwProperties,
+  TYPOGRAPHY_DEFAULTS,
+  mappedTwProperties,
+  textStyles,
+  twClassNameMapping,
+  typographyStyles,
+  type FontWeight,
+  type TypographyStyle,
+} from "../typography";
+
+describe("MapTwFontClass styles lib function", () => {
+  describe.each(mappedTwProperties)(
+    "should correctly map %s values",
+    (propName) => {
+      it(`with default params`, () => {
+        const result = mapTwFontClass(propName);
+
+        expect(result).toBe(
+          `${twClassNameMapping[propName]}-${TYPOGRAPHY_DEFAULTS[propName]}`,
+        );
+      });
+
+      it.each(typographyStyles)(`for %s style`, (style) => {
+        const result = mapTwFontClass(propName, { style });
+
+        expect(result).toBe(
+          `${twClassNameMapping[propName]}-${textStyles[style][propName]}`,
+        );
+      });
+    },
+  );
+
+  it(`should correctly map with a passed in prop value`, () => {
+    const propName: MappedTwProperties = "fontWeight";
+    const propValue: FontWeight = "semibold";
+
+    const result = mapTwFontClass(propName, { propValue });
+
+    expect(result).toBe(`${twClassNameMapping[propName]}-${propValue}`);
+  });
+
+  it("should use the prop value over the pre-set style value", () => {
+    const propName: MappedTwProperties = "color";
+    const style: TypographyStyle = "body-small";
+    const propValue = "rose-900";
+
+    const result = mapTwFontClass(propName, { style, propValue });
+
+    expect(result).toBe(`${twClassNameMapping[propName]}-${propValue}`);
+  });
+});

--- a/src/lib/styles/index.ts
+++ b/src/lib/styles/index.ts
@@ -1,0 +1,2 @@
+export * from "./typography";
+export * from "./mapTwFontClass";

--- a/src/lib/styles/mapTwFontClass.ts
+++ b/src/lib/styles/mapTwFontClass.ts
@@ -1,0 +1,26 @@
+import {
+  type TypographyStyle,
+  type MappedTwProperties,
+  twClassNameMapping,
+  textStyles,
+  TYPOGRAPHY_DEFAULTS,
+} from "./typography";
+
+export const mapTwFontClass = (
+  propName: MappedTwProperties,
+  options?: { style?: TypographyStyle; propValue?: string },
+) => {
+  const twPrefix = twClassNameMapping[propName];
+
+  let styleValue: string = TYPOGRAPHY_DEFAULTS[propName];
+
+  if (options?.style) {
+    styleValue = textStyles[options.style][propName];
+  }
+
+  if (options?.propValue) {
+    styleValue = options.propValue;
+  }
+
+  return `${twPrefix}-${styleValue}`;
+};

--- a/src/lib/styles/typography.ts
+++ b/src/lib/styles/typography.ts
@@ -1,0 +1,103 @@
+export const typographyStyles = [
+  "header-large",
+  "header-medium",
+  "header-medium-semibold",
+  "header-small",
+  "header-small-semibold",
+  "body-small",
+  "small",
+  "small-semibold",
+] as const;
+
+export type TypographyStyle = (typeof typographyStyles)[number];
+
+export type FontWeight = "normal" | "medium" | "semibold" | "bold";
+
+export const mappedTwProperties = [
+  "fontWeight",
+  "fontSize",
+  "lineHeight",
+  "letterSpacing",
+  "color",
+] as const;
+
+export type MappedTwProperties = (typeof mappedTwProperties)[number];
+
+export type FontStyles = Record<MappedTwProperties, string>;
+
+export const TYPOGRAPHY_DEFAULTS: Record<MappedTwProperties, string> = {
+  fontWeight: "normal",
+  fontSize: "base" /* 16px */,
+  lineHeight: "normal" /* 150% */,
+  letterSpacing: "normal",
+  color: "slate-900",
+};
+
+export const twClassNameMapping: Record<MappedTwProperties, string> = {
+  fontWeight: "font",
+  fontSize: "text",
+  lineHeight: "leading",
+  letterSpacing: "tracking",
+  color: "text",
+};
+
+export const textStyles: Record<TypographyStyle, FontStyles> = {
+  "header-large": {
+    color: "slate-900",
+    fontSize: "2xl" /* 24px */,
+    lineHeight: "normal" /* 150% / 30px */,
+    fontWeight: "semibold",
+    letterSpacing: "normal",
+  },
+  "header-medium": {
+    color: "slate-700",
+    fontSize: "base" /* 16px */,
+    lineHeight: "normal" /* 150% / 24px */,
+    fontWeight: "normal",
+    letterSpacing: "normal",
+  },
+  "header-medium-semibold": {
+    color: "slate-900",
+    fontSize: "base" /* 16px */,
+    lineHeight: "tight" /* 125% / 20px */,
+    fontWeight: "semibold",
+    letterSpacing: "normal",
+  },
+  "header-small": {
+    color: "slate-500",
+    fontSize: "xs" /* 12px */,
+    lineHeight: "tight" /* 125% / 15px */,
+    fontWeight: "normal",
+    letterSpacing: "normal",
+  },
+  "header-small-semibold": {
+    color: "slate-500",
+    fontSize: "xs" /* 12px */,
+    lineHeight: "tight" /* 125% / 15px*/,
+    fontWeight: "semibold",
+    letterSpacing: "tighter" /* -0.05em */,
+  },
+  "body-small": {
+    color: "slate-900",
+    fontSize: "xs" /* 12px */,
+    lineHeight: "normal" /* 150% / 18px */,
+    fontWeight: "normal",
+    letterSpacing: "normal",
+  },
+  small: {
+    color: "slate-700",
+    fontSize:
+      "[10px]" /* 10px doesn't exists as a preset font-size in Tailwind */,
+    lineHeight: "normal" /* 150% / 15px */,
+    fontWeight: "normal",
+    letterSpacing: "normal",
+  },
+  "small-semibold": {
+    color: "slate-900",
+    fontSize:
+      "[10px]" /* 10px doesn't exists as a preset font-size in Tailwind */,
+    lineHeight: "normal" /* 150% / 15px */,
+    fontWeight: "semibold",
+    letterSpacing: "tight" /* -0.025em */,
+  },
+};

--- a/src/modules/SetListCard/components/PlayHistoryItem/PlayHistoryItem.tsx
+++ b/src/modules/SetListCard/components/PlayHistoryItem/PlayHistoryItem.tsx
@@ -93,6 +93,7 @@ export const PlayHistoryItem: React.FC<PlayHistoryItemProps> = ({
           <Text asElement="span" style="small-semibold">
             {formattedDate}
           </Text>
+          {/* FIXME: come up with better solution to hard-coding the space around "for" */}
           <Text asElement="span" style="small">
             {" "}
             for{" "}

--- a/src/modules/SetListCard/components/PlayHistoryItem/PlayHistoryItem.tsx
+++ b/src/modules/SetListCard/components/PlayHistoryItem/PlayHistoryItem.tsx
@@ -1,12 +1,13 @@
 import {
   SongKey,
   type SongKeyFlatProps,
-  type SongKeySharpProps,
   type SongKeyProps,
-} from "@/components";
-import { type SetListCardHeaderProps } from "../SetListCardHeader";
-import { formatDate } from "@/lib/date";
-import { type None } from "@/lib/types";
+  type SongKeySharpProps,
+} from "@components/SongKey";
+import { Text } from "@components/Text";
+import { formatDate } from "@lib/date";
+import { type None } from "@lib/types";
+import { type SetListCardHeaderProps } from "@modules/SetListCard/components/SetListCardHeader";
 import { PlayHistoryBullet } from "../PlayHistoryBullet/PlayHistoryBullet";
 
 /**
@@ -68,11 +69,13 @@ export const PlayHistoryItem: React.FC<PlayHistoryItemProps> = ({
     return (
       <>
         <PlayHistoryBullet />
-        <div
-          className={`relative flex flex-col gap-1 text-[10px] font-semibold`}
-        >
-          <p>Song added to library</p>
-          <p className="font-normal text-slate-500">{formattedDate}</p>
+        <div className={`relative flex flex-col gap-1`}>
+          <Text fontWeight="semibold" fontSize="[10px]">
+            Song added to library
+          </Text>
+          <Text fontSize="[10px]" color="slate-500">
+            {formattedDate}
+          </Text>
         </div>
       </>
     );
@@ -85,20 +88,31 @@ export const PlayHistoryItem: React.FC<PlayHistoryItemProps> = ({
        * NOTE: the styles for the play history item's `::before` pseudo element is in `styles/globals.css`
        * as Tailwind wouldn't properly apply the styles
        */}
-      <div
-        className={`play-history-item relative flex flex-col gap-1 text-[10px]`}
-      >
-        <p>
-          <span className="font-semibold">{formattedDate}</span>
-          <span> for </span>
-          <span className="font-semibold">{eventType}</span>
-        </p>
-        <p className="flex gap-1 text-slate-500">
-          <span className="">Played in</span>
+      <div className={`play-history-item relative flex flex-col gap-1`}>
+        <div>
+          <Text asElement="span" style="small-semibold">
+            {formattedDate}
+          </Text>
+          <Text asElement="span" style="small">
+            {" "}
+            for{" "}
+          </Text>
+          <Text asElement="span" style="small-semibold">
+            {eventType}
+          </Text>
+        </div>
+        <div className="flex gap-1">
+          <Text asElement="span" style="small" color="slate-500">
+            Played in
+          </Text>
           <SongKey songKey={songKey} {...accidentalsProps} />
-          <span className="">during </span>
-          <span className="lowercase text-slate-700">{setSection}</span>
-        </p>
+          <Text asElement="span" style="small" color="slate-500">
+            during{" "}
+          </Text>
+          <Text asElement="span" style="small" className="lowercase">
+            {setSection}
+          </Text>
+        </div>
       </div>
     </>
   );

--- a/src/modules/SetListCard/components/ResourceCard/ResourceCard.tsx
+++ b/src/modules/SetListCard/components/ResourceCard/ResourceCard.tsx
@@ -1,3 +1,4 @@
+import { Text } from "@components/Text";
 import { Link } from "@phosphor-icons/react/dist/ssr";
 
 export type ResourceCardProps = {
@@ -12,8 +13,12 @@ export const ResourceCard: React.FC<ResourceCardProps> = ({ title, url }) => {
         <Link className="text-slate-400" size={24} />
       </div>
       <div className="flex-[4] px-2 py-1">
-        <p className="text-[10px] font-semibold text-slate-700">{title}</p>
-        <p className="text-[8px] text-slate-500">{url}</p>
+        <Text style="small-semibold" color="slate-700">
+          {title}
+        </Text>
+        <Text fontSize="[8px]" color="slate-500">
+          {url}
+        </Text>
       </div>
     </div>
   );

--- a/src/modules/SetListCard/components/SetListCardHeader/SetListCardHeader.tsx
+++ b/src/modules/SetListCard/components/SetListCardHeader/SetListCardHeader.tsx
@@ -1,4 +1,5 @@
-import { formatDate } from "@/lib/date/";
+import { Text } from "@components/Text";
+import { formatDate } from "@lib/date/";
 
 export type SetListCardHeaderProps = {
   /** date of set */
@@ -20,12 +21,20 @@ export const SetListCardHeader: React.FC<
   return (
     <header className="mb-4 flex items-center gap-2">
       <div className="flex flex-col items-center gap-[2px] rounded bg-slate-100 p-2">
-        <span className="text-[8px]/[8px] uppercase">{month}</span>
-        <span className="text-base/4 font-medium">{day}</span>
+        <Text asElement="span" fontSize="[8px]/[8px]" className="uppercase">
+          {month}
+        </Text>
+        <Text asElement="span" fontWeight="medium" fontSize="base/4">
+          {day}
+        </Text>
       </div>
       <div>
-        <h2 className="text-base/5 font-bold">{type}</h2>
-        <p className="text-[10px] text-slate-500">{numberOfSongs} songs</p>
+        <Text asElement="h2" fontWeight="bold" fontSize="base/5">
+          {type}
+        </Text>
+        <Text style="small" color="slate-500">
+          {numberOfSongs} songs
+        </Text>
       </div>
     </header>
   );

--- a/src/modules/SetListCard/components/SetListCardHeader/SetListCardHeader.tsx
+++ b/src/modules/SetListCard/components/SetListCardHeader/SetListCardHeader.tsx
@@ -21,14 +21,17 @@ export const SetListCardHeader: React.FC<
   return (
     <header className="mb-4 flex items-center gap-2">
       <div className="flex flex-col items-center gap-[2px] rounded bg-slate-100 p-2">
+        {/* FIXME: should this use an existing text style or a new style be defined? */}
         <Text asElement="span" fontSize="[8px]/[8px]" className="uppercase">
           {month}
         </Text>
+        {/* FIXME: should this use an existing text style or a new style be defined? */}
         <Text asElement="span" fontWeight="medium" fontSize="base/4">
           {day}
         </Text>
       </div>
       <div>
+        {/* FIXME: should this use an existing text style or a new style be defined? */}
         <Text asElement="h2" fontWeight="bold" fontSize="base/5">
           {type}
         </Text>

--- a/src/modules/SetListCard/components/SetListCardSection/SetListCardSection.tsx
+++ b/src/modules/SetListCard/components/SetListCardSection/SetListCardSection.tsx
@@ -1,3 +1,5 @@
+import { Text } from "@components/Text";
+
 export type SetListCardSectionProps = {
   title: string;
 };
@@ -7,7 +9,14 @@ export const SetListCardSection: React.FC<
 > = ({ title, children }) => {
   return (
     <section>
-      <h3 className="mb-2 text-[10px] uppercase text-slate-500">{title}</h3>
+      <Text
+        asElement="h4"
+        style="small"
+        color="slate-500"
+        className="mb-2 uppercase "
+      >
+        {title}
+      </Text>
       <div className="flex flex-col gap-1">{children}</div>
     </section>
   );

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -1,4 +1,5 @@
-import { SongKey, type SongKeyProps } from "@/components";
+import { SongKey, type SongKeyProps } from "@components/SongKey";
+import { Text } from "@components/Text";
 
 export type SongItemProps = {
   /** index of song in the set list */
@@ -28,12 +29,14 @@ export const SongItem: React.FC<SongItemProps> = ({
       <div className="flex flex-col gap-2">
         <div className="items-top flex gap-2">
           <SongKey songKey={songKey} />
-          <p className="text-slate-900">{name}</p>
+          <Text style="body-small" fontWeight="semibold">
+            {name}
+          </Text>
         </div>
         {notes ? (
-          <p className="text-[10px]/[16px] font-normal text-slate-700">
+          <Text style="small" color="slate-700">
             {notes}
-          </p>
+          </Text>
         ) : null}
       </div>
     </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,12 +24,12 @@
     "incremental": true,
 
     /* Path Aliases */
-    "baseUrl": ".",
+    "baseUrl": "src",
     "paths": {
-      "@/*": ["./src/*"],
-      "@components/*": ["./src/components/*"],
-      "@modules/*": ["./src/modules/*"],
-      "@lib/*": ["./src/lib/*"]
+      "@/*": ["./*"],
+      "@components/*": ["components/*"],
+      "@modules/*": ["modules/*"],
+      "@lib/*": ["lib/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Background
This PR is to add a reusable `Text` component and styles

## What's changed
[Pages]
- Updated the pages to use the `Text` component

[Components]
- General components
  - Added `Text` component
  - Updated instances of text to use `Text` component
- Play history components
  - Updated instances of text to use `Text` component
- Set list module components
  - Updated instances of text to use `Text` component

[Lib]
- Added `mapTwFontClass` helper function to map React props to the correct Tailwind classnames
- Added typography defaults and styles

## How to test
This PR shouldn't introduce any visual changes. However, it's still a good idea to click around in the app and make sure all the text/UI matches the designs