### PR TITLE
[SWY-49] integrate search query to song search dialog

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -96,10 +96,12 @@ const config: Config = {
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
+    "^@components/(.*)$": "<rootDir>/components/$1",
+    "^@modules/(.*)$": "<rootDir>/modules/$1",
+    "^@lib/(.*)$": "<rootDir>/lib/$1",
+    "^@server/(.*)$": "<rootDir>/server/$1",
+    "^@app/(.*)$": "<rootDir>/app/$1",
     "^@/(.*)$": "<rootDir>/$1",
-    "^@/components/(.*)$": "<rootDir>/components/$1",
-    "^@/modules/(.*)$": "<rootDir>/modules/$1",
-    "^@/lib/(.*)$": "<rootDir>/lib/$1",
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -40,7 +40,7 @@ const CommandDialog: React.FC<CommandDialogProps> = ({
       <DialogContent
         className={cn(
           "overflow-hidden rounded-lg p-0 shadow-lg",
-          // fixedClassnames,
+          "max-w-3xl pb-3",
           {
             "translate-y-0": fixed,
             "w-[calc(100%_-_24px)]": fixed,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -5,7 +5,7 @@ import { type DialogProps } from "@radix-ui/react-dialog";
 import { Command as CommandPrimitive } from "cmdk";
 import { Search } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "@lib/utils";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 
 const Command = React.forwardRef<
@@ -23,11 +23,40 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+type CommandDialogProps = DialogProps & {
+  fixed?: boolean;
+  loop?: boolean;
+  shouldFilter?: boolean;
+};
+const CommandDialog: React.FC<CommandDialogProps> = ({
+  children,
+  fixed = false,
+  loop = true,
+  shouldFilter,
+  ...props
+}) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden rounded-lg p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+      <DialogContent
+        className={cn(
+          "overflow-hidden rounded-lg p-0 shadow-lg",
+          // fixedClassnames,
+          {
+            "translate-y-0": fixed,
+            "w-[calc(100%_-_24px)]": fixed,
+            "mt-3": fixed,
+            "top-0": fixed,
+            "md:mt-0": fixed,
+            "md:top-[12%]": fixed,
+            "lg:top-[25%]": fixed,
+          },
+        )}
+      >
+        <Command
+          loop={loop}
+          shouldFilter={shouldFilter}
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
           {children}
         </Command>
       </DialogContent>

--- a/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
+++ b/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   CommandDialog,
   CommandEmpty,
@@ -6,23 +8,114 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { api } from "@/trpc/react";
+import { useAuth } from "@clerk/nextjs";
+import { Text } from "@components/Text";
+import { useUserQuery } from "@modules/users/api/queries";
+import { CommandLoading } from "cmdk";
+import { redirect } from "next/navigation";
+import { useState } from "react";
+import { useDebounceValue } from "usehooks-ts";
 
 type SongSearchDialogProps = {
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
+const SEARCH_DEBOUNCE_DELAY = 350;
+
 export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
   open,
   setOpen,
 }) => {
+  const { userId, isLoaded } = useAuth();
+
+  const defaultSearchQuery = "";
+  const [searchInput, setSearchInput] = useState<string>(defaultSearchQuery);
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useDebounceValue(
+    searchInput,
+    SEARCH_DEBOUNCE_DELAY,
+  );
+
+  if (!userId) {
+    redirect("/");
+  }
+
+  const {
+    data: userData,
+    error: userQueryError,
+    isLoading: userQueryLoading,
+  } = useUserQuery({ userId });
+  const userMembership = userData?.memberships[0];
+
+  const {
+    data: songSearchData,
+    error: songSearchError,
+    isLoading: songSearchLoading,
+  } = api.song.search.useQuery(
+    {
+      organizationId: userMembership!.organizationId, // we use a type assertion here since if this isn't true, the query will be disabled
+      searchInput: debouncedSearchQuery,
+    },
+    {
+      enabled:
+        !!userMembership?.organizationId &&
+        !!debouncedSearchQuery &&
+        debouncedSearchQuery.length > 2,
+    },
+  );
+
+  if (!isLoaded) {
+    return <Text>Loading auth...</Text>;
+  }
+
+  if (userQueryLoading) {
+    return <Text>Getting user...</Text>;
+  }
+
+  if (!songSearchData || songSearchError) {
+    // TODO: handle the error
+  }
+
+  const handleSearchInputChange = (newValue: string) => {
+    setSearchInput(newValue);
+    setDebouncedSearchQuery(newValue);
+  };
+
   return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Search for a song or tag..." />
+    <CommandDialog
+      open={open}
+      onOpenChange={(open) => {
+        setSearchInput("");
+        setOpen(open);
+      }}
+      shouldFilter={false}
+      fixed
+    >
+      <CommandInput
+        placeholder="Search for a song..."
+        value={searchInput}
+        onValueChange={(newValue) => handleSearchInputChange(newValue)}
+      />
       <CommandList>
-        <CommandEmpty>No songs found.</CommandEmpty>
+        {songSearchLoading && (
+          <CommandLoading>Searching songs...</CommandLoading>
+        )}
+        {!songSearchLoading &&
+          debouncedSearchQuery &&
+          debouncedSearchQuery.length > 0 && (
+            <CommandEmpty>
+              No songs found for &quot;{debouncedSearchQuery}&quot;.
+            </CommandEmpty>
+          )}
         <CommandGroup heading="Songs">
-          <CommandItem>Test song</CommandItem>
+          {songSearchData?.map((searchResult) => {
+            return (
+              <CommandItem key={searchResult.id} value={searchResult.name}>
+                {searchResult.name}
+              </CommandItem>
+            );
+          })}
         </CommandGroup>
       </CommandList>
     </CommandDialog>

--- a/src/modules/users/api/queries.ts
+++ b/src/modules/users/api/queries.ts
@@ -1,0 +1,14 @@
+import { api } from "@/trpc/react";
+import { validate as uuidValidate } from "uuid";
+
+export const useUserQuery = (params: { userId: string }) => {
+  const { userId } = params;
+  return api.user.getUser.useQuery(
+    {
+      userId: userId,
+    },
+    {
+      enabled: !!userId && uuidValidate(userId),
+    },
+  );
+};

--- a/src/server/db/seed.ts
+++ b/src/server/db/seed.ts
@@ -129,6 +129,10 @@ const seedTags: NewTag[] = [
 const seed = async () => {
   console.log("🌱 Seeding database...");
 
+  /** enable the pg_trgm extension if needed */
+  await db.execute(sql`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+  console.log("🚀 ~ seed ~ enable trigram extension (if necessary)");
+
   /** seed the organization table */
   await db.execute(sql`TRUNCATE TABLE sanbi_organizations CASCADE`);
   const [organization] = await db

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,12 +26,12 @@
     /* Path Aliases */
     "baseUrl": "src",
     "paths": {
-      "@/*": ["./*"],
       "@components/*": ["components/*"],
       "@modules/*": ["modules/*"],
       "@lib/*": ["lib/*"],
       "@server/*": ["server/*"],
-      "@app/*": ["app/*"]
+      "@app/*": ["app/*"],
+      "@/*": ["./*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Background
This PR is to integrate the search query into the song search dialog. 
After this PR, a user should be able to use the song search dialog to find actual song results from the database.
<video src="https://github.com/user-attachments/assets/2bdf0e53-bcf0-4663-bd48-9f353ae05946" />

## What's changed
[UI components]
- added command component

[songs module]
- updated `SongSearchDialog` to integrate with the song search query

[users module]
- added `useUserQuery` hook

[`tsconfig`]
- updated path aliases

[jest config]
- updated path aliases (`moduleNameMapper`)

## How to test
- Go to [the preview deploy ](https://sanbi-git-swy-49-integrate-search-qu-f59020-justaddcls-projects.vercel.app/) and go to an empty set (or create a new set) and you should see the "Add a song" button
- Click the button to bring up the song search dialog. You should be able to type and start receiving real time search result from the database