### PR TITLE
[SWY-23] Updates ResourceCard layout to grid

### DIFF
--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -107,7 +107,7 @@ export default async function SetListPage({
             </div>
             <hr className="bg-slate-100" />
           </header>
-          <div className="flex flex-wrap gap-2">
+          <div className="grid grid-cols-[repeat(auto-fill,_124px)] grid-rows-[repeat(auto-fill,_92px)] gap-2">
             <ResourceCard title="In My Place" url="theworshipinitiative.com" />
             <ResourceCard title="In My Place" url="open.spotify.com" />
           </div>

--- a/src/modules/SetListCard/components/ResourceCard/ResourceCard.tsx
+++ b/src/modules/SetListCard/components/ResourceCard/ResourceCard.tsx
@@ -8,7 +8,7 @@ export type ResourceCardProps = {
 
 export const ResourceCard: React.FC<ResourceCardProps> = ({ title, url }) => {
   return (
-    <div className="flex h-[92px] w-[124px] flex-col rounded bg-slate-200">
+    <div className="flex flex-col rounded bg-slate-200">
       <div className="flex h-full flex-[6] items-center justify-center rounded-t bg-slate-300">
         <Link className="text-slate-400" size={24} />
       </div>


### PR DESCRIPTION
## Background
This PR is to convert the resource card body layout (on the song details page) to use CSS `grid` instead of `flexbox`. I think using grid helps the code to be a little more understandable and allows the resource card  to define the size of the resource links instead of having them explicitly defined on the `ResourceCard` component.

## What's changed
[Pages]
-updated the `[organization]/songs/[songId]` route to use CSS `grid` instead of `flexbox` to define the layout of the resource card body

[Components]
- updated the `ResourceCard` component to no longer explicitly define the width and height

## How to test
This PR shouldn't change anything visually, but hopefully makes the code a little easier to read and understand.