### PR TITLE
[SWY-35] Add app frame

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,61 +1,58 @@
 /** @type {import("eslint").Linter.Config} */
 const config = {
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "project": true
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: true,
   },
-  "plugins": [
-    "@typescript-eslint",
-    "drizzle"
-  ],
-  "extends": [
+  plugins: ["@typescript-eslint", "drizzle"],
+  extends: [
     "next/core-web-vitals",
     "plugin:@typescript-eslint/recommended-type-checked",
-    "plugin:@typescript-eslint/stylistic-type-checked"
+    "plugin:@typescript-eslint/stylistic-type-checked",
   ],
-  "rules": {
+  rules: {
     "@typescript-eslint/array-type": "off",
     "@typescript-eslint/consistent-type-definitions": "off",
     "@typescript-eslint/consistent-type-imports": [
       "warn",
       {
-        "prefer": "type-imports",
-        "fixStyle": "inline-type-imports"
-      }
+        prefer: "type-imports",
+        fixStyle: "inline-type-imports",
+      },
     ],
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {
-        "argsIgnorePattern": "^_"
-      }
+        argsIgnorePattern: "^_",
+      },
     ],
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/no-misused-promises": [
       "error",
       {
-        "checksVoidReturn": {
-          "attributes": false
-        }
-      }
+        checksVoidReturn: {
+          attributes: false,
+        },
+      },
+    ],
+    "@typescript-eslint/ban-ts-comment": [
+      "warn",
+      {
+        "ts-expect-error": "allow-with-description",
+      },
     ],
     "drizzle/enforce-delete-with-where": [
       "error",
       {
-        "drizzleObjectName": [
-          "db",
-          "ctx.db"
-        ]
-      }
+        drizzleObjectName: ["db", "ctx.db"],
+      },
     ],
     "drizzle/enforce-update-with-where": [
       "error",
       {
-        "drizzleObjectName": [
-          "db",
-          "ctx.db"
-        ]
-      }
-    ]
-  }
-}
+        drizzleObjectName: ["db", "ctx.db"],
+      },
+    ],
+  },
+};
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^10.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "5.0.0-rc.2"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^0.45.0",
@@ -80,7 +81,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.15.6",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.4"
   },
   "ct3aMetadata": {
     "initVersion": "7.34.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@faker-js/faker": "^8.4.1",
     "@hookform/resolvers": "^3.9.0",
     "@phosphor-icons/react": "^2.1.5",
+    "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@sentry/nextjs": "^8.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 8.13.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.1)(next@14.2.3(@babel/core@7.24.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.92.1(esbuild@0.19.12))
       '@t3-oss/env-nextjs':
         specifier: ^0.10.1
-        version: 0.10.1(typescript@5.4.5)(zod@3.23.8)
+        version: 0.10.1(typescript@5.6.2)(zod@3.23.8)
       '@tanstack/react-query':
         specifier: ^5.39.0
         version: 5.40.1(react@18.3.1)
@@ -97,13 +97,16 @@ importers:
         version: 2.4.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))
+        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
       zod:
         specifier: ^3.23.8
         version: 3.23.8
+      zustand:
+        specifier: 5.0.0-rc.2
+        version: 5.0.0-rc.2(@types/react@18.3.3)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1))
     devDependencies:
       '@dotenvx/dotenvx':
         specifier: ^0.45.0
@@ -113,7 +116,7 @@ importers:
         version: 5.51.21(@tanstack/react-query@5.40.1(react@18.3.1))(react@18.3.1)
       '@testing-library/jest-dom':
         specifier: ^6.4.5
-        version: 6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))
+        version: 6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)))
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.0.0(@testing-library/dom@10.1.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -137,10 +140,10 @@ importers:
         version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.1.1
-        version: 7.12.0(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.12.0(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/parser':
         specifier: ^7.1.1
-        version: 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.12.0(eslint@8.57.0)(typescript@5.6.2)
       drizzle-kit:
         specifier: ^0.21.4
         version: 0.21.4
@@ -149,13 +152,13 @@ importers:
         version: 8.57.0
       eslint-config-next:
         specifier: ^14.1.3
-        version: 14.2.3(eslint@8.57.0)(typescript@5.4.5)
+        version: 14.2.3(eslint@8.57.0)(typescript@5.6.2)
       eslint-plugin-drizzle:
         specifier: ^0.2.3
         version: 0.2.3(eslint@8.57.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+        version: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -170,10 +173,10 @@ importers:
         version: 0.5.14(prettier@3.3.1)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+        version: 3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.14.2)(typescript@5.4.5)
+        version: 10.9.2(@types/node@20.14.2)(typescript@5.6.2)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -181,8 +184,8 @@ importers:
         specifier: ^4.15.6
         version: 4.15.6
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.2
 
 packages:
 
@@ -4807,8 +4810,8 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5068,6 +5071,24 @@ packages:
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  zustand@5.0.0-rc.2:
+    resolution: {integrity: sha512-o2Nwuvnk8vQBX7CcHL8WfFkZNJdxB/VKeWw0tNglw8p4cypsZ3tRT7rTRTDNeUPFS0qaMBRSKe+fVwL5xpcE3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -5684,7 +5705,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -5698,7 +5719,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6527,18 +6548,18 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.6.3
 
-  '@t3-oss/env-core@0.10.1(typescript@5.4.5)(zod@3.23.8)':
+  '@t3-oss/env-core@0.10.1(typescript@5.6.2)(zod@3.23.8)':
     dependencies:
       zod: 3.23.8
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
-  '@t3-oss/env-nextjs@0.10.1(typescript@5.4.5)(zod@3.23.8)':
+  '@t3-oss/env-nextjs@0.10.1(typescript@5.6.2)(zod@3.23.8)':
     dependencies:
-      '@t3-oss/env-core': 0.10.1(typescript@5.4.5)(zod@3.23.8)
+      '@t3-oss/env-core': 0.10.1(typescript@5.6.2)(zod@3.23.8)
       zod: 3.23.8
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
   '@tanstack/query-core@5.40.0': {}
 
@@ -6566,7 +6587,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)))':
+  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)))':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.24.6
@@ -6579,7 +6600,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
 
   '@testing-library/react@16.0.0(@testing-library/dom@10.1.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -6818,47 +6839,47 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.12.0(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@7.12.0(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.1
