### PR TITLE
[SWY-51/SWY-52] Style song search result item

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -55,7 +55,7 @@ const CommandDialog: React.FC<CommandDialogProps> = ({
         <Command
           loop={loop}
           shouldFilter={shouldFilter}
-          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-3 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-4 [&_[cmdk-item]_svg]:w-4"
         >
           {children}
         </Command>
@@ -144,7 +144,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-3 py-2 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className,
     )}
     {...props}

--- a/src/lib/types/db.ts
+++ b/src/lib/types/db.ts
@@ -31,6 +31,8 @@ export type EventType = typeof eventTypes.$inferSelect;
 export type NewSetSectionType = typeof setSectionTypes.$inferInsert;
 export type SetSectionTypeType = typeof setSectionTypes.$inferSelect;
 
+export type SetSectionSongsType = typeof setSectionSongs.$inferSelect;
+
 export type NewTag = typeof tags.$inferInsert;
 export type Tag = typeof tags.$inferSelect;
 
@@ -38,8 +40,10 @@ export type NewSong = typeof songs.$inferInsert;
 export type Song = typeof songs.$inferSelect;
 
 export type NewSongTag = typeof songTags.$inferInsert;
+export type SongTagType = typeof songTags.$inferSelect;
 
 export type NewSet = typeof sets.$inferInsert;
+export type SetType = typeof sets.$inferSelect;
 
 export type NewSetSection = typeof setSections.$inferInsert;
 export type SetSectionType = typeof setSections.$inferSelect;

