### PR TITLE
[SWY-46] Fix set empty state positioning

### DIFF
--- a/src/modules/sets/components/SetEmptyState/SetEmptyState.tsx
+++ b/src/modules/sets/components/SetEmptyState/SetEmptyState.tsx
@@ -4,7 +4,7 @@ import { MusicNoteSimple } from "@phosphor-icons/react/dist/ssr";
 
 export const SetEmptyState: React.FC = () => {
   return (
-    <div className="flex grow flex-col items-center justify-center gap-4">
+    <div className="flex grow flex-col items-center justify-center gap-4 min-[1025px]:mt-32 min-[1025px]:grow-0">
       <Text style="header-medium-semibold">No songs... yet</Text>
       <Text style="body-small" className="text-slate-700">
         Add a song or section to start putting your set together


### PR DESCRIPTION
## Background

| Before | After |
| ------ | ----- |
| ![SWY-46--before](https://github.com/user-attachments/assets/bf8d1e5d-ef07-4924-963b-2937cba75725) | ![SWY-46--after](https://github.com/user-attachments/assets/f3d4afae-6d1a-49e8-988a-8381d7f3e904) |

## What's changed
[set details page]
- Updated the container to have a set `margin-top` rather than taking up the remaining space

## How to test
Run the branch locally and navigate to an empty set's details page. It should match the "After" screenshot above.