-      '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/scope-manager': 7.12.0
-      '@typescript-eslint/type-utils': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 7.12.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/utils': 7.12.0(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 7.12.0
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.12.0
       '@typescript-eslint/types': 7.12.0
-      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 7.12.0
       debug: 4.3.5
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.6.2)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.3.5
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6872,15 +6893,15 @@ snapshots:
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/visitor-keys': 7.2.0
 
-  '@typescript-eslint/type-utils@7.12.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@7.12.0(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.6.2)
+      '@typescript-eslint/utils': 7.12.0(eslint@8.57.0)(typescript@5.6.2)
       debug: 4.3.5
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6888,7 +6909,7 @@ snapshots:
 
   '@typescript-eslint/types@7.2.0': {}
 
-  '@typescript-eslint/typescript-estree@7.12.0(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@7.12.0(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/types': 7.12.0
       '@typescript-eslint/visitor-keys': 7.12.0
@@ -6897,13 +6918,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.4
       semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.2.0(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@7.2.0(typescript@5.6.2)':
     dependencies:
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/visitor-keys': 7.2.0
@@ -6912,18 +6933,18 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.12.0(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/utils@7.12.0(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 7.12.0
       '@typescript-eslint/types': 7.12.0
-      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 7.12.0(typescript@5.6.2)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -7478,13 +7499,13 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  create-jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
+  create-jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7934,20 +7955,20 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@14.2.3(eslint@8.57.0)(typescript@5.4.5):
+  eslint-config-next@14.2.3(eslint@8.57.0)(typescript@5.6.2):
     dependencies:
       '@next/eslint-plugin-next': 14.2.3
       '@rushstack/eslint-patch': 1.10.3
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -7960,13 +7981,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -7977,24 +7998,24 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.2.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8002,7 +8023,7 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -8012,7 +8033,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -8023,7 +8044,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 7.12.0(eslint@8.57.0)(typescript@5.6.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -8732,16 +8753,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
+  jest-cli@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      create-jest: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -8751,7 +8772,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)):
     dependencies:
       '@babel/core': 7.24.7
       '@jest/test-sequencer': 29.7.0
@@ -8777,7 +8798,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.2
-      ts-node: 10.9.2(@types/node@20.14.2)(typescript@5.4.5)
+      ts-node: 10.9.2(@types/node@20.14.2)(typescript@5.6.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9018,12 +9039,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
+  jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      jest-cli: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9540,13 +9561,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.38
 
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.3
     optionalDependencies:
       postcss: 8.4.38
-      ts-node: 10.9.2(@types/node@20.14.2)(typescript@5.4.5)
+      ts-node: 10.9.2(@types/node@20.14.2)(typescript@5.6.2)
 
   postcss-nested@6.0.1(postcss@8.4.38):
     dependencies:
@@ -10025,11 +10046,11 @@ snapshots:
 
   tailwind-merge@2.4.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))):
     dependencies:
-      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
 
-  tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
+  tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -10048,7 +10069,7 @@ snapshots:
       postcss: 8.4.38
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2))
       postcss-nested: 6.0.1(postcss@8.4.38)
       postcss-selector-parser: 6.1.0
       resolve: 1.22.8
@@ -10122,13 +10143,13 @@ snapshots:
 
   triple-beam@1.4.1: {}
 
-  ts-api-utils@1.3.0(typescript@5.4.5):
+  ts-api-utils@1.3.0(typescript@5.6.2):
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.6.2
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5):
+  ts-node@10.9.2(@types/node@20.14.2)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -10142,7 +10163,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.4.5
+      typescript: 5.6.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -10218,7 +10239,7 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typescript@5.4.5: {}
+  typescript@5.6.2: {}
 
   unbox-primitive@1.0.2:
     dependencies:
