### PR TITLE
[SWY-42/SWY-47] Add song search modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@vercel/postgres": "^0.8.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "cmdk": "1.0.0",
     "date-fns": "^3.6.0",
     "drizzle-orm": "^0.30.10",
     "drizzle-zod": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: 1.0.0
+        version: 1.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
@@ -1304,6 +1307,9 @@ packages:
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
 
+  '@radix-ui/primitive@1.0.1':
+    resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
+
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
 
@@ -1372,11 +1378,29 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.0.1':
+    resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.0.1':
+    resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1397,6 +1421,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.0.5':
+    resolution: {integrity: sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-dialog@1.1.1':
@@ -1432,6 +1469,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.0.5':
+    resolution: {integrity: sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.0':
@@ -1473,6 +1523,15 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.0.1':
+    resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.0':
     resolution: {integrity: sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==}
     peerDependencies:
@@ -1491,6 +1550,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-focus-scope@1.0.4':
+    resolution: {integrity: sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-scope@1.1.0':
     resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
     peerDependencies:
@@ -1502,6 +1574,15 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.0.1':
+    resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@radix-ui/react-id@1.1.0':
@@ -1565,6 +1646,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-portal@1.0.4':
+    resolution: {integrity: sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.1':
     resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
     peerDependencies:
@@ -1591,6 +1685,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.0.1':
+    resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.1.0':
     resolution: {integrity: sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==}
     peerDependencies:
@@ -1611,6 +1718,19 @@ packages:
       '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@1.0.3':
+    resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1656,6 +1776,15 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-slot@1.0.2':
+    resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-slot@1.1.0':
     resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
     peerDependencies:
@@ -1691,11 +1820,29 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.0.1':
+    resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.0':
     resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.0.1':
+    resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1709,11 +1856,29 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-escape-keydown@1.0.3':
+    resolution: {integrity: sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.0':
     resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.0.1':
+    resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2678,6 +2843,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.0.0:
+    resolution: {integrity: sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -4666,6 +4837,16 @@ packages:
       '@types/react':
         optional: true
 
+  react-remove-scroll@2.5.5:
+    resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-remove-scroll@2.5.7:
     resolution: {integrity: sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==}
     engines: {node: '>=10'}
@@ -6583,6 +6764,10 @@ snapshots:
 
   '@radix-ui/number@1.1.0': {}
 
+  '@radix-ui/primitive@1.0.1':
+    dependencies:
+      '@babel/runtime': 7.24.6
+
   '@radix-ui/primitive@1.1.0': {}
 
   '@radix-ui/react-accordion@1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -6653,8 +6838,22 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-compose-refs@1.0.1(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
   '@radix-ui/react-compose-refs@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-context@1.0.1(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3
@@ -6670,6 +6869,29 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3
+
+  '@radix-ui/react-dialog@1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.5(@types/react@18.3.3)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-dialog@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -6721,6 +6943,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  '@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-dismissable-layer@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -6762,6 +6998,13 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-focus-guards@1.0.1(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
   '@radix-ui/react-focus-guards@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -6774,6 +7017,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  '@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-focus-scope@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
@@ -6784,6 +7039,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-id@1.0.1(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   '@radix-ui/react-id@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
@@ -6868,6 +7131,16 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-portal@1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-portal@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6888,6 +7161,17 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-presence@1.0.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-presence@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
@@ -6902,6 +7186,16 @@ snapshots:
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-primitive@1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -6963,6 +7257,14 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-slot@1.0.2(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
   '@radix-ui/react-slot@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
@@ -7001,8 +7303,23 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3
@@ -7014,9 +7331,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
   '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.6
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3
@@ -8181,6 +8513,16 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cmdk@1.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.2: {}
@@ -8736,7 +9078,7 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
@@ -8758,7 +9100,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -10447,6 +10789,17 @@ snapshots:
       react: 18.3.1
       react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.3.1)
       tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  react-remove-scroll@2.5.5(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.6(@types/react@18.3.3)(react@18.3.1)
+      react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.3.1)
+      tslib: 2.6.3
+      use-callback-ref: 1.3.2(@types/react@18.3.3)(react@18.3.1)
+      use-sidecar: 1.1.2(@types/react@18.3.3)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.3
 

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,86 +1,95 @@
 "use client";
 import { pluralize } from "@lib/string";
-import { CardList, SetListCardBody, SongItem } from "@modules/SetListCard";
+import { CardList } from "@modules/SetListCard";
 import { PageTitle } from "@components/PageTitle";
 import { Text } from "@components/Text";
-import { Archive, DotsThree, Note } from "@phosphor-icons/react/dist/ssr";
-import Link from "next/link";
+import { Archive, Note } from "@phosphor-icons/react/dist/ssr";
 import { redirect } from "next/navigation";
 import { SetActionsMenu } from "@modules/sets/components/SetActionsMenu";
 import { SetEmptyState } from "@modules/sets/components/SetEmptyState";
 import { Button } from "@components/ui/button";
 import { formatDate } from "@lib/date";
 import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
-import React from "react";
+import { useState, useCallback, type FC } from "react";
 import { api } from "@/trpc/react";
 import { validate as uuidValidate } from "uuid";
 import { useAuth } from "@clerk/nextjs";
+import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
+import { type SetSectionWithSongs } from "@lib/types";
+import { useSetQuery } from "@modules/sets/api";
 
-export default function SetListPage({
-  params,
-}: {
-  params: { organization: string; setId: string };
-}) {
-  const isOrganizationIdValidUuid = uuidValidate(params.organization);
-  const isSetIdValidUuid = uuidValidate(params.setId);
+const SetPageLoadingState: FC = () => {
+  return <Text>Loading...</Text>;
+};
 
-  if (!isOrganizationIdValidUuid) {
-    console.error(`🤖 - ${params.organization} is an invalid organization ID`);
-  }
+const SetPageErrorState: FC = () => {
+  return <Text>Uh oh. Something went wrong.</Text>;
+};
 
-  if (!isSetIdValidUuid) {
-    console.error(`🤖 - ${params.setId} is invalid set ID`);
-  }
+type SetListPageProps = { params: { organization: string; setId: string } };
 
-  if (!isOrganizationIdValidUuid || !isSetIdValidUuid) {
-    console.error(`🤖 - Invalid params`);
-    // notFound();
-  }
+export default function SetListPage({ params }: SetListPageProps) {
+  const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] =
+    useState<boolean>(false);
 
-  const {
-    data: setData,
-    isLoading: isSetQueryLoading,
-    error: setQueryError,
-  } = api.set.get.useQuery({
-    organizationId: params.organization,
-    setId: params.setId,
-  });
+  const validateParams = useCallback(() => {
+    const isOrganizationIdValidUuid = uuidValidate(params.organization);
+    const isSetIdValidUuid = uuidValidate(params.setId);
+    if (!isOrganizationIdValidUuid) {
+      console.error(
+        `🤖 - ${params.organization} is an invalid organization ID`,
+      );
+    }
 
-  // Auth
+    if (!isSetIdValidUuid) {
+      console.error(`🤖 - ${params.setId} is invalid set ID`);
+    }
+
+    if (!isOrganizationIdValidUuid || !isSetIdValidUuid) {
+      console.error(`🤖 - Invalid params`);
+      // notFound();
+    }
+  }, [params.organization, params.setId]);
+
+  // auth
   const { userId, isLoaded: isAuthLoaded } = useAuth();
-
   if (isAuthLoaded && !userId) {
     redirect("/");
   }
 
-  const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] =
-    React.useState<boolean>(false);
+  // data queries
+  const {
+    data: setData,
+    isLoading: isSetQueryLoading,
+    error: setQueryError,
+  } = useSetQuery({
+    setId: params.setId,
+    organizationId: params.organization,
+    userId: userId!, // we use a non-null assertion here since the redirect would have already fired if userId is falsy
+  });
 
-  // FIXME: redirect to dashboard if no sets are found
-  if (!userId) {
-    redirect(`/`);
-  }
-
-  // const userData = await api.user.getUser({ userId });
   const {
     data: userData,
     isLoading: isUserQueryLoading,
     error: userQueryError,
-  } = api.user.getUser.useQuery({ userId });
+  } = api.user.getUser.useQuery({ userId: userId! }, { enabled: !!userId }); // we use a non-null assertion here since the query will be disabled if userId is falsy
   const userMembership = userData?.memberships[0];
 
-  const isPageLoading = isSetQueryLoading || isUserQueryLoading;
+  validateParams();
+
+  const isPageLoading =
+    !isAuthLoaded || isSetQueryLoading || isUserQueryLoading;
+  if (isPageLoading) {
+    return <SetPageLoadingState />;
+  }
+
   const queryError = !!setQueryError || !!userQueryError;
+  if (!!setQueryError || !!userQueryError) {
+    return <SetPageErrorState />;
+  }
 
-  if (!isPageLoading && !queryError) {
-    // if (!userMembership) {
-    if (!userData?.memberships[0] || !setData) {
-      redirect(`/`);
-    }
-
-    if (!setData) {
-      redirect("/");
-    }
+  if (!userMembership || !setData) {
+    redirect(`/`);
   }
 
   const songCount =
@@ -91,7 +100,6 @@ export default function SetListPage({
 
   return (
     <div className="flex h-full min-w-full max-w-xs flex-1 flex-col gap-6">
-      {isPageLoading && <Text>Loading...</Text>}
       {!isPageLoading && !queryError && (
         <>
           <PageTitle
@@ -125,59 +133,25 @@ export default function SetListPage({
           )}
           {setData?.sections && setData.sections.length > 0 && (
             <CardList gap="gap-6">
-              {setData.sections.map((section) => (
-                // FIXME: refactor into reusable component
-                <div
-                  key={section.id}
-                  className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow"
-                >
-                  <header className="flex flex-col gap-2">
-                    <div className="flex justify-between">
-                      <Text asElement="h3" style="header-medium-semibold">
-                        {section.type.section}
-                      </Text>
-                      <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
-                        <DotsThree className="text-slate-900" size={12} />
-                      </button>
-                    </div>
-                    <hr className="bg-slate-100" />
-                  </header>
-                  <SetListCardBody>
-                    {section.songs && section.songs.length > 0 && (
-                      <div className="flex flex-col gap-3">
-                        {section.songs.map((setSectionSong) => {
-                          let indexStart = 1;
+              {setData.sections.map((section) => {
+                let sectionStartIndex = 1;
 
-                          for (
-                            let sectionPosition = 0;
-                            sectionPosition < section.position;
-                            sectionPosition++
-                          ) {
-                            indexStart +=
-                              setData.sections[sectionPosition]!.songs.length;
-                          }
-
-                          return (
-                            <Link
-                              key={setSectionSong.songId}
-                              href={`../songs/${setSectionSong.songId}`}
-                            >
-                              <SongItem
-                                index={indexStart + setSectionSong.position}
-                                songKey={setSectionSong.key}
-                                name={setSectionSong.song.name}
-                                {...(setSectionSong.notes && {
-                                  notes: setSectionSong.notes,
-                                })}
-                              />
-                            </Link>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </SetListCardBody>
-                </div>
-              ))}
+                for (
+                  let sectionPosition = 0;
+                  sectionPosition < section.position;
+                  sectionPosition++
+                ) {
+                  sectionStartIndex +=
+                    setData.sections[sectionPosition]!.songs.length;
+                }
+                return (
+                  <SetSectionCard
+                    key={section.id}
+                    section={section as SetSectionWithSongs}
+                    sectionStartIndex={sectionStartIndex}
+                  />
+                );
+              })}
             </CardList>
           )}
           <SongSearchDialog

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -10,21 +10,15 @@ import { SetEmptyState } from "@modules/sets/components/SetEmptyState";
 import { Button } from "@components/ui/button";
 import { formatDate } from "@lib/date";
 import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
-import { useState, useCallback, type FC } from "react";
+import { useState, useCallback } from "react";
 import { api } from "@/trpc/react";
 import { validate as uuidValidate } from "uuid";
 import { useAuth } from "@clerk/nextjs";
 import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
 import { type SetSectionWithSongs } from "@lib/types";
 import { useSetQuery } from "@modules/sets/api";
-
-const SetPageLoadingState: FC = () => {
-  return <Text>Loading...</Text>;
-};
-
-const SetPageErrorState: FC = () => {
-  return <Text>Uh oh. Something went wrong.</Text>;
-};
+import { SetPageLoadingState } from "@modules/sets/components/SetLoadingState";
+import { SetPageErrorState } from "@modules/sets/components/SetErrorState";
 
 type SetListPageProps = { params: { organization: string; setId: string } };
 

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,55 +1,86 @@
+"use client";
 import { pluralize } from "@lib/string";
 import { CardList, SetListCardBody, SongItem } from "@modules/SetListCard";
-import { db } from "@server/db";
-import { sets } from "@server/db/schema";
 import { PageTitle } from "@components/PageTitle";
 import { Text } from "@components/Text";
 import { Archive, DotsThree, Note } from "@phosphor-icons/react/dist/ssr";
-import { eq } from "drizzle-orm";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { auth } from "@clerk/nextjs/server";
-import { api } from "@/trpc/server";
 import { SetActionsMenu } from "@modules/sets/components/SetActionsMenu";
 import { SetEmptyState } from "@modules/sets/components/SetEmptyState";
 import { Button } from "@components/ui/button";
 import { formatDate } from "@lib/date";
+import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
+import React from "react";
+import { api } from "@/trpc/react";
+import { validate as uuidValidate } from "uuid";
+import { useAuth } from "@clerk/nextjs";
 
-export default async function SetListPage({
+export default function SetListPage({
   params,
 }: {
-  params: { setId: string };
+  params: { organization: string; setId: string };
 }) {
-  // TODO: useQuery instead?
-  const setData = await db.query.sets.findFirst({
-    where: eq(sets.id, params.setId),
-    with: {
-      eventType: true,
-      sections: {
-        with: {
-          type: true,
-          songs: {
-            with: {
-              song: true,
-            },
-          },
-        },
-      },
-    },
+  const isOrganizationIdValidUuid = uuidValidate(params.organization);
+  const isSetIdValidUuid = uuidValidate(params.setId);
+
+  if (!isOrganizationIdValidUuid) {
+    console.error(`🤖 - ${params.organization} is an invalid organization ID`);
+  }
+
+  if (!isSetIdValidUuid) {
+    console.error(`🤖 - ${params.setId} is invalid set ID`);
+  }
+
+  if (!isOrganizationIdValidUuid || !isSetIdValidUuid) {
+    console.error(`🤖 - Invalid params`);
+    // notFound();
+  }
+
+  const {
+    data: setData,
+    isLoading: isSetQueryLoading,
+    error: setQueryError,
+  } = api.set.get.useQuery({
+    organizationId: params.organization,
+    setId: params.setId,
   });
 
-  const { userId } = auth();
+  // Auth
+  const { userId, isLoaded: isAuthLoaded } = useAuth();
+
+  if (isAuthLoaded && !userId) {
+    redirect("/");
+  }
+
+  const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] =
+    React.useState<boolean>(false);
 
   // FIXME: redirect to dashboard if no sets are found
-  if (!userId || !setData) {
+  if (!userId) {
     redirect(`/`);
   }
 
-  const userData = await api.user.getUser({ userId });
+  // const userData = await api.user.getUser({ userId });
+  const {
+    data: userData,
+    isLoading: isUserQueryLoading,
+    error: userQueryError,
+  } = api.user.getUser.useQuery({ userId });
   const userMembership = userData?.memberships[0];
 
-  if (!userMembership) {
-    redirect(`/`);
+  const isPageLoading = isSetQueryLoading || isUserQueryLoading;
+  const queryError = !!setQueryError || !!userQueryError;
+
+  if (!isPageLoading && !queryError) {
+    // if (!userMembership) {
+    if (!userData?.memberships[0] || !setData) {
+      redirect(`/`);
+    }
+
+    if (!setData) {
+      redirect("/");
+    }
   }
 
   const songCount =
@@ -57,89 +88,103 @@ export default async function SetListPage({
       (total, section) => total + section.songs.length,
       0,
     ) ?? 0;
+
   return (
     <div className="flex h-full min-w-full max-w-xs flex-1 flex-col gap-6">
-      <PageTitle
-        title={formatDate(setData.date, { month: "long" })}
-        subtitle={setData.eventType.event}
-        details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
-      />
-      {setData.isArchived && (
-        <div className="flex items-center gap-1 uppercase text-slate-500">
-          <Archive />
-          <Text>Set is archived</Text>
-        </div>
-      )}
-      <section className="flex gap-2">
-        <Button variant="outline" size="sm">
-          <Note />
-          Add set notes
-        </Button>
-        <SetActionsMenu
-          setId={params.setId}
-          organizationId={userMembership.organizationId}
-          archived={setData.isArchived ?? false}
-        />
-      </section>
-      {(!setData?.sections || setData.sections.length === 0) && (
-        <SetEmptyState />
-      )}
-      {setData?.sections && setData.sections.length > 0 && (
-        <CardList gap="gap-6">
-          {setData.sections.map((section) => (
-            // FIXME: refactor into reusable component
-            <div
-              key={section.id}
-              className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow"
-            >
-              <header className="flex flex-col gap-2">
-                <div className="flex justify-between">
-                  <Text asElement="h3" style="header-medium-semibold">
-                    {section.type.section}
-                  </Text>
-                  <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
-                    <DotsThree className="text-slate-900" size={12} />
-                  </button>
-                </div>
-                <hr className="bg-slate-100" />
-              </header>
-              <SetListCardBody>
-                {section.songs && section.songs.length > 0 && (
-                  <div className="flex flex-col gap-3">
-                    {section.songs.map((setSectionSong) => {
-                      let indexStart = 1;
-
-                      for (
-                        let sectionPosition = 0;
-                        sectionPosition < section.position;
-                        sectionPosition++
-                      ) {
-                        indexStart +=
-                          setData.sections[sectionPosition]!.songs.length;
-                      }
-
-                      return (
-                        <Link
-                          key={setSectionSong.songId}
-                          href={`../songs/${setSectionSong.songId}`}
-                        >
-                          <SongItem
-                            index={indexStart + setSectionSong.position}
-                            songKey={setSectionSong.key}
-                            name={setSectionSong.song.name}
-                            {...(setSectionSong.notes && {
-                              notes: setSectionSong.notes,
-                            })}
-                          />
-                        </Link>
-                      );
-                    })}
-                  </div>
-                )}
-              </SetListCardBody>
+      {isPageLoading && <Text>Loading...</Text>}
+      {!isPageLoading && !queryError && (
+        <>
+          <PageTitle
+            title={formatDate(setData.date, { month: "long" })}
+            subtitle={setData.eventType.event}
+            details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
+          />
+          {setData.isArchived && (
+            <div className="flex items-center gap-1 uppercase text-slate-500">
+              <Archive />
+              <Text>Set is archived</Text>
             </div>
-          ))}
-        </CardList>
+          )}
+          <section className="flex gap-2">
+            <Button variant="outline" size="sm">
+              <Note />
+              Add set notes
+            </Button>
+            <SetActionsMenu
+              setId={params.setId}
+              organizationId={userMembership.organizationId}
+              archived={setData.isArchived ?? false}
+            />
+          </section>
+          {(!setData?.sections || setData.sections.length === 0) && (
+            <SetEmptyState
+              onActionClick={() => {
+                setIsSongSearchDialogOpen(true);
+              }}
+            />
+          )}
+          {setData?.sections && setData.sections.length > 0 && (
+            <CardList gap="gap-6">
+              {setData.sections.map((section) => (
+                // FIXME: refactor into reusable component
+                <div
+                  key={section.id}
+                  className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow"
+                >
+                  <header className="flex flex-col gap-2">
+                    <div className="flex justify-between">
+                      <Text asElement="h3" style="header-medium-semibold">
+                        {section.type.section}
+                      </Text>
+                      <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
+                        <DotsThree className="text-slate-900" size={12} />
+                      </button>
+                    </div>
+                    <hr className="bg-slate-100" />
+                  </header>
+                  <SetListCardBody>
+                    {section.songs && section.songs.length > 0 && (
+                      <div className="flex flex-col gap-3">
+                        {section.songs.map((setSectionSong) => {
+                          let indexStart = 1;
+
+                          for (
+                            let sectionPosition = 0;
+                            sectionPosition < section.position;
+                            sectionPosition++
+                          ) {
+                            indexStart +=
+                              setData.sections[sectionPosition]!.songs.length;
+                          }
+
+                          return (
+                            <Link
+                              key={setSectionSong.songId}
+                              href={`../songs/${setSectionSong.songId}`}
+                            >
+                              <SongItem
+                                index={indexStart + setSectionSong.position}
+                                songKey={setSectionSong.key}
+                                name={setSectionSong.song.name}
+                                {...(setSectionSong.notes && {
+                                  notes: setSectionSong.notes,
+                                })}
+                              />
+                            </Link>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </SetListCardBody>
+                </div>
+              ))}
+            </CardList>
+          )}
+          <SongSearchDialog
+            open={isSongSearchDialogOpen}
+            setOpen={setIsSongSearchDialogOpen}
+          />
+        </>
       )}
     </div>
   );

--- a/src/components/HStack/HSTack.tsx
+++ b/src/components/HStack/HSTack.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/lib/utils";
+import { type DetailedHTMLProps, type HTMLAttributes, type FC } from "react";
+type HStackProps = DetailedHTMLProps<
+  HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+export const HStack: FC<HStackProps> = ({ className, ...props }) => {
+  return <div className={cn(`flex flex-row`, className)} {...props}></div>;
+};

--- a/src/components/HStack/index.ts
+++ b/src/components/HStack/index.ts
@@ -1,0 +1,1 @@
+export * from "./HSTack";

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import * as React from "react";
+import { type DialogProps } from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+Command.displayName = CommandPrimitive.displayName;
+
+const CommandDialog = ({ children, ...props }: DialogProps) => {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden rounded-lg p-0 shadow-lg">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  </div>
+));
+
+CommandInput.displayName = CommandPrimitive.Input.displayName;
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+));
+
+CommandList.displayName = CommandPrimitive.List.displayName;
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm"
+    {...props}
+  />
+));
+
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
+
+const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      className,
+    )}
+    {...props}
+  />
+));
+
+CommandItem.displayName = CommandPrimitive.Item.displayName;
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+CommandShortcut.displayName = "CommandShortcut";
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/src/lib/types/db.ts
+++ b/src/lib/types/db.ts
@@ -29,6 +29,7 @@ export type NewEventType = typeof eventTypes.$inferInsert;
 export type EventType = typeof eventTypes.$inferSelect;
 
 export type NewSetSectionType = typeof setSectionTypes.$inferInsert;
+export type SetSectionTypeType = typeof setSectionTypes.$inferSelect;
 
 export type NewTag = typeof tags.$inferInsert;
 export type Tag = typeof tags.$inferSelect;
@@ -41,6 +42,21 @@ export type NewSongTag = typeof songTags.$inferInsert;
 export type NewSet = typeof sets.$inferInsert;
 
 export type NewSetSection = typeof setSections.$inferInsert;
-export type SetSection = typeof setSections.$inferSelect;
+export type SetSectionType = typeof setSections.$inferSelect;
 
 export type NewSetSectionSong = typeof setSectionSongs.$inferInsert;
+export type SetSectionSongType = typeof setSectionSongs.$inferSelect;
+
+export type SetSectionSongWithSongData = SetSectionSongType & {
+  song: Song;
+};
+
+export type SetSectionWithSongs = SetSectionType & {
+  type: SetSectionTypeType;
+  songs: SetSectionSongWithSongData[];
+};
+
+export type SetSectionProps = {
+  section: SetSectionWithSongs;
+  sectionStartIndex: number;
+};

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -32,6 +32,7 @@ export const insertOrganizationMembershipSchema = createInsertSchema(
 /**
  * Set schemas
  */
+export const getSetSchema = z.object({ setId: z.string().uuid() });
 export const insertSetSchema = createInsertSchema(sets);
 
 const setIdSchema = z.object({

--- a/src/modules/sets/api/index.ts
+++ b/src/modules/sets/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./queries";

--- a/src/modules/sets/api/queries.ts
+++ b/src/modules/sets/api/queries.ts
@@ -1,0 +1,19 @@
+import { api } from "@/trpc/react";
+import { validate as uuidValidate } from "uuid";
+
+export const useSetQuery = (params: {
+  setId: string;
+  organizationId: string;
+  userId: string;
+}) => {
+  const { setId, organizationId, userId } = params;
+  return api.set.get.useQuery(
+    {
+      organizationId,
+      setId: params.setId,
+    },
+    {
+      enabled: !!userId && uuidValidate(organizationId) && uuidValidate(setId),
+    },
+  );
+};

--- a/src/modules/sets/components/SetEmptyState/SetEmptyState.tsx
+++ b/src/modules/sets/components/SetEmptyState/SetEmptyState.tsx
@@ -2,7 +2,13 @@ import { Text } from "@components/Text";
 import { Button } from "@components/ui/button";
 import { MusicNoteSimple } from "@phosphor-icons/react/dist/ssr";
 
-export const SetEmptyState: React.FC = () => {
+type SetEmptyStateProps = {
+  onActionClick: () => void;
+};
+
+export const SetEmptyState: React.FC<SetEmptyStateProps> = ({
+  onActionClick,
+}) => {
   return (
     <div className="flex grow flex-col items-center justify-center gap-4 min-[1025px]:mt-32 min-[1025px]:grow-0">
       <Text style="header-medium-semibold">No songs... yet</Text>
@@ -12,6 +18,7 @@ export const SetEmptyState: React.FC = () => {
       {/* TODO: wire up button with onClick handler */}
       <Button
         leftIcon={<MusicNoteSimple size={14} className="text-slate-100" />}
+        onClick={onActionClick}
       >
         Add a song
       </Button>

--- a/src/modules/sets/components/SetErrorState/SetErrorState.tsx
+++ b/src/modules/sets/components/SetErrorState/SetErrorState.tsx
@@ -1,0 +1,6 @@
+import { type FC } from "react";
+import { Text } from "@components/Text";
+
+export const SetPageErrorState: FC = () => {
+  return <Text>Uh oh. Something went wrong.</Text>;
+};

--- a/src/modules/sets/components/SetErrorState/index.ts
+++ b/src/modules/sets/components/SetErrorState/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetErrorState";

--- a/src/modules/sets/components/SetLoadingState/SetLoadingState.tsx
+++ b/src/modules/sets/components/SetLoadingState/SetLoadingState.tsx
@@ -1,6 +1,14 @@
 import { type FC } from "react";
 import { Text } from "@components/Text";
+import { CircleNotch } from "@phosphor-icons/react/dist/ssr";
+import { HStack } from "@components/HStack";
 
+// TODO: update this to skeleton?
 export const SetPageLoadingState: FC = () => {
-  return <Text>Loading...</Text>;
+  return (
+    <HStack className="items-center">
+      <CircleNotch size={12} className="mr-2 h-4 w-4 animate-spin" />
+      <Text>Getting set information...</Text>
+    </HStack>
+  );
 };

--- a/src/modules/sets/components/SetLoadingState/SetLoadingState.tsx
+++ b/src/modules/sets/components/SetLoadingState/SetLoadingState.tsx
@@ -1,0 +1,6 @@
+import { type FC } from "react";
+import { Text } from "@components/Text";
+
+export const SetPageLoadingState: FC = () => {
+  return <Text>Loading...</Text>;
+};

--- a/src/modules/sets/components/SetLoadingState/index.ts
+++ b/src/modules/sets/components/SetLoadingState/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetLoadingState";

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -1,0 +1,59 @@
+import { type FC } from "react";
+import { type SetSectionWithSongs } from "@lib/types";
+import { DotsThree } from "@phosphor-icons/react/dist/ssr";
+import { SetListCardBody, SongItem } from "@modules/SetListCard";
+import Link from "next/link";
+import { Text } from "@components/Text";
+
+export type SetSectionProps = {
+  section: SetSectionWithSongs;
+  sectionStartIndex: number;
+};
+
+export const SetSectionCard: FC<SetSectionProps> = ({
+  section,
+  sectionStartIndex,
+}) => {
+  const { id, type, songs } = section;
+  return (
+    <div
+      key={id}
+      className="flex flex-col gap-4 rounded border border-slate-200 p-4 shadow"
+    >
+      <header className="flex flex-col gap-2">
+        <div className="flex justify-between">
+          <Text asElement="h3" style="header-medium-semibold">
+            {type.section}
+          </Text>
+          <button className="flex h-6 w-6 place-content-center rounded border border-slate-300 p-[6px]">
+            <DotsThree className="text-slate-900" size={12} />
+          </button>
+        </div>
+        <hr className="bg-slate-100" />
+      </header>
+      <SetListCardBody>
+        {songs && songs.length > 0 && (
+          <div className="flex flex-col gap-3">
+            {section.songs.map((setSectionSong) => {
+              return (
+                <Link
+                  key={setSectionSong.songId}
+                  href={`../songs/${setSectionSong.songId}`}
+                >
+                  <SongItem
+                    index={sectionStartIndex + setSectionSong.position}
+                    songKey={setSectionSong.key}
+                    name={setSectionSong.song.name}
+                    {...(setSectionSong.notes && {
+                      notes: setSectionSong.notes,
+                    })}
+                  />
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </SetListCardBody>
+    </div>
+  );
+};

--- a/src/modules/sets/components/SetSectionCard/index.ts
+++ b/src/modules/sets/components/SetSectionCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetSectionCard";

--- a/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
+++ b/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
@@ -1,0 +1,30 @@
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+
+type SongSearchDialogProps = {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
+  open,
+  setOpen,
+}) => {
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput placeholder="Search for a song or tag..." />
+      <CommandList>
+        <CommandEmpty>No songs found.</CommandEmpty>
+        <CommandGroup heading="Songs">
+          <CommandItem>Test song</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+};

--- a/src/modules/songs/components/SongSearchDialog/index.ts
+++ b/src/modules/songs/components/SongSearchDialog/index.ts
@@ -1,0 +1,1 @@
+export * from "./SongSearchDialog";

--- a/src/server/db/seed.ts
+++ b/src/server/db/seed.ts
@@ -31,7 +31,7 @@ import {
   type NewSet,
   type NewSetSection,
   type NewSetSectionSong,
-  type SetSection,
+  type SetSectionType,
 } from "@lib/types/db";
 import { faker } from "@faker-js/faker";
 import { sql } from "drizzle-orm";
@@ -327,7 +327,7 @@ const seed = async () => {
   await db.execute(sql`TRUNCATE TABLE sanbi_set_section_songs CASCADE`);
 
   const createSeedForSetSection = async (
-    setSection: SetSection,
+    setSection: SetSectionType,
   ): Promise<NewSetSectionSong[]> => {
     const randomAmountOfSongs =
       Math.floor(Math.random() * MAX_AMOUNT_OF_SONGS_PER_SECTION) +
@@ -356,7 +356,7 @@ const seed = async () => {
   };
 
   const createSeedForSet = (
-    setSections: SetSection[],
+    setSections: SetSectionType[],
   ): Promise<NewSetSectionSong[]>[] =>
     setSections.map((setSection) => createSeedForSetSection(setSection));
 


### PR DESCRIPTION
## Background
This PR is to add the song search dialog skeleton (the content and features will come in future tickets/PRs). 
To enable this, the set details page had to be refactored to be a client component.
![SWY-47--after](https://github.com/user-attachments/assets/6e431872-e077-4c74-87b6-e74904905719)

## What's changed
[dependencies]
- added `cmdk`

[shared UI components]
- added command component
- added HStack component

[set details page]
- refactored to a client component in order to use query hooks (instead of direct DB queries)
- refactored to break up the markup into separate components
- adds song search dialog that can be triggered via "Add a song" button

[set module]
- added set section card (from set details page)
- added set empty state component
- added set loading state component
- added set error state component
- added song search dialog

[db]
- added `useSetQuery` hook to reuse set data
- added `set.get` TRPC route
- updated types for set sections and set sections with songs
- added schema for `set.get` query
- updated seed function to reflect updated types

## How to test
1. On the preview branch, go to an empty set (or create a new set)
2. Click the "Add a song" button. It should bring up the song search dialog.