### PR TITLE
[SWY-45] Updates set details page header styles

### DIFF
--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -58,7 +58,7 @@ export default async function SetListPage({
       0,
     ) ?? 0;
   return (
-    <div className="flex h-full min-w-full max-w-xs flex-1 flex-col justify-center gap-6">
+    <div className="flex h-full min-w-full max-w-xs flex-1 flex-col gap-6">
       <PageTitle
         title={formatDate(setData.date, { month: "long" })}
         subtitle={setData.eventType.event}

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -4,7 +4,7 @@ import { db } from "@server/db";
 import { sets } from "@server/db/schema";
 import { PageTitle } from "@components/PageTitle";
 import { Text } from "@components/Text";
-import { Archive, DotsThree } from "@phosphor-icons/react/dist/ssr";
+import { Archive, DotsThree, Note } from "@phosphor-icons/react/dist/ssr";
 import { eq } from "drizzle-orm";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -12,6 +12,8 @@ import { auth } from "@clerk/nextjs/server";
 import { api } from "@/trpc/server";
 import { SetActionsMenu } from "@modules/sets/components/SetActionsMenu";
 import { SetEmptyState } from "@modules/sets/components/SetEmptyState";
+import { Button } from "@components/ui/button";
+import { formatDate } from "@lib/date";
 
 export default async function SetListPage({
   params,
@@ -58,7 +60,7 @@ export default async function SetListPage({
   return (
     <div className="flex h-full min-w-full max-w-xs flex-1 flex-col justify-center gap-6">
       <PageTitle
-        title={setData.date}
+        title={formatDate(setData.date, { month: "long" })}
         subtitle={setData.eventType.event}
         details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
       />
@@ -68,10 +70,11 @@ export default async function SetListPage({
           <Text>Set is archived</Text>
         </div>
       )}
-      <section className="flex justify-between gap-2">
-        <button className="w-full rounded border border-slate-300 px-3 text-xs font-semibold text-slate-700">
-          Add notes
-        </button>
+      <section className="flex gap-2">
+        <Button variant="outline" size="sm">
+          <Note />
+          Add set notes
+        </Button>
         <SetActionsMenu
           setId={params.setId}
           organizationId={userMembership.organizationId}

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -23,12 +23,16 @@ export const PageTitle: React.FC<PageTitleProps> = ({
         {title}
       </Text>
       {subtitle && (
-        <Text asElement="h2" style="header-medium" className="leading-tight">
+        <Text
+          asElement="h2"
+          style="header-medium"
+          className="leading-tight text-slate-700"
+        >
           {subtitle}
         </Text>
       )}
       {details && (
-        <Text asElement="h3" style="header-small">
+        <Text asElement="h3" style="header-small" className="text-slate-500">
           {details}
         </Text>
       )}

--- a/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
+++ b/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
@@ -107,9 +107,9 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
         onOpenChange={setIsSetActionsMenuOpen}
       >
         <DropdownMenuTrigger>
-          <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
+          <Button variant="outline" size="sm">
             <DotsThree className="text-slate-900" size={12} />
-          </button>
+          </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
           <DropdownMenuItem

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -78,6 +78,9 @@ const config = {
       },
     },
   },
+  safelist: [
+    "text-2xl", // Tailwind doesn't automatically include this class as this value is used in @lib/styles/typography and dynamically applied with `mapTwFontClass`
+  ],
   plugins: [require("tailwindcss-animate")],
 } satisfies Config;
 


### PR DESCRIPTION
## Background
This PR is to update the set details page header to match the design.
| Before | After |
| ------ | ----- |
| ![SWY-45--before](https://github.com/user-attachments/assets/5c7e5830-1ebc-48ec-ac40-6747bb5cdc19) | ![SWY-45--afte](https://github.com/user-attachments/assets/ec59c601-e7a5-4edd-b64c-55a13b047cc4) |

## What's changed
[`PageTitle` component]
- Updates subtitle styling
- Updates details styling

[set details page]
- Updates the copy for the notes button
- Updates notes button to use `Button` component
- Updates title to use formatted date

[`SetActionsMenu` component]
- Updates to use `Button` component


## How to test
