### PR TITLE
[SWY-61] Add notes field to set creation dialog

### DIFF
--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -30,7 +30,7 @@ export default async function Dashboard({
     notFound();
   }
 
-  // FIXME: move query to db/queries
+  // FIXME: move query to api set router
   const organizationSets = await db.query.sets.findMany({
     where: eq(sets.organizationId, params.organization),
     with: {

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -19,6 +19,8 @@ import { type SetSectionWithSongs } from "@lib/types";
 import { useSetQuery } from "@modules/sets/api";
 import { SetPageLoadingState } from "@modules/sets/components/SetLoadingState";
 import { SetPageErrorState } from "@modules/sets/components/SetErrorState";
+import { HStack } from "@components/HStack";
+import { VStack } from "@components/VStack";
 
 type SetListPageProps = { params: { organization: string; setId: string } };
 
@@ -93,7 +95,7 @@ export default function SetListPage({ params }: SetListPageProps) {
     ) ?? 0;
 
   return (
-    <div className="flex h-full min-w-full max-w-xs flex-1 flex-col gap-6">
+    <VStack className="flex h-full min-w-full max-w-xs flex-1 flex-col gap-6">
       {!isPageLoading && !queryError && (
         <>
           <PageTitle
@@ -102,22 +104,32 @@ export default function SetListPage({ params }: SetListPageProps) {
             details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
           />
           {setData.isArchived && (
-            <div className="flex items-center gap-1 uppercase text-slate-500">
+            <HStack className="flex items-center gap-1 uppercase text-slate-500">
               <Archive />
               <Text>Set is archived</Text>
-            </div>
+            </HStack>
           )}
-          <section className="flex gap-2">
-            <Button variant="outline" size="sm">
-              <Note />
-              Add set notes
-            </Button>
-            <SetActionsMenu
-              setId={params.setId}
-              organizationId={userMembership.organizationId}
-              archived={setData.isArchived ?? false}
-            />
-          </section>
+          <VStack className="gap-6">
+            {setData.notes && (
+              <VStack className="gap-2">
+                <Text style="header-small-semibold" className="text-slate-500">
+                  Set notes
+                </Text>
+                <Text>{setData.notes}</Text>
+              </VStack>
+            )}
+            <HStack className="flex gap-2">
+              <Button variant="outline" size="sm">
+                <Note />
+                {setData.notes ? "Edit notes" : "Add set notes"}
+              </Button>
+              <SetActionsMenu
+                setId={params.setId}
+                organizationId={userMembership.organizationId}
+                archived={setData.isArchived ?? false}
+              />
+            </HStack>
+          </VStack>
           {(!setData?.sections || setData.sections.length === 0) && (
             <SetEmptyState
               onActionClick={() => {
@@ -163,6 +175,6 @@ export default function SetListPage({ params }: SetListPageProps) {
           />
         </>
       )}
-    </div>
+    </VStack>
   );
 }

--- a/src/components/HStack/HSTack.tsx
+++ b/src/components/HStack/HSTack.tsx
@@ -1,10 +1,16 @@
 import { cn } from "@/lib/utils";
-import { type DetailedHTMLProps, type HTMLAttributes, type FC } from "react";
-type HStackProps = DetailedHTMLProps<
-  HTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
->;
+import { type PolymorphicComponentProps } from "@lib/types";
 
-export const HStack: FC<HStackProps> = ({ className, ...props }) => {
-  return <div className={cn(`flex flex-row`, className)} {...props}></div>;
+export const HStack = <HTMLElement extends React.ElementType = "div">({
+  as,
+  children,
+  className,
+  ...props
+}: PolymorphicComponentProps<HTMLElement>) => {
+  const HTMLElement = as ?? "div";
+  return (
+    <HTMLElement className={cn(`flex flex-row`, className)} {...props}>
+      {children}
+    </HTMLElement>
+  );
 };

--- a/src/components/VStack/VStack.tsx
+++ b/src/components/VStack/VStack.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+import { type PolymorphicComponentProps } from "@lib/types";
+
+export const VStack = <HTMLElement extends React.ElementType = "div">({
+  as,
+  children,
+  className,
+  ...props
+}: PolymorphicComponentProps<HTMLElement>) => {
+  const HTMLElement = as ?? "div";
+  return (
+    <HTMLElement className={cn(`flex flex-col`, className)} {...props}>
+      {children}
+    </HTMLElement>
+  );
+};

--- a/src/components/VStack/index.ts
+++ b/src/components/VStack/index.ts
@@ -1,0 +1,1 @@
+export * from "./VStack";

--- a/src/lib/types/utils.ts
+++ b/src/lib/types/utils.ts
@@ -1,3 +1,13 @@
+import type React from "react";
+
 export type None<Type> = {
   [Property in keyof Type]?: never;
 };
+
+export type PolymorphicComponentProps<
+  HTMLElement extends React.ElementType,
+  Props = object,
+> = Props & {
+  as?: HTMLElement;
+  children?: React.ReactNode;
+} & Omit<React.ComponentPropsWithoutRef<HTMLElement>, keyof Props>;

--- a/src/modules/SetListCard/components/CardList/CardList.tsx
+++ b/src/modules/SetListCard/components/CardList/CardList.tsx
@@ -1,3 +1,5 @@
+import { VStack } from "@components/VStack";
+
 export type CardListProps = {
   /** spacing between cards - uses TailwindCSS values - https://tailwindcss.com/docs/gap  */
   gap?: string;
@@ -7,5 +9,5 @@ export const CardList: React.FC<React.PropsWithChildren<CardListProps>> = ({
   gap = "gap-4",
   children,
 }) => {
-  return <div className={`flex flex-col ${gap}`}>{children}</div>;
+  return <VStack className={`flex flex-col ${gap}`}>{children}</VStack>;
 };

--- a/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
+++ b/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
@@ -79,7 +79,6 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
 
   const handleCreateSetSubmit = async (formValues: CreateSetFormFields) => {
     const { date, eventTypeId, notes } = formValues;
-    console.log("🚀 ~ handleCreateSetSubmit ~ formValues:", formValues);
 
     if (!isError && userData) {
       const organizationMembership = userData.memberships[0];

--- a/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
+++ b/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
@@ -10,14 +10,6 @@ import {
 import { Text } from "@components/Text";
 import { Button } from "@components/ui/button";
 import { DatePicker, type DatePickerPreset } from "@components/ui/datePicker";
-import { Switch } from "@components/ui/switch";
-import { Label } from "@components/ui/label";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@components/ui/accordion";
 import { useForm } from "react-hook-form";
 import { insertSetSchema } from "@lib/types/zod";
 import { type z } from "zod";
@@ -34,12 +26,19 @@ import { useAuth } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { skipToken } from "@tanstack/react-query";
+import { Textarea } from "@components/ui/textarea";
 
 const createSetFormSchema = insertSetSchema.pick({
   date: true,
   eventTypeId: true,
+  notes: true,
 });
-export type CreateSetFormFields = z.infer<typeof createSetFormSchema>;
+export type CreateSetFormFields = Omit<
+  z.infer<typeof createSetFormSchema>,
+  "notes"
+> & {
+  notes: NonNullable<z.infer<typeof createSetFormSchema>["notes"]>;
+};
 
 type CreateSetFormProps = {
   onSubmit: () => void;
@@ -54,6 +53,7 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
     defaultValues: {
       date: undefined,
       eventTypeId: undefined,
+      notes: "",
     },
     mode: "onChange",
   });
@@ -78,7 +78,8 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
   );
 
   const handleCreateSetSubmit = async (formValues: CreateSetFormFields) => {
-    const { date, eventTypeId } = formValues;
+    const { date, eventTypeId, notes } = formValues;
+    console.log("🚀 ~ handleCreateSetSubmit ~ formValues:", formValues);
 
     if (!isError && userData) {
       const organizationMembership = userData.memberships[0];
@@ -91,6 +92,7 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
         {
           date,
           eventTypeId,
+          notes: notes || null,
           organizationId: organizationMembership.organizationId,
           isArchived: false,
         },
@@ -183,7 +185,24 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
             </FormItem>
           )}
         />
-        <div className="flex flex-col gap-2">
+        <FormField
+          control={createSetForm.control}
+          name="notes"
+          render={({ field }) => (
+            <FormItem className="">
+              <FormLabel
+              // className={cn("font-normal text-slate-900", textSize)}
+              >
+                Song notes
+              </FormLabel>
+              <FormControl>
+                <Textarea {...field} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        {/* TODO: this was for proof of concept, but we should figure out if we want to implement it */}
+        {/* <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between">
             <Label htmlFor="start-with-last-set-toggle">
               Start with last week&apos;s set
@@ -198,7 +217,7 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
               <AccordionContent>Last set&apos;s songs here</AccordionContent>
             </AccordionItem>
           </Accordion>
-        </div>
+        </div> */}
         <Button
           className="w-full"
           type="submit"

--- a/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
+++ b/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
@@ -189,11 +189,7 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
           name="notes"
           render={({ field }) => (
             <FormItem className="">
-              <FormLabel
-              // className={cn("font-normal text-slate-900", textSize)}
-              >
-                Song notes
-              </FormLabel>
+              <FormLabel>Set notes</FormLabel>
               <FormControl>
                 <Textarea {...field} />
               </FormControl>


### PR DESCRIPTION
## Background
This PR is to allow a user to add notes to a set at the time of creation via the create new set dialog.
This PR also updates the set details page to render the set's notes (if there are any) and then render the appropriate copy to the "add/edit notes" button.

| Before | After |
| ------- | -----|
| ![SWY-61__before--new-set-dialog](https://github.com/user-attachments/assets/97c9b327-c5bf-493e-a685-acaa664cc933) | ![SWY-61__after--new-set-dialog](https://github.com/user-attachments/assets/daa70b62-af53-4781-868d-4ea57daa7ce6) |
| ![SWY-61__before--set-with-notes](https://github.com/user-attachments/assets/368846b0-a706-4004-b636-fb4e0c574b81) | ![SWY-61__after--set-with-notes](https://github.com/user-attachments/assets/3efc503e-f879-4da4-b2b8-b9958d131ca2) |
| ![SWY-61__before--set-without-notes](https://github.com/user-attachments/assets/3a7c7ba1-8064-48e3-947b-b8518c080761) | ![SWY-61__after--set-without-notes](https://github.com/user-attachments/assets/97de5bc7-4b91-42ca-90b8-5815a31a0c6e) |

## What's changed
### Shared components
- added `VStack` component
- updated `HStack` component to be polymorphic

### lib
- added `PolymorphicComponentProps` type

### Sets module
- updated `CreateSetForm` to include the notes field and updated the submit handler to include the notes field to the create mutation

### Set details page
- added set notes
- updated "add/edit notes" button copy to consider if there are any set notes
- updated markup structure to be easier to understand

### SetListCard module
- updated `CardList` component to use `VStack`


## How to test
### Create set form
1. On any page where the sidebar is visible, click the "New" button and you should now see the "Set notes"
2. If you add notes in the text area and click "Create set", when you are redirected to the new set's page, you should see the "Set notes" heading along with the notes you added. Also, the button under the notes should now say "Edit notes"
3. If you do not add any notes and then click "Create set" (or are viewing a set with no notes), you should see no change