### PR TITLE
[SWY-32] Fix PlayHistoryItem timeline styling

### DIFF
--- a/src/modules/SetListCard/components/PlayHistoryItem/PlayHistoryItem.tsx
+++ b/src/modules/SetListCard/components/PlayHistoryItem/PlayHistoryItem.tsx
@@ -93,45 +93,44 @@ export const PlayHistoryItem: React.FC<PlayHistoryItemProps> = ({
        * NOTE: the styles for the play history item's `::before` pseudo element is in `styles/globals.css`
        * as Tailwind wouldn't properly apply the styles
        */}
-      <Link href={`../sets/${setId}`}>
-        <div
-          className={`play-history-item relative flex flex-col gap-1 ${isFuture(date) ? "italic" : "not-italic"}`}
-        >
-          <div className="flex gap-[3px] leading-[16px]">
-            <Text
-              style="small-semibold"
-              // TODO: figure out a better way of changing the text color as this is repeated
-              {...(isFuture(date) && { color: "slate-500" })}
-            >
-              {formattedDate}
-            </Text>
-            <Text style="small" {...(isFuture(date) && { color: "slate-500" })}>
-              for
-            </Text>
-            <Text
-              style="small-semibold"
-              {...(isFuture(date) && { color: "slate-500" })}
-            >
-              {eventType}
-            </Text>
-          </div>
-          <div className="flex gap-1">
-            <Text asElement="span" style="small" color="slate-500">
-              {isFuture(date) ? "Will play" : "Played"} in
-            </Text>
-            <SongKey songKey={songKey} {...accidentalsProps} />
-            <Text asElement="span" style="small" color="slate-500">
-              during{" "}
-            </Text>
-            <Text
-              asElement="span"
-              style="small"
-              className="lowercase"
-              {...(isFuture(date) && { color: "slate-500" })}
-            >
-              {setSection}
-            </Text>
-          </div>
+      <Link
+        href={`../sets/${setId}`}
+        className={`play-history-item relative flex flex-col gap-1 ${isFuture(date) ? "italic" : "not-italic"}`}
+      >
+        <div className="flex gap-[3px] leading-[16px]">
+          <Text
+            style="small-semibold"
+            // TODO: figure out a better way of changing the text color as this is repeated
+            {...(isFuture(date) && { color: "slate-500" })}
+          >
+            {formattedDate}
+          </Text>
+          <Text style="small" {...(isFuture(date) && { color: "slate-500" })}>
+            for
+          </Text>
+          <Text
+            style="small-semibold"
+            {...(isFuture(date) && { color: "slate-500" })}
+          >
+            {eventType}
+          </Text>
+        </div>
+        <div className="flex gap-1">
+          <Text asElement="span" style="small" color="slate-500">
+            {isFuture(date) ? "Will play" : "Played"} in
+          </Text>
+          <SongKey songKey={songKey} {...accidentalsProps} />
+          <Text asElement="span" style="small" color="slate-500">
+            during{" "}
+          </Text>
+          <Text
+            asElement="span"
+            style="small"
+            className="lowercase"
+            {...(isFuture(date) && { color: "slate-500" })}
+          >
+            {setSection}
+          </Text>
         </div>
       </Link>
     </>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -68,42 +68,45 @@
   }
 }
 
-/* FIXME: this no longer renders correctly after ShadCN was installed */
-.play-history-item:not(:last-child)::before {
-  --bullet-offset: 4px;
-  --bullet-width: 8px;
-  --bullet-grid-column-width: 16px;
-  --bullet-grid-row-gap: 16px;
+@layer components {
+  .play-history-item:not(:last-child)::before {
+    --bullet-offset: 4px;
+    --bullet-width: 8px;
+    --bullet-grid-column-width: 16px;
+    --bullet-grid-row-gap: 16px;
 
-  /**
+    /**
      * the starting y position of the line must account for the top offset (which
      * should be half of the text line height of the corresponding row) and
      * height of the bullet (8px) as well as and margin below the bullet (4px)
      */
-  --line-top-offset: calc(calc(var(--bullet-offset) * 2) + var(--bullet-width));
+    --line-top-offset: calc(
+      calc(var(--bullet-offset) * 2) + var(--bullet-width)
+    );
 
-  position: absolute;
-  width: 1px;
-  background-color: rgb(
-    203 213 225
-  ); /* should be the same value as slate-300 */
-  content: "";
+    position: absolute;
+    width: 1px;
+    background-color: rgb(
+      203 213 225
+    ); /* should be the same value as slate-300 */
+    content: "";
 
-  /**
+    /**
      * the line needs to line up with the middle of the bullet so
      * it needs to be shifted the width of the first column (16px) minus half
      * the width of the bullet (8px)
      * the current solution is hard-coded since using the calc function won't work
      */
-  left: calc(
-    -1 * calc(var(--bullet-grid-column-width) - calc(var(--bullet-width) / 2))
-  );
+    left: calc(
+      -1 * calc(var(--bullet-grid-column-width) - calc(var(--bullet-width) / 2))
+    );
 
-  top: var(--line-top-offset);
+    top: var(--line-top-offset);
 
-  /**
+    /**
      * the height of the line should be the height of the element + grid gap (16px)
      * minus the top offset so the line ends right when the next item below begins
      */
-  height: calc(100% + var(--bullet-grid-row-gap) - var(--line-top-offset));
+    height: calc(100% + var(--bullet-grid-row-gap) - var(--line-top-offset));
+  }
 }


### PR DESCRIPTION
## Background
After investigation, it appears that #9 broke the `PlayHistoryItem` component's timeline styling (initially, #13 was incorrectly believed to have been the cause). This PR fixes this and gets the play history item to match the design again. 

Since the play history item was wrapped by the `Link` component, it made it so that the play history item was always the last child, and therefore did not apply the desired styling. Removing that specific layer of nesting correctly made the play history items siblings once again, applying the correct styling.

| Before | After |
|--------|--------|
| ![SWY-32--before](https://github.com/user-attachments/assets/c8a91189-49f1-4714-a6e9-b1486f84db40) | ![SWY-32--after](https://github.com/user-attachments/assets/47421d98-7829-4f55-9dd5-ff79a806739e) |

## What's changed
[`PlayHistoryItem` component]
- Removed the direct `div` element child of the `Link` component
- Updated the `Link` component to have the `classNames` from the removed `div`

[global styles]
- Updated the play history item's styling to Tailwind's `components` layer

## How to test
1. On the [preview deploy](https://sanbi-git-swy-32-fix-play-history-ti-5e7d73-justaddcls-projects.vercel.app/), go to any song details page (ex. - ["In My Place"](https://sanbi-git-swy-32-fix-play-history-ti-5e7d73-justaddcls-projects.vercel.app/2f93d7b3-f2ec-48a7-8534-51f2e27c910a/songs/94d41897-c272-4b29-89cd-e5c85e1bc8ca) )
2. Scroll down to the play history and ensure the timeline styling is rendering as the "After" screenshot above.