@@ -10504,3 +10525,9 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.23.8: {}
+
+  zustand@5.0.0-rc.2(@types/react@18.3.3)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1)):
+    optionalDependencies:
+      '@types/react': 18.3.3
+      react: 18.3.1
+      use-sync-external-store: 1.2.2(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.5
         version: 2.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-label':
         specifier: ^2.1.0
         version: 2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1238,6 +1241,9 @@ packages:
   '@prisma/instrumentation@5.16.0':
     resolution: {integrity: sha512-MVzNRW2ikWvVNnMIEgQMcwWxpFD+XF2U2h0Qz7MjutRqJxrhWexWV2aSi2OXRaU8UL5wzWw7pnjdKUzYhWauLg==}
 
+  '@radix-ui/primitive@1.1.0':
+    resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
+
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
@@ -1247,8 +1253,100 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.0':
+    resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.1':
+    resolution: {integrity: sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.0':
+    resolution: {integrity: sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.0':
+    resolution: {integrity: sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.0':
+    resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.0':
+    resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-label@2.1.0':
     resolution: {integrity: sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.1':
+    resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.0':
+    resolution: {integrity: sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1275,6 +1373,42 @@ packages:
 
   '@radix-ui/react-slot@1.1.0':
     resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.0':
+    resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.1.0':
+    resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.0':
+    resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.0':
+    resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1959,6 +2093,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.4:
+    resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -2389,6 +2527,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2924,6 +3065,10 @@ packages:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
 
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
@@ -3100,6 +3245,9 @@ packages:
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
+
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   is-array-buffer@3.0.4:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
@@ -4133,6 +4281,36 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-remove-scroll-bar@2.3.6:
+    resolution: {integrity: sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.5.7:
+    resolution: {integrity: sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.1:
+    resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -4662,6 +4840,26 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-callback-ref@1.3.2:
+    resolution: {integrity: sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.2:
+    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.2.2:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
@@ -5945,8 +6143,75 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@radix-ui/primitive@1.1.0': {}
+
   '@radix-ui/react-compose-refs@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-context@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-dialog@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.7(@types/react@18.3.3)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-dismissable-layer@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-focus-guards@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-focus-scope@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-id@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3
@@ -5954,6 +6219,26 @@ snapshots:
   '@radix-ui/react-label@2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-portal@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-presence@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -5972,6 +6257,32 @@ snapshots:
   '@radix-ui/react-slot@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3
@@ -6808,6 +7119,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.4:
+    dependencies:
+      tslib: 2.6.3
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -7282,6 +7597,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-newline@3.1.0: {}
+
+  detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -7984,6 +8301,8 @@ snapshots:
       has-symbols: 1.0.3
       hasown: 2.0.2
 
+  get-nonce@1.0.1: {}
+
   get-package-type@0.1.0: {}
 
   get-stream@6.0.1: {}
@@ -8181,6 +8500,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
+
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
 
   is-array-buffer@3.0.4:
     dependencies:
@@ -9326,6 +9649,34 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-remove-scroll-bar@2.3.6(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.3.1)
+      tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  react-remove-scroll@2.5.7(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.6(@types/react@18.3.3)(react@18.3.1)
+      react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.3.1)
+      tslib: 2.6.3
+      use-callback-ref: 1.3.2(@types/react@18.3.3)(react@18.3.1)
+      use-sidecar: 1.1.2(@types/react@18.3.3)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  react-style-singleton@2.2.1(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
+      invariant: 2.2.4
+      react: 18.3.1
+      tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -9905,6 +10256,21 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-callback-ref@1.3.2(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  use-sidecar@1.1.2(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   use-sync-external-store@1.2.2(react@18.3.1):
     dependencies:

--- a/src/app/[organization]/layout.tsx
+++ b/src/app/[organization]/layout.tsx
@@ -30,5 +30,9 @@ export default async function DashboardLayout({
     notFound();
   }
 
-  return <main className="container px-4 pb-16 pt-8">{children}</main>;
+  return (
+    <main className="container px-4 pb-16 pt-8 lg:px-9 lg:py-6">
+      {children}
+    </main>
+  );
 }

--- a/src/app/[organization]/layout.tsx
+++ b/src/app/[organization]/layout.tsx
@@ -30,17 +30,5 @@ export default async function DashboardLayout({
     notFound();
   }
 
-  const organization: Organization = (await getOrganization(
-    params.organization,
-  )) as Organization;
-
-  return (
-    <main className="container px-4 pb-16">
-      <nav className="flex h-[60px] items-center text-slate-700">
-        <Link href="/">Sanbi</Link> <span>&nbsp;//&nbsp;</span>
-        <Link href={`/${params.organization}`}>{organization.name}</Link>
-      </nav>
-      {children}
-    </main>
-  );
+  return <main className="container px-4 pb-16 pt-8">{children}</main>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Navbar } from "@components/Navbar";
 import { GlobalNav } from "@components/GlobalNav";
 import { OrganizationHeader } from "@/components/OrganizationHeader";
 import { auth } from "@clerk/nextjs/server";
+import { SanbiStoreProvider } from "@/providers/sanbi-store-provider";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -36,18 +37,20 @@ export default function RootLayout({
       <html lang="en" className={`${poppins.variable}`}>
         <body>
           <TRPCReactProvider>
-            <div className={`lg:grid ${gridColumns} min-h-screen`}>
-              <SignedIn>
-                <nav className="hidden rounded-b border border-t-0 border-slate-100 bg-slate-50 lg:block lg:px-8 lg:py-6">
-                  <OrganizationHeader />
-                  <GlobalNav />
-                </nav>
-              </SignedIn>
-              <div>
-                <Navbar />
-                {children}
+            <SanbiStoreProvider>
+              <div className={`lg:grid ${gridColumns} min-h-screen`}>
+                <SignedIn>
+                  <nav className="hidden rounded-b border border-t-0 border-slate-100 bg-slate-50 lg:block lg:px-8 lg:py-6">
+                    <OrganizationHeader />
+                    <GlobalNav />
+                  </nav>
+                </SignedIn>
+                <div>
+                  <Navbar />
+                  {children}
+                </div>
               </div>
-            </div>
+            </SanbiStoreProvider>
           </TRPCReactProvider>
         </body>
       </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
 }) {
   const { userId } = auth();
 
-  const gridColumns = userId ? "lg:grid-cols-[300px_1fr]" : "";
+  const gridColumns = userId ? "min-[1025px]:grid-cols-[300px_1fr]" : "";
 
   return (
     <ClerkProvider>
@@ -38,9 +38,9 @@ export default function RootLayout({
         <body>
           <TRPCReactProvider>
             <SanbiStoreProvider>
-              <div className={`lg:grid ${gridColumns} min-h-screen`}>
+              <div className={`min-[1025px]:grid ${gridColumns} min-h-screen`}>
                 <SignedIn>
-                  <nav className="hidden rounded-b border border-t-0 border-slate-100 bg-slate-50 lg:block lg:px-8 lg:py-6">
+                  <nav className="hidden rounded-b border border-t-0 border-slate-100 bg-slate-50 min-[1025px]:sticky min-[1025px]:top-0 min-[1025px]:block min-[1025px]:px-8 min-[1025px]:py-6">
                     <OrganizationHeader />
                     <GlobalNav />
                   </nav>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,14 +3,8 @@ import "@/styles/globals.css";
 import { Poppins } from "next/font/google";
 
 import { TRPCReactProvider } from "@/trpc/react";
-import {
-  ClerkProvider,
-  SignInButton,
-  SignedIn,
-  SignedOut,
-  UserButton,
-} from "@clerk/nextjs";
-import Link from "next/link";
+import { ClerkProvider } from "@clerk/nextjs";
+import { Navbar } from "@/components/Navbar";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -34,15 +28,7 @@ export default function RootLayout({
     <ClerkProvider>
       <html lang="en" className={`${poppins.variable}`}>
         <body>
-          <header className="flex justify-between px-4 py-2">
-            <Link href="/">Sanbi</Link>
-            <SignedOut>
-              <SignInButton fallbackRedirectUrl="sign-in" />
-            </SignedOut>
-            <SignedIn>
-              <UserButton />
-            </SignedIn>
-          </header>
+          <Navbar />
           <TRPCReactProvider>{children}</TRPCReactProvider>
         </body>
       </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,11 @@ import "@/styles/globals.css";
 import { Poppins } from "next/font/google";
 
 import { TRPCReactProvider } from "@/trpc/react";
-import { ClerkProvider } from "@clerk/nextjs";
-import { Navbar } from "@/components/Navbar";
+import { ClerkProvider, SignedIn } from "@clerk/nextjs";
+import { Navbar } from "@components/Navbar";
+import { GlobalNav } from "@components/GlobalNav";
+import { OrganizationHeader } from "@/components/OrganizationHeader";
+import { auth } from "@clerk/nextjs/server";
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -24,12 +27,28 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const { userId } = auth();
+
+  const gridColumns = userId ? "lg:grid-cols-[300px_1fr]" : "";
+
   return (
     <ClerkProvider>
       <html lang="en" className={`${poppins.variable}`}>
         <body>
-          <Navbar />
-          <TRPCReactProvider>{children}</TRPCReactProvider>
+          <TRPCReactProvider>
+            <div className={`lg:grid ${gridColumns} min-h-screen`}>
+              <SignedIn>
+                <nav className="hidden rounded-b border border-t-0 border-slate-100 bg-slate-50 lg:block lg:px-8 lg:py-6">
+                  <OrganizationHeader />
+                  <GlobalNav />
+                </nav>
+              </SignedIn>
+              <div>
+                <Navbar />
+                {children}
+              </div>
+            </div>
+          </TRPCReactProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/src/components/GlobalNav/GlobalNav.tsx
+++ b/src/components/GlobalNav/GlobalNav.tsx
@@ -18,7 +18,7 @@ export const GlobalNav = () => {
   const {
     isPending,
     isError,
-    // @ts-expect-error: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
+    // @ts-ignore: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
     data: userData,
   } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
   const user: UserWithMemberships = userData as UserWithMemberships;

--- a/src/components/GlobalNav/GlobalNav.tsx
+++ b/src/components/GlobalNav/GlobalNav.tsx
@@ -56,10 +56,11 @@ export const GlobalNav = () => {
 
   const { organizationId } = organizationMembership;
   return (
-    <nav className="grid gap-2">
+    <nav className="grid gap-2 lg:fixed lg:top-24 lg:w-[234px]">
       <NavLink
         href={`/${organizationId}`}
         icon={<HouseLine weight={true ? "bold" : "regular"} />}
+        // TODO: dynamically set which menu item is active
         active
       >
         Home

--- a/src/components/GlobalNav/GlobalNav.tsx
+++ b/src/components/GlobalNav/GlobalNav.tsx
@@ -21,7 +21,7 @@ export const GlobalNav = () => {
     // @ts-ignore: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
     data: userData,
   } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
-  const user: UserWithMemberships = userData as UserWithMemberships;
+  const user = userData as UserWithMemberships;
 
   if (isPending) {
     return (

--- a/src/components/GlobalNav/GlobalNav.tsx
+++ b/src/components/GlobalNav/GlobalNav.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  HouseLine,
+  MagnifyingGlass,
+  MusicNoteSimple,
+  Playlist,
+} from "@phosphor-icons/react/dist/ssr";
+import { NavLink } from "@components/NavLink";
+import { useAuth } from "@clerk/nextjs";
+import { api } from "@/trpc/react";
+import { Skeleton } from "@components/ui/skeleton";
+import { type UserWithMemberships } from "@/lib/types";
+import { skipToken } from "@tanstack/react-query";
+
+export const GlobalNav = () => {
+  const { userId, isSignedIn } = useAuth();
+  const {
+    isPending,
+    isError,
+    // @ts-expect-error: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
+    data: userData,
+  } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
+  const user: UserWithMemberships = userData as UserWithMemberships;
+
+  if (isPending) {
+    return (
+      <div className="grid gap-2">
+        <div className="flex items-center gap-4 py-2 align-middle lg:gap-3">
+          <Skeleton className="size-5 rounded lg:size-4" />
+          <Skeleton className="h-5 w-full lg:h-4" />
+        </div>
+        <div className="flex items-center gap-4 py-2 align-middle lg:gap-3">
+          <Skeleton className="size-5 rounded lg:size-4" />
+          <Skeleton className="h-5 w-full lg:h-4" />
+        </div>
+        <div className="flex items-center gap-4 py-2 align-middle lg:gap-3">
+          <Skeleton className="size-5 rounded lg:size-4" />
+          <Skeleton className="h-5 w-full lg:h-4" />
+        </div>
+        <div className="flex items-center gap-4 py-2 align-middle lg:gap-3">
+          <Skeleton className="size-5 rounded lg:size-4" />
+          <Skeleton className="h-5 w-full lg:h-4" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!isSignedIn || !userId || isError || !user) {
+    return null;
+  }
+
+  const organizationMembership = user.memberships[0];
+
+  if (!organizationMembership) {
+    return null;
+  }
+
+  const { organizationId } = organizationMembership;
+  return (
+    <nav className="grid gap-2">
+      <NavLink
+        href={`/${organizationId}`}
+        icon={<HouseLine weight={true ? "bold" : "regular"} />}
+        active
+      >
+        Home
+      </NavLink>
+      <NavLink href="#" icon={<MagnifyingGlass />}>
+        Search
+      </NavLink>
+      <NavLink href="#" icon={<Playlist />}>
+        Sets
+      </NavLink>
+      <NavLink href="#" icon={<MusicNoteSimple />}>
+        Songs
+      </NavLink>
+    </nav>
+  );
+};

--- a/src/components/GlobalNav/GlobalNav.tsx
+++ b/src/components/GlobalNav/GlobalNav.tsx
@@ -18,10 +18,9 @@ export const GlobalNav = () => {
   const {
     isPending,
     isError,
-    // @ts-ignore: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
     data: userData,
   } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
-  const user = userData as UserWithMemberships;
+  const user = userData;
 
   if (isPending) {
     return (

--- a/src/components/GlobalNav/GlobalNav.tsx
+++ b/src/components/GlobalNav/GlobalNav.tsx
@@ -10,7 +10,6 @@ import { NavLink } from "@components/NavLink";
 import { useAuth } from "@clerk/nextjs";
 import { api } from "@/trpc/react";
 import { Skeleton } from "@components/ui/skeleton";
-import { type UserWithMemberships } from "@/lib/types";
 import { skipToken } from "@tanstack/react-query";
 
 export const GlobalNav = () => {

--- a/src/components/GlobalNav/index.tsx
+++ b/src/components/GlobalNav/index.tsx
@@ -1,0 +1,1 @@
+export * from "./GlobalNav";

--- a/src/components/NavLink/NavLink.tsx
+++ b/src/components/NavLink/NavLink.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+type NavLinkProps = React.PropsWithChildren & {
+  href: string;
+  active?: boolean;
+  icon?: React.ReactNode;
+};
+
+export const NavLink: React.FC<NavLinkProps> = ({
+  href,
+  active,
+  icon,
+  children,
+}) => {
+  const activeLinkStyling = active
+    ? "bg-slate-200 mx-[-16px] px-4 hover:bg-slate-200"
+    : "";
+  const colorStyles = active
+    ? "text-slate-700"
+    : "text-slate-400 hover:text-slate-600";
+  const activeTextStyle = active ? "font-semibold" : "";
+
+  return (
+    <Link
+      href={href}
+      className={`flex gap-4 rounded py-2 align-middle text-lg leading-5 hover:mx-[-8px] hover:bg-slate-100 hover:px-2 active:bg-slate-300 lg:gap-3 lg:text-sm lg:hover:mx-[-16px] lg:hover:px-4 ${colorStyles} ${activeLinkStyling} ${activeTextStyle}`}
+    >
+      <span className={`my-auto grid size-5 place-items-center lg:size-4`}>
+        {icon}
+      </span>
+      {children}
+    </Link>
+  );
+};

--- a/src/components/NavLink/NavLink.tsx
+++ b/src/components/NavLink/NavLink.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import React from "react";
+import { NavLinkElement } from "@components/NavLink/NavLinkElement";
 
 type NavLinkProps = React.PropsWithChildren & {
   href: string;
@@ -20,15 +22,15 @@ export const NavLink: React.FC<NavLinkProps> = ({
     : "text-slate-400 hover:text-slate-600";
   const activeTextStyle = active ? "font-semibold" : "";
 
+  const ForwardedNavLinkElement = React.forwardRef(NavLinkElement);
+
   return (
-    <Link
-      href={href}
-      className={`flex gap-4 rounded py-2 align-middle text-lg leading-5 hover:mx-[-8px] hover:bg-slate-100 hover:px-2 active:bg-slate-300 lg:gap-3 lg:text-sm lg:hover:mx-[-16px] lg:hover:px-4 ${colorStyles} ${activeLinkStyling} ${activeTextStyle}`}
-    >
-      <span className={`my-auto grid size-5 place-items-center lg:size-4`}>
-        {icon}
-      </span>
-      {children}
+    <Link href={href} passHref legacyBehavior>
+      <ForwardedNavLinkElement
+        text={children}
+        icon={icon}
+        className={`flex gap-4 rounded py-2 align-middle text-lg leading-5 hover:mx-[-8px] hover:bg-slate-100 hover:px-2 active:bg-slate-300 lg:gap-3 lg:text-sm lg:hover:mx-[-16px] lg:hover:px-4 ${colorStyles} ${activeLinkStyling} ${activeTextStyle}`}
+      />
     </Link>
   );
 };

--- a/src/components/NavLink/NavLinkElement.tsx
+++ b/src/components/NavLink/NavLinkElement.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useSanbiStore } from "@/providers/sanbi-store-provider";
+import React from "react";
+
+type NavLinkElementProps = {
+  text?: React.ReactNode;
+  href?: string;
+  icon?: React.ReactNode;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  className?: string;
+};
+
+export const NavLinkElement: React.ForwardRefRenderFunction<
+  HTMLAnchorElement,
+  NavLinkElementProps
+> = ({ text, href, icon, onClick, className }, ref) => {
+  const { closeMobileNav } = useSanbiStore((state) => state);
+
+  const onClickHandler = (
+    clickEvent: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+  ) => {
+    onClick?.(clickEvent);
+    closeMobileNav();
+  };
+
+  return (
+    <a
+      className={className}
+      href={href}
+      onClick={(clickEvent: React.MouseEvent<HTMLAnchorElement, MouseEvent>) =>
+        onClickHandler(clickEvent)
+      }
+      ref={ref}
+    >
+      <span className={`my-auto grid size-5 place-items-center lg:size-4`}>
+        {icon}
+      </span>
+      {text}
+    </a>
+  );
+};

--- a/src/components/NavLink/index.ts
+++ b/src/components/NavLink/index.ts
@@ -1,0 +1,1 @@
+export * from "./NavLink";

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -17,8 +17,8 @@ export const Navbar: React.FC = () => {
   return (
     <>
       <SignedIn>
-        <header className="grid h-14 grid-cols-[40px_1fr_40px] content-center items-center gap-x-4 rounded-t border border-l-0 border-solid border-slate-100 bg-slate-50 px-4 lg:h-16 lg:grid-cols-[1fr_28px] lg:bg-inherit lg:px-9">
-          <div className="lg:hidden">
+        <header className="sticky top-0 z-50 grid h-14 grid-cols-[40px_1fr_40px] content-center items-center gap-x-4 rounded-t border border-l-0 border-solid border-slate-100 bg-slate-50 px-4 min-[1025px]:h-16 min-[1025px]:grid-cols-[1fr_28px] min-[1025px]:bg-white min-[1025px]:px-9">
+          <div className="min-[1025px]:hidden">
             <Sheet open={isMobileNavOpen} onOpenChange={setIsMobileNavOpen}>
               <SheetTrigger asChild>
                 <Button
@@ -36,17 +36,17 @@ export const Navbar: React.FC = () => {
             </Sheet>
           </div>
           {/* TODO: The search input will be implemented in SWY-36 and SWY-37*/}
-          <div className="relative flex w-full items-center justify-self-center rounded-lg border border-slate-200 bg-white px-3 lg:max-w-3xl">
+          <div className="relative flex w-full items-center justify-self-center rounded-lg border border-slate-200 bg-white px-3 min-[1025px]:max-w-3xl">
             <MagnifyingGlass size={16} className="" />
             <Input placeholder="Search" className="border-none" />
           </div>
-          <div className="grid place-content-center lg:block lg:place-self-end">
+          <div className="grid place-content-center min-[1025px]:block min-[1025px]:place-self-end">
             <UserButton />
           </div>
         </header>
       </SignedIn>
       <SignedOut>
-        <header className="flex h-14 justify-between gap-x-4 rounded-t border border-solid border-slate-100 bg-slate-50 px-4 py-2 lg:h-16">
+        <header className="flex h-14 justify-between gap-x-4 rounded-t border border-solid border-slate-100 bg-slate-50 px-4 py-2 min-[1025px]:h-16">
           <Link href="/" className="self-center">
             Sanbi
           </Link>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,0 +1,24 @@
+import { SignedIn, UserButton } from "@clerk/nextjs";
+import { Button } from "../ui/button";
+import { MagnifyingGlass, Sidebar } from "@phosphor-icons/react/dist/ssr";
+import { Input } from "../ui/input";
+
+export const Navbar: React.FC = () => {
+  return (
+    <header className="grid h-14 grid-cols-[40px_1fr] items-center gap-x-4 border-b px-4 py-2">
+      <Button variant="outline" size="icon" className="rounded">
+        <Sidebar size={16} />
+      </Button>
+      <div className="grid grid-cols-[1fr_40px] gap-x-4">
+        <SignedIn>
+          {/* TODO: The search input will be implemented in SWY-36 and SWY-37*/}
+          <div className="relative flex items-center rounded border border-slate-200 px-3">
+            <MagnifyingGlass size={16} className="" />
+            <Input placeholder="Search" className="border-none" />
+          </div>
+          <UserButton />
+        </SignedIn>
+      </div>
+    </header>
+  );
+};

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,24 +1,54 @@
-import { SignedIn, UserButton } from "@clerk/nextjs";
-import { Button } from "../ui/button";
+import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/nextjs";
+import { Button } from "@components/ui/button";
 import { MagnifyingGlass, Sidebar } from "@phosphor-icons/react/dist/ssr";
-import { Input } from "../ui/input";
+import { Input } from "@components/ui/input";
+import { Sheet, SheetContent, SheetTrigger } from "@components/ui/sheet";
+import Link from "next/link";
+import { GlobalNav } from "@components/GlobalNav";
+import { OrganizationHeader } from "@components/OrganizationHeader";
 
 export const Navbar: React.FC = () => {
   return (
-    <header className="grid h-14 grid-cols-[40px_1fr] items-center gap-x-4 border-b px-4 py-2">
-      <Button variant="outline" size="icon" className="rounded">
-        <Sidebar size={16} />
-      </Button>
-      <div className="grid grid-cols-[1fr_40px] gap-x-4">
-        <SignedIn>
+    <>
+      <SignedIn>
+        <header className="grid h-14 grid-cols-[40px_1fr_40px] content-center items-center gap-x-4 rounded-t border border-l-0 border-solid border-slate-100 bg-slate-50 px-4 lg:h-16 lg:grid-cols-[1fr_28px] lg:bg-inherit lg:px-9">
+          <div className="lg:hidden">
+            <Sheet>
+              <SheetTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="rounded border-slate-200"
+                >
+                  <Sidebar size={16} />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left">
+                <OrganizationHeader />
+                <GlobalNav />
+              </SheetContent>
+            </Sheet>
+          </div>
           {/* TODO: The search input will be implemented in SWY-36 and SWY-37*/}
-          <div className="relative flex items-center rounded border border-slate-200 px-3">
+          <div className="relative flex w-full items-center justify-self-center rounded-lg border border-slate-200 bg-white px-3 lg:max-w-3xl">
             <MagnifyingGlass size={16} className="" />
             <Input placeholder="Search" className="border-none" />
           </div>
-          <UserButton />
-        </SignedIn>
-      </div>
-    </header>
+          <div className="grid place-content-center lg:block lg:place-self-end">
+            <UserButton />
+          </div>
+        </header>
+      </SignedIn>
+      <SignedOut>
+        <header className="flex h-14 justify-between gap-x-4 rounded-t border border-solid border-slate-100 bg-slate-50 px-4 py-2 lg:h-16">
+          <Link href="/" className="self-center">
+            Sanbi
+          </Link>
+          <Button>
+            <SignInButton />
+          </Button>
+        </header>
+      </SignedOut>
+    </>
   );
 };

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -46,7 +46,7 @@ export const Navbar: React.FC = () => {
         </header>
       </SignedIn>
       <SignedOut>
-        <header className="flex h-14 justify-between gap-x-4 rounded-t border border-solid border-slate-100 bg-slate-50 px-4 py-2 min-[1025px]:h-16">
+        <header className="sticky top-0 flex h-14 justify-between gap-x-4 rounded-t border border-solid border-slate-100 bg-slate-50 px-4 py-2 min-[1025px]:h-16">
           <Link href="/" className="self-center">
             Sanbi
           </Link>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/nextjs";
 import { Button } from "@components/ui/button";
 import { MagnifyingGlass, Sidebar } from "@phosphor-icons/react/dist/ssr";
@@ -6,14 +7,19 @@ import { Sheet, SheetContent, SheetTrigger } from "@components/ui/sheet";
 import Link from "next/link";
 import { GlobalNav } from "@components/GlobalNav";
 import { OrganizationHeader } from "@components/OrganizationHeader";
+import { useSanbiStore } from "@/providers/sanbi-store-provider";
 
 export const Navbar: React.FC = () => {
+  const { isMobileNavOpen, setIsMobileNavOpen } = useSanbiStore(
+    (state) => state,
+  );
+
   return (
     <>
       <SignedIn>
         <header className="grid h-14 grid-cols-[40px_1fr_40px] content-center items-center gap-x-4 rounded-t border border-l-0 border-solid border-slate-100 bg-slate-50 px-4 lg:h-16 lg:grid-cols-[1fr_28px] lg:bg-inherit lg:px-9">
           <div className="lg:hidden">
-            <Sheet>
+            <Sheet open={isMobileNavOpen} onOpenChange={setIsMobileNavOpen}>
               <SheetTrigger asChild>
                 <Button
                   variant="outline"

--- a/src/components/Navbar/index.ts
+++ b/src/components/Navbar/index.ts
@@ -1,0 +1,1 @@
+export * from "./Navbar";

--- a/src/components/OrganizationHeader/OrganizationHeader.tsx
+++ b/src/components/OrganizationHeader/OrganizationHeader.tsx
@@ -14,7 +14,7 @@ export const OrganizationHeader: React.FC = () => {
   const {
     isPending,
     isError,
-    // @ts-expect-error: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
+    // @ts-ignore: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
     data: userData,
   } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
   const user: UserWithMemberships = userData as UserWithMemberships;

--- a/src/components/OrganizationHeader/OrganizationHeader.tsx
+++ b/src/components/OrganizationHeader/OrganizationHeader.tsx
@@ -14,10 +14,9 @@ export const OrganizationHeader: React.FC = () => {
   const {
     isPending,
     isError,
-    // @ts-ignore: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
     data: userData,
   } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
-  const user = userData as UserWithMemberships;
+  const user = userData;
 
   if (isPending) {
     return (

--- a/src/components/OrganizationHeader/OrganizationHeader.tsx
+++ b/src/components/OrganizationHeader/OrganizationHeader.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { type UserWithMemberships } from "@/lib/types";
+import { api } from "@/trpc/react";
+import { useAuth } from "@clerk/nextjs";
+import { Text } from "@components/Text";
+import { Skeleton } from "@components/ui/skeleton";
+import { skipToken } from "@tanstack/react-query";
+import Link from "next/link";
+
+export const OrganizationHeader: React.FC = () => {
+  const { userId, isSignedIn } = useAuth();
+
+  const {
+    isPending,
+    isError,
+    // @ts-expect-error: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
+    data: userData,
+  } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
+  const user: UserWithMemberships = userData as UserWithMemberships;
+
+  if (isPending) {
+    return (
+      <div className="mb-8 flex items-center gap-3 lg:mb-10">
+        <Skeleton className="size-8 rounded" />
+        <Skeleton className="h-8 w-full" />
+      </div>
+    );
+  }
+
+  if (!isSignedIn || !userId || isError || !user) {
+    return null;
+  }
+
+  const organizationMembership = user.memberships[0];
+
+  if (!organizationMembership) {
+    return null;
+  }
+
+  const organizationName = organizationMembership?.organization.name;
+  const organizationInitials = organizationName
+    ?.split(" ")
+    .map((word: string) => word[0])
+    .join("");
+
+  return (
+    <Link href={`/${organizationMembership.organizationId}`}>
+      <div className="mb-8 flex items-center gap-3 lg:mb-10">
+        <div className="flex size-8 place-content-center rounded bg-slate-200 py-1">
+          {/* TODO: determine how to style if more than two letter initials */}
+          <Text
+            style="header-medium-semibold"
+            color="slate-700"
+            className="inline-block"
+            lineHeight="normal"
+          >
+            {organizationInitials}
+          </Text>
+        </div>
+        <Text style="header-medium-semibold" color="slate-700">
+          {organizationName}
+        </Text>
+      </div>
+    </Link>
+  );
+};

--- a/src/components/OrganizationHeader/OrganizationHeader.tsx
+++ b/src/components/OrganizationHeader/OrganizationHeader.tsx
@@ -17,7 +17,7 @@ export const OrganizationHeader: React.FC = () => {
     // @ts-ignore: even though `data` exists at runtime, TS doesn't recognize `data` as part of the object the query returns
     data: userData,
   } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
-  const user: UserWithMemberships = userData as UserWithMemberships;
+  const user = userData as UserWithMemberships;
 
   if (isPending) {
     return (

--- a/src/components/OrganizationHeader/OrganizationHeader.tsx
+++ b/src/components/OrganizationHeader/OrganizationHeader.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { type UserWithMemberships } from "@/lib/types";
 import { api } from "@/trpc/react";
 import { useAuth } from "@clerk/nextjs";
-import { Text } from "@components/Text";
 import { Skeleton } from "@components/ui/skeleton";
 import { skipToken } from "@tanstack/react-query";
 import Link from "next/link";
+import React from "react";
+import { OrganizationHeaderLink } from "@components/OrganizationHeader/OrganizationHeaderLink";
 
 export const OrganizationHeader: React.FC = () => {
   const { userId, isSignedIn } = useAuth();
@@ -38,29 +38,17 @@ export const OrganizationHeader: React.FC = () => {
   }
 
   const organizationName = organizationMembership?.organization.name;
-  const organizationInitials = organizationName
-    ?.split(" ")
-    .map((word: string) => word[0])
-    .join("");
 
+  const ForwardedOrganizationHeaderLink = React.forwardRef(
+    OrganizationHeaderLink,
+  );
   return (
-    <Link href={`/${organizationMembership.organizationId}`}>
-      <div className="mb-8 flex items-center gap-3 lg:mb-10">
-        <div className="flex size-8 place-content-center rounded bg-slate-200 py-1">
-          {/* TODO: determine how to style if more than two letter initials */}
-          <Text
-            style="header-medium-semibold"
-            color="slate-700"
-            className="inline-block"
-            lineHeight="normal"
-          >
-            {organizationInitials}
-          </Text>
-        </div>
-        <Text style="header-medium-semibold" color="slate-700">
-          {organizationName}
-        </Text>
-      </div>
+    <Link
+      href={`/${organizationMembership.organizationId}`}
+      passHref
+      legacyBehavior
+    >
+      <ForwardedOrganizationHeaderLink organizationName={organizationName} />
     </Link>
   );
 };

--- a/src/components/OrganizationHeader/OrganizationHeaderLink.tsx
+++ b/src/components/OrganizationHeader/OrganizationHeaderLink.tsx
@@ -30,7 +30,7 @@ export const OrganizationHeaderLink: React.ForwardRefRenderFunction<
 
   return (
     <a
-      className="mb-8 flex items-center gap-3 lg:mb-10"
+      className="mb-8 flex items-center gap-3 lg:fixed lg:top-6"
       href={href}
       onClick={(clickEvent: React.MouseEvent<HTMLAnchorElement, MouseEvent>) =>
         onClickHandler(clickEvent)

--- a/src/components/OrganizationHeader/OrganizationHeaderLink.tsx
+++ b/src/components/OrganizationHeader/OrganizationHeaderLink.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useSanbiStore } from "@/providers/sanbi-store-provider";
+import React from "react";
+import { Text } from "@components/Text";
+
+type NavLinkElementProps = {
+  organizationName: string;
+  href?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+};
+
+export const OrganizationHeaderLink: React.ForwardRefRenderFunction<
+  HTMLAnchorElement,
+  NavLinkElementProps
+> = ({ organizationName, href, onClick }, ref) => {
+  const { closeMobileNav } = useSanbiStore((state) => state);
+
+  const onClickHandler = (
+    clickEvent: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+  ) => {
+    onClick?.(clickEvent);
+    closeMobileNav();
+  };
+
+  const organizationInitials = organizationName
+    ?.split(" ")
+    .map((word: string) => word[0])
+    .join("");
+
+  return (
+    <a
+      className="mb-8 flex items-center gap-3 lg:mb-10"
+      href={href}
+      onClick={(clickEvent: React.MouseEvent<HTMLAnchorElement, MouseEvent>) =>
+        onClickHandler(clickEvent)
+      }
+      ref={ref}
+    >
+      <div className="flex size-8 place-content-center rounded bg-slate-200 py-1">
+        {/* TODO: determine how to style if more than two letter initials */}
+        <Text
+          style="header-medium-semibold"
+          color="slate-700"
+          className="inline-block"
+          lineHeight="normal"
+        >
+          {organizationInitials}
+        </Text>
+      </div>
+      <Text style="header-medium-semibold" color="slate-700">
+        {organizationName}
+      </Text>
+    </a>
+  );
+};

--- a/src/components/OrganizationHeader/index.ts
+++ b/src/components/OrganizationHeader/index.ts
@@ -1,0 +1,1 @@
+export * from "./OrganizationHeader";

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-md bg-muted bg-slate-200",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/lib/types/db.ts
+++ b/src/lib/types/db.ts
@@ -1,3 +1,4 @@
+import { type RouterOutputs } from "@/trpc/react";
 import {
   type organizations,
   type setSectionTypes,
@@ -21,6 +22,8 @@ export type OrganizationMembership =
   typeof organizationMemberships.$inferSelect;
 
 export type NewUser = typeof users.$inferInsert;
+export type User = typeof users.$inferSelect;
+export type UserWithMemberships = RouterOutputs["user"]["getUser"];
 
 export type NewEventType = typeof eventTypes.$inferInsert;
 export type EventType = typeof eventTypes.$inferSelect;

--- a/src/providers/sanbi-store-provider.tsx
+++ b/src/providers/sanbi-store-provider.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { type ReactNode, createContext, useRef, useContext } from "react";
+import { useStore } from "zustand";
+
+import {
+  type SanbiStore,
+  createSanbiStore,
+  initSanbiStore,
+} from "@/stores/sanbi-store";
+
+export type SanbiStoreApi = ReturnType<typeof createSanbiStore>;
+
+export const SanbiStoreContext = createContext<SanbiStoreApi | undefined>(
+  undefined,
+);
+
+export type SanbiStoreProviderProps = {
+  children: ReactNode;
+};
+
+export const SanbiStoreProvider = ({ children }: SanbiStoreProviderProps) => {
+  const storeRef = useRef<SanbiStoreApi>();
+  if (!storeRef.current) {
+    storeRef.current = createSanbiStore(initSanbiStore());
+  }
+
+  return (
+    <SanbiStoreContext.Provider value={storeRef.current}>
+      {children}
+    </SanbiStoreContext.Provider>
+  );
+};
+
+export const useSanbiStore = <T,>(selector: (store: SanbiStore) => T): T => {
+  const sanbiStoreContext = useContext(SanbiStoreContext);
+
+  if (!sanbiStoreContext) {
+    throw new Error(`useSanbiStore must be used within SanbiStoreProvider`);
+  }
+
+  return useStore(sanbiStoreContext, selector);
+};

--- a/src/stores/sanbi-store.ts
+++ b/src/stores/sanbi-store.ts
@@ -1,0 +1,34 @@
+import { createStore } from "zustand/vanilla";
+import { devtools } from "zustand/middleware";
+
+export type SanbiState = {
+  isMobileNavOpen: boolean;
+};
+
+export type SanbiActions = {
+  setIsMobileNavOpen: (isMobileNavOpen: boolean) => void;
+  openMobileNav: () => void;
+  closeMobileNav: () => void;
+};
+
+export type SanbiStore = SanbiState & SanbiActions;
+
+export const initSanbiStore = (): SanbiState => {
+  return { isMobileNavOpen: false };
+};
+
+export const defaultInitState: SanbiState = {
+  isMobileNavOpen: false,
+};
+
+export const createSanbiStore = (initState: SanbiState = defaultInitState) => {
+  return createStore<SanbiStore>()(
+    devtools((set) => ({
+      ...initState,
+      setIsMobileNavOpen: (isMobileNavOpen: boolean) =>
+        set(() => ({ isMobileNavOpen })),
+      openMobileNav: () => set(() => ({ isMobileNavOpen: true })),
+      closeMobileNav: () => set(() => ({ isMobileNavOpen: false })),
+    })),
+  );
+};


### PR DESCRIPTION
## Background
This PR is to add the mobile and desktop navs and "frame" for the app.

Note: the only links that work in the nav are the organization name/avatar (goes to organization dashboard) and "Home" (also goes to the organization dashboard)

### Unauthenticated
| | Before | After |
|--------|--------|--------|
| Mobile | ![SWY-35__before--mobile-signed-out](https://github.com/user-attachments/assets/f46ac959-4826-4406-94f7-7d81001f690d) | ![SWY-35__after--mobile-signed-out](https://github.com/user-attachments/assets/a9009f81-e0aa-4100-9c87-256573080188) |
| Desktop | ![SWY-35__before--desktop-signed-out](https://github.com/user-attachments/assets/c2f54b3d-29cf-4e4a-9e3c-aa0a9f24371a) | ![SWY-35__after--desktop-signed-out](https://github.com/user-attachments/assets/8a5e25e7-1e51-4df2-bc39-08a2eed514af) |

### Authenticated
#### Mobile
| Before | After | After (menu open) |
|--------|--------|--------|
| ![SWY-35__before--mobile](https://github.com/user-attachments/assets/3b167367-20d9-41a6-9188-9ea128d6bcd3) | ![SWY-35__after--mobile](https://github.com/user-attachments/assets/1d65f384-a5d6-49db-997b-e4d7f32084e5) | ![SWY-35__after--mobile-menu-open](https://github.com/user-attachments/assets/627b0e48-8432-4590-b91b-509705689d88) |

#### Desktop
| Before | After |
|--------|--------|
| ![SWY-35__before--desktop](https://github.com/user-attachments/assets/d9343017-f892-4c24-ad50-8487afe2ec4b) | ![SWY-35__after--desktop](https://github.com/user-attachments/assets/d5867083-bd67-4ce0-bc55-cdb8518280eb) |

## What's changed


## How to test
- Open the preview deploy link and while signed out, verify the nav that you see is appropriate for not being signed in (no organization name, links etc.)
- Sign in with a user that is a member of an organization. Once signed in, go to an organization page (dashboard, set, song, etc.) and ensure you see the navs as shown in the "after" screenshots for both mobile and desktop. Also check sizes in between.