### PR TITLE
[SWY-34] Fix non organization member redirect

### DIFF
--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -1,4 +1,5 @@
 import { api } from "@/trpc/server";
+import { auth } from "@clerk/nextjs/server";
 import { TRPCError } from "@trpc/server";
 import { redirect } from "next/navigation";
 import { validate as uuidValidate } from "uuid";
@@ -24,6 +25,8 @@ export async function getOrganization(organizationId: string) {
           console.error(
             `queries/getOrganization/${organizationId}: ${fetchOrganizationError.message}`,
           );
+          const { redirectToSignIn } = auth();
+          redirectToSignIn();
           break;
         default:
           console.error(

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -23,14 +23,14 @@ export async function getOrganization(organizationId: string) {
         case "FORBIDDEN":
           // TODO: capture Sentry error?
           console.error(
-            `queries/getOrganization/${organizationId}: ${fetchOrganizationError.message}`,
+            `🤖 - [queries/getOrganization/${organizationId}]: ${fetchOrganizationError.message}`,
           );
           const { redirectToSignIn } = auth();
           redirectToSignIn();
           break;
         default:
           console.error(
-            `queries/getOrganization/${organizationId}: ${fetchOrganizationError.message}`,
+            `🤖 - [queries/getOrganization/${organizationId}]: ${fetchOrganizationError.message}`,
           );
           redirect("/");
       }

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -1,5 +1,4 @@
 import { api } from "@/trpc/server";
-import { auth } from "@clerk/nextjs/server";
 import { TRPCError } from "@trpc/server";
 import { redirect } from "next/navigation";
 import { validate as uuidValidate } from "uuid";
@@ -21,13 +20,6 @@ export async function getOrganization(organizationId: string) {
     if (fetchOrganizationError instanceof TRPCError) {
       switch (fetchOrganizationError.code) {
         case "FORBIDDEN":
-          // TODO: capture Sentry error?
-          console.error(
-            `🤖 - [queries/getOrganization/${organizationId}]: ${fetchOrganizationError.message}`,
-          );
-          const { redirectToSignIn } = auth();
-          redirectToSignIn();
-          break;
         default:
           console.error(
             `🤖 - [queries/getOrganization/${organizationId}]: ${fetchOrganizationError.message}`,


### PR DESCRIPTION
## Background
If a user attempts to access an organization's page that they are not a part of, they aren't properly redirected which leads to an Unhandled Runtime Error: `Error: Cannot read properties of undefined (reading 'name')` as the user won't have permission to fetch the organization's details since they are not a member. This PR updates the update on `FORBIDDEN` error to redirect the user to the home page (`/`) if they aren't a member of the target organization.

| Before | After |
|--------|--------|
|  <video width="50%" src="https://github.com/user-attachments/assets/cba591fd-2f57-495b-9c90-e8769982d23d"> | <video width="50%" src="https://github.com/user-attachments/assets/eb369f1c-31b3-472e-b0a7-5939b3ce6f39" /> |

## What's changed
[queries/getOrganization]
- updated error switch statement to combine `FORBIDDEN` and default cases since we want to log the error and redirect to the home page in both cases.

## How to test
- On the preview branch, log in with a user that does not have access to an existing organization
- Attempt to navigate to that organization's dashboard and verify that you've been redirected to the page
- Then, attempt to navigate to an organization that the user is a member of and verify that you can access the dashboard as expected