--- a/src/modules/songs/components/SongListItem/SongListItem.tsx
+++ b/src/modules/songs/components/SongListItem/SongListItem.tsx
@@ -1,0 +1,79 @@
+import { type FC } from "react";
+import { Text } from "@components/Text";
+import {
+  type SongTagType,
+  type Song,
+  type SetSectionSongsType,
+  Tag,
+  SetType,
+} from "@lib/types";
+import { SongKey } from "@components/SongKey";
+import { ClockCounterClockwise } from "@phosphor-icons/react/dist/ssr";
+import {
+  differenceInCalendarDays,
+  differenceInCalendarMonths,
+  differenceInCalendarWeeks,
+  formatDistanceToNow,
+  intervalToDuration,
+  intlFormatDistance,
+} from "date-fns";
+import { Badge } from "@components/Badge";
+
+type SongListItemSongData = Pick<
+  Song,
+  "id" | "name" | "preferredKey" | "isArchived"
+>;
+
+type SongListItemProps = {
+  song: SongListItemSongData;
+  lastPlayed: Date | null;
+  tags?: Tag["tag"][];
+};
+
+export const SongListItem: FC<SongListItemProps> = ({
+  song,
+  lastPlayed,
+  tags,
+}) => {
+  const distanceFromLastPlayedInDays = differenceInCalendarDays(
+    new Date(),
+    lastPlayed ?? new Date(),
+  );
+
+  const distanceFromLastPlayedInWeeks = differenceInCalendarWeeks(
+    new Date(),
+    lastPlayed ?? new Date(),
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Text style="header-medium-semibold">{song.name}</Text>
+        <SongKey size="medium" songKey={song.preferredKey} />
+      </div>
+      <div className="flex gap-3">
+        {lastPlayed ? (
+          <div className="flex items-center gap-1">
+            <ClockCounterClockwise className="text-slate-400" size="8px" />
+            <Text style="body-small" className="text-slate-500">
+              {distanceFromLastPlayedInWeeks > 0
+                ? `${distanceFromLastPlayedInWeeks}w`
+                : `${distanceFromLastPlayedInDays}d`}
+            </Text>
+          </div>
+        ) : (
+          <Text style="body-small" className="text-slate-500">
+            Never played
+          </Text>
+        )}
+        {tags && tags.length > 0 && (
+          <div className="flex gap-2">
+            {tags.map((tag) => (
+              <Badge key={tag} label={tag} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/modules/songs/components/SongListItem/index.ts
+++ b/src/modules/songs/components/SongListItem/index.ts
@@ -1,0 +1,1 @@
+export * from "./SongListItem";

--- a/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
+++ b/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
@@ -16,6 +16,8 @@ import { CommandLoading } from "cmdk";
 import { redirect } from "next/navigation";
 import { useState } from "react";
 import { useDebounceValue } from "usehooks-ts";
+import { SongListItem } from "../SongListItem";
+import { CaretRight } from "@phosphor-icons/react/dist/ssr";
 
 type SongSearchDialogProps = {
   open: boolean;
@@ -109,13 +111,25 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
             </CommandEmpty>
           )}
         <CommandGroup heading="Songs">
-          {songSearchData?.map((searchResult) => {
-            return (
-              <CommandItem key={searchResult.id} value={searchResult.name}>
-                {searchResult.name}
-              </CommandItem>
-            );
-          })}
+          <div className="flex flex-col gap-2">
+            {songSearchData?.map((searchResult) => {
+              const { lastPlayedDate, tags, ...songData } = searchResult;
+              return (
+                <CommandItem
+                  key={searchResult.songId}
+                  value={searchResult.name}
+                  className="flex items-center justify-between"
+                >
+                  <SongListItem
+                    song={{ id: songData.songId, ...songData }}
+                    lastPlayed={lastPlayedDate}
+                    tags={tags}
+                  />
+                  <CaretRight size="12px" className="text-slate-500" />
+                </CommandItem>
+              );
+            })}
+          </div>
         </CommandGroup>
       </CommandList>
     </CommandDialog>

--- a/src/server/api/routers/song.ts
+++ b/src/server/api/routers/song.ts
@@ -172,7 +172,10 @@ export const songRouter = createTRPCRouter({
         .where(
           sql`similarity(${songs.name}, ${input.searchInput}) > ${TRIGRAM_SIMILARITY_THRESHOLD}`,
         )
-        .groupBy(songs.id);
+        .groupBy(songs.id)
+        .orderBy(
+          desc(sql<number>`similarity(${songs.name}, ${input.searchInput})`),
+        );
 
       console.log(
         `🤖 - [song/search] - result for ${input.searchInput}:`,

--- a/src/server/api/routers/song.ts
+++ b/src/server/api/routers/song.ts
@@ -6,14 +6,24 @@ import {
   searchSongSchema,
   unarchiveSongSchema,
 } from "@lib/types/zod";
-import { songs } from "@server/db/schema";
+import {
+  eventTypes,
+  sets,
+  setSections,
+  setSectionSongs,
+  setSectionTypes,
+  songs,
+  songTags,
+  songTags as songTagsTable,
+  tags,
+} from "@server/db/schema";
 import {
   adminProcedure,
   createTRPCRouter,
   organizationProcedure,
 } from "@server/api/trpc";
 import { TRPCError } from "@trpc/server";
-import { eq, sql, or, getTableColumns } from "drizzle-orm";
+import { eq, sql, or, getTableColumns, desc, asc } from "drizzle-orm";
 
 const TRIGRAM_SIMILARITY_THRESHOLD = 0.1;
 
@@ -53,6 +63,7 @@ export const songRouter = createTRPCRouter({
 
       return ctx.db.insert(songs).values(newSong).returning();
     }),
+
   archive: adminProcedure
     .input(archiveSongSchema)
     .mutation(async ({ ctx, input }) => {
@@ -136,13 +147,32 @@ export const songRouter = createTRPCRouter({
        */
       const searchResults = await ctx.db
         .select({
-          ...getTableColumns(songs),
+          songId: songs.id,
+          name: songs.name,
+          preferredKey: songs.preferredKey,
+          isArchived: songs.isArchived,
           similarityScore: sql<number>`similarity(${songs.name}, ${input.searchInput})`,
+          tags: sql<
+            string[]
+          >`array_agg(DISTINCT ${tags.tag} ORDER BY ${tags.tag})`,
+          lastPlayedDate: sql<Date | null>`
+            MAX(
+              CASE WHEN ${sets.date} <= NOW()
+              THEN ${sets.date}
+              END
+            )
+          `,
         })
         .from(songs)
+        .leftJoin(setSectionSongs, eq(setSectionSongs.songId, songs.id))
+        .leftJoin(setSections, eq(setSections.id, setSectionSongs.setSectionId))
+        .leftJoin(sets, eq(sets.id, setSections.setId))
+        .leftJoin(songTags, eq(songTags.songId, songs.id))
+        .leftJoin(tags, eq(tags.id, songTags.tagId))
         .where(
           sql`similarity(${songs.name}, ${input.searchInput}) > ${TRIGRAM_SIMILARITY_THRESHOLD}`,
-        );
+        )
+        .groupBy(songs.id);
 
       console.log(
         `🤖 - [song/search] - result for ${input.searchInput}:`,


### PR DESCRIPTION
## Background
This PR is to style the song search result and adds tweaks to the song search route query to include all the data required.

| Before | After |
| ------ | ----- |
| ![SWY-52__before--song-search-dialog-results](https://github.com/user-attachments/assets/51e6b480-fe66-4afd-8bb4-b0bca73d577a) | ![SWY-52__after--song-search-dialog-results](https://github.com/user-attachments/assets/906fe9c2-c9ac-47a2-a108-ef2d594b5e32) |
| ![SWY-52__before--song-search-query](https://github.com/user-attachments/assets/5d44c4cd-87c5-435a-90d1-38d5e0ad7b15) | ![SWY-52__after--song-search-query](https://github.com/user-attachments/assets/98e53b45-791c-46d8-968b-f6b17f6fe39f) |

## What's changed
[UI components]
- updated the `command` component's styling to better match the design of the song search dialog

[db]
- added type for `set_section_song` table selects
- added type for `song_tag` table selects
- added type for `set` table selects

[song module]
- added `SongListItem` component
- updated `SongSearchDialog` to use `SongListItems` to display search results

[TRPC router]
- updated `song/search` route's query to include tags and latest played date

## How to test
On the [Visit Preview](https://sanbi-git-swy-51-create-song-search-e23b87-justaddcls-projects.vercel.app/), go to an empty set, click the "Add a song" button, and enter in a search query that has results. You should see the new styling powered by the updated query!