### PR TITLE
[SWY-30] Build out the login flow

### DIFF
--- a/src/app/[organization]/layout.tsx
+++ b/src/app/[organization]/layout.tsx
@@ -18,6 +18,9 @@ export default async function DashboardLayout({
   protect();
 
   if (!userId) {
+    console.log(
+      "🤖 - userID was not found. Redirecting to sign-in page - organization/layout",
+    );
     redirectToSignIn();
   }
 
@@ -27,23 +30,9 @@ export default async function DashboardLayout({
     notFound();
   }
 
-  // const isUserPartOfOrg =
-  //   await api.organizationMemberships.isMemberOfOrganization({
-  //     organizationId: params.organization,
-  //   });
-
-  // if (!isUserPartOfOrg) {
-  //   redirect("/");
-  // }
-
   const organization: Organization = (await getOrganization(
     params.organization,
   )) as Organization;
-
-  // if (!organization) {
-  //   console.error(`Invalid Organization ID: ${params.organization}`);
-  //   redirect("/");
-  // }
 
   return (
     <main className="container px-4 pb-16">

--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -24,6 +24,9 @@ export default async function Dashboard({
 
   const isOrgIdValidUuid = uuidValidate(params.organization);
   if (!isOrgIdValidUuid) {
+    console.error(
+      `🤖 - ${params.organization} is not a valid UUID - queries/getOrganization`,
+    );
     notFound();
   }
 

--- a/src/app/create-team/page.tsx
+++ b/src/app/create-team/page.tsx
@@ -26,8 +26,9 @@ export default async function CreateTeamPage({
         if (createUserError.code === "CONFLICT") {
           console.info(createUserError.message);
         }
+      } else {
+        console.error(createUserError);
       }
-      console.error(createUserError);
     }
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ export default function RootLayout({
           <header className="flex justify-between px-4 py-2">
             <Link href="/">Sanbi</Link>
             <SignedOut>
-              <SignInButton />
+              <SignInButton fallbackRedirectUrl="sign-in" />
             </SignedOut>
             <SignedIn>
               <UserButton />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,8 +28,13 @@ export default async function Home() {
     const userMembership = await api.organizationMemberships.forUser({
       userId,
     });
-    console.log("🚀 ~ [[sign-in]] page ~ userMembership:", userMembership);
 
-    redirect(`/${userMembership?.organizationId}`);
+    if (!userMembership) {
+      redirect("/create-team");
+    } else {
+      console.log("🚀 ~ [[sign-in]] page ~ userMembership:", userMembership);
+
+      redirect(`/${userMembership?.organizationId}`);
+    }
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,35 @@
 import { db } from "@/server/db";
 import { organizations } from "@/server/db/schema";
+import { api } from "@/trpc/server";
+import { auth } from "@clerk/nextjs/server";
 import { eq } from "drizzle-orm";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 
 export default async function Home() {
-  // FIXME: move query to db/queries
-  const [stonewayOrg] = await db
-    .select()
-    .from(organizations)
-    .where(eq(organizations.name, "Stoneway"));
+  const { userId } = auth();
 
-  if (!stonewayOrg) {
-    throw new Error("No organizations.");
+  if (!userId) {
+    // FIXME: move query to db/queries
+    const [stonewayOrg] = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.name, "Stoneway"));
+
+    if (!stonewayOrg) {
+      throw new Error("No organizations.");
+    }
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#2e026d] to-[#15162c] text-white">
+        <Link href={`${stonewayOrg.id}/`}>賛美 // Sanbi</Link>
+      </main>
+    );
+  } else {
+    const userMembership = await api.organizationMemberships.forUser({
+      userId,
+    });
+    console.log("🚀 ~ [[sign-in]] page ~ userMembership:", userMembership);
+
+    redirect(`/${userMembership?.organizationId}`);
   }
-
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#2e026d] to-[#15162c] text-white">
-      <Link href={`${stonewayOrg.id}/`}>賛美 // Sanbi</Link>
-    </main>
-  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,17 +24,17 @@ export default async function Home() {
         <Link href={`${stonewayOrg.id}/`}>賛美 // Sanbi</Link>
       </main>
     );
-  } else {
-    const userMembership = await api.organizationMemberships.forUser({
-      userId,
-    });
-
-    if (!userMembership) {
-      redirect("/create-team");
-    } else {
-      console.log("🚀 ~ [[sign-in]] page ~ userMembership:", userMembership);
-
-      redirect(`/${userMembership?.organizationId}`);
-    }
   }
+
+  const userMembership = await api.organizationMemberships.forUser({
+    userId,
+  });
+
+  if (!userMembership) {
+    redirect("/create-team");
+  }
+
+  console.log("🚀 ~ [[sign-in]] page ~ userMembership:", userMembership);
+
+  redirect(`/${userMembership?.organizationId}`);
 }

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,5 +1,18 @@
+"use server";
 import { SignIn } from "@clerk/nextjs";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 
-export default function Page() {
-  return <SignIn />;
+export default async function Page() {
+  const { userId } = auth();
+
+  if (!userId) {
+    return (
+      <main className="m-auto mt-16 max-w-md">
+        <SignIn />
+      </main>
+    );
+  } else {
+    redirect("/");
+  }
 }

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,5 +1,9 @@
 import { SignUp } from "@clerk/nextjs";
 
 export default function Page() {
-  return <SignUp />;
+  return (
+    <main className="m-auto mt-16 max-w-md">
+      <SignUp />
+    </main>
+  );
 }

--- a/src/lib/types/error.ts
+++ b/src/lib/types/error.ts
@@ -1,0 +1,23 @@
+import { TRPCError } from "@trpc/server";
+
+export class SanbiError extends TRPCError {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore override doesn't work in all environments due to "This member cannot have an 'override' modifier because it is not declared in the base class 'Error'"
+  public readonly code;
+
+  constructor({
+    message,
+    code,
+    cause,
+  }: {
+    message?: string;
+    code: TRPCError["code"];
+    cause?: TRPCError["cause"];
+  }) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore https://github.com/tc39/proposal-error-cause
+    super({ message, code, cause });
+
+    this.name = "SanbiError";
+  }
+}

--- a/src/modules/onboarding/createTeam/components/createTeamForm.tsx
+++ b/src/modules/onboarding/createTeam/components/createTeamForm.tsx
@@ -45,9 +45,11 @@ export const CreateTeamForm: React.FC = () => {
     if (!result?.data) {
       result?.errors.forEach((error) => {
         console.log("🚀 ~ error:", error);
-        createTeamForm.setError(error.path, {
-          message: error.message,
-        });
+        if (error.path) {
+          createTeamForm.setError(error.path, {
+            message: error.message,
+          });
+        }
       });
     }
 

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -88,7 +88,7 @@ export const userRouter = createTRPCRouter({
     };
     console.log(`🤖 - New sanbi user - createMe`, newUser);
 
-    return ctx.db
+    return await ctx.db
       .insert(users)
       .values(newUser)
       .onConflictDoNothing({ target: users.id })

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -5,6 +5,9 @@ import { validate as uuidValidate } from "uuid";
 
 export async function getOrganization(organizationId: string) {
   if (!uuidValidate(organizationId)) {
+    console.error(
+      `🤖 - ${organizationId} is not a valid UUID - queries/getOrganization`,
+    );
     redirect("/");
   }
 
@@ -21,7 +24,11 @@ export async function getOrganization(organizationId: string) {
           console.error(
             `queries/getOrganization/${organizationId}: ${fetchOrganizationError.message}`,
           );
+          break;
         default:
+          console.error(
+            `queries/getOrganization/${organizationId}: ${fetchOrganizationError.message}`,
+          );
           redirect("/");
       }
     }


### PR DESCRIPTION
## Background
This PR is to build out the experience when a user logs in. Currently, nothing happens in addition to creating a user session after a user logs in. This PR updates the login flow to redirect the user to his/her team's dashboard if he/she belongs to a team, or to the create-a-team page if not.

## What's changed

[app]
- added `fallbackRedirectUrl` for the sign in button in the layout
- updated the home page to handle the updated post-login flow

[sign-in]
- updated page layout
- added redirect if the user is already logged in

[sign-up]
- updated page layout

[create-team]
- moved error log to `else` statement

[organization]
- added logging if there is no user in the layout
- added logging if the organization ID isn't a valid UUID in the organization dashboard page
- removed unnecessary commented out code from layout

[API]
- added SanbiError for API errors
- added `organizationMemberships.forUser` to fetch organization memberships for a given user
- updated `organizations.create` to throw `CreateOrganizationError` errors to clarify error type
- updated `organizationMemberships.create` to throw `CreateOrganizationMembership` errors to clarify error type
- fixed `users.createMe` to await the returned result of creating the user
- fixed the TRPC `authedProcedure` to skip the Sanbi user query as that will fail when called in `users.createMe` and no longer returns the sanbi user in the returned `ctx` - need to find a more permanent solution
- updated `createOrganizationAndAddUser` mutation to check error instances for improved error handling
- added logging to `getOrganization` query 

## How to test
With a user that has an organization membership:
- Log in to Sanbi
- You should be redirected to the organization's dashboard

With a user that does not have an organization membership:
- Log into Sanbi
- You should be redirected to the `create-team` page