### PR TITLE
[SWY-41] Set details page empty state

### DIFF
--- a/src/app/[organization]/layout.tsx
+++ b/src/app/[organization]/layout.tsx
@@ -31,7 +31,7 @@ export default async function DashboardLayout({
   }
 
   return (
-    <main className="container px-4 pb-16 pt-8 lg:px-9 lg:py-6">
+    <main className="grow-1 container flex h-full flex-col px-4 pb-16 pt-8 max-[1025px]:flex-1 lg:px-9 lg:py-6">
       {children}
     </main>
   );

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -75,7 +75,7 @@ export default async function SetListPage({
         <SetActionsMenu
           setId={params.setId}
           organizationId={userMembership.organizationId}
-          archived={(setData.isArchived as boolean) ?? false} // FIXME: fix this type assertion - most likely with using TRPC query
+          archived={setData.isArchived ?? false}
         />
       </section>
       {(!setData?.sections || setData.sections.length === 0) && (

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -10,7 +10,8 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { auth } from "@clerk/nextjs/server";
 import { api } from "@/trpc/server";
-import { SetActionsMenu } from "@/modules/sets/components/SetActionsMenu";
+import { SetActionsMenu } from "@modules/sets/components/SetActionsMenu";
+import { SetEmptyState } from "@modules/sets/components/SetEmptyState";
 
 export default async function SetListPage({
   params,
@@ -55,7 +56,7 @@ export default async function SetListPage({
       0,
     ) ?? 0;
   return (
-    <div className="flex min-w-full max-w-xs flex-col justify-center gap-6">
+    <div className="flex h-full min-w-full max-w-xs flex-1 flex-col justify-center gap-6">
       <PageTitle
         title={setData.date}
         subtitle={setData.eventType.event}
@@ -74,9 +75,12 @@ export default async function SetListPage({
         <SetActionsMenu
           setId={params.setId}
           organizationId={userMembership.organizationId}
-          archived={setData.isArchived ?? false}
+          archived={(setData.isArchived as boolean) ?? false} // FIXME: fix this type assertion - most likely with using TRPC query
         />
       </section>
+      {(!setData?.sections || setData.sections.length === 0) && (
+        <SetEmptyState />
+      )}
       {setData?.sections && setData.sections.length > 0 && (
         <CardList gap="gap-6">
           {setData.sections.map((section) => (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,7 +53,7 @@ export default function RootLayout({
                     <GlobalNav />
                   </div>
                 </SignedIn>
-                <div>
+                <div className="flex min-h-screen flex-col">
                   <Navbar />
                   {children}
                 </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { CircleNotch } from "@phosphor-icons/react/dist/ssr";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed gap-2",
   {
     variants: {
       variant: {
@@ -21,7 +21,7 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
+        default: "h-10 px-5 py-2",
         sm: "h-9 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",
@@ -38,11 +38,22 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
     isLoading?: boolean;
+    leftIcon?: React.ReactNode;
+    rightIcon?: React.ReactNode;
   };
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    { className, variant, size, asChild = false, isLoading = false, ...props },
+    {
+      className,
+      variant,
+      size,
+      asChild = false,
+      isLoading = false,
+      leftIcon,
+      rightIcon,
+      ...props
+    },
     ref,
   ) => {
     const Comp = asChild ? Slot : "button";
@@ -56,7 +67,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {isLoading && (
           <CircleNotch size={12} className="mr-2 h-4 w-4 animate-spin" />
         )}
+        {!isLoading && leftIcon}
         {props.children}
+        {rightIcon}
       </Comp>
     );
   },

--- a/src/modules/sets/components/SetEmptyState/SetEmptyState.tsx
+++ b/src/modules/sets/components/SetEmptyState/SetEmptyState.tsx
@@ -1,0 +1,20 @@
+import { Text } from "@components/Text";
+import { Button } from "@components/ui/button";
+import { MusicNoteSimple } from "@phosphor-icons/react/dist/ssr";
+
+export const SetEmptyState: React.FC = () => {
+  return (
+    <div className="flex grow flex-col items-center justify-center gap-4">
+      <Text style="header-medium-semibold">No songs... yet</Text>
+      <Text style="body-small" className="text-slate-700">
+        Add a song or section to start putting your set together
+      </Text>
+      {/* TODO: wire up button with onClick handler */}
+      <Button
+        leftIcon={<MusicNoteSimple size={14} className="text-slate-100" />}
+      >
+        Add a song
+      </Button>
+    </div>
+  );
+};

--- a/src/modules/sets/components/SetEmptyState/index.ts
+++ b/src/modules/sets/components/SetEmptyState/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetEmptyState";


### PR DESCRIPTION
## Background
After a set is created, the user is essentially shown a blank page. This PR is to add an empty state that matches [the design](https://www.figma.com/design/zTViP06TM8LbQCyvIgcKhE/Sanbi?node-id=1174-12872&t=P6Mk7x5xXsfiTA6u-1).

| Mobile | Desktop |
|--------|---------|
| ![SWY__after--mobile](https://github.com/user-attachments/assets/71fc990b-cad3-4512-b301-8b6e1f15ea41) | ![SWY__after--desktop](https://github.com/user-attachments/assets/b3e9f88c-0788-4bc5-9d90-0fe1672b49a7) |

## What's changed
### Global layout page
- Updated the main "content" `div` element to have a minimum height of `100vh` and to use flexbox

### [organization] layout page
- Updated the `main` element to fill all available space and use flexbox

### Set details page
- Adds the `SetEmptyState` when there are no set sections

### Shared components
- Updated the `Button` component to accept left and right icons
- Updated `Button` default size horizontal padding

### Set module components
- Added the `SetEmptyState` component

## How to test
1. Create a new set (or use an existing set that doesn't have any songs or sections)
2. When the set has been successfully created, you should be redirected to the set's details page
3. You should see the empty state shown in the screenshots above