### PR TITLE
[SWY-62] Fix song notes label copy

### DIFF
--- a/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
+++ b/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
@@ -168,7 +168,7 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
           name="notes"
           render={({ field }) => (
             <FormItem className="flex flex-col gap-2">
-              <FormLabel>Song name</FormLabel>
+              <FormLabel>Song notes</FormLabel>
               <FormControl>
                 <Textarea placeholder="Add notes about the song" {...field} />
               </FormControl>

--- a/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
+++ b/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
@@ -29,14 +29,13 @@ import { formatSongKey } from "@/lib/string/formatSongKey";
 const createSongFormSchema = insertSongSchema
   .pick({
     name: true,
-    preferredKey: true,
   })
   .extend({
     /**
      * by default, zod thinks preferred key and notes are nullable which causes type issues.
      * these fields have been manually re-defined to omit the nullable
      */
-    preferredKey: z.enum(songKeys).optional(), // TODO: confirm if this should be optional
+    preferredKey: z.enum(songKeys),
     notes: z.string().optional(),
   });
 
@@ -72,7 +71,6 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
     });
 
   const handleCreateSongSubmit = async (formValues: CreateSongFormFields) => {
-    console.log("🚀 ~ handleCreateSongSubmit ~ formValues:", formValues);
     const { name, preferredKey, notes } = formValues;
 
     // attempt to create song

--- a/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
+++ b/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
@@ -170,7 +170,7 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
             <FormItem className="flex flex-col gap-2">
               <FormLabel>Song notes</FormLabel>
               <FormControl>
-                <Textarea placeholder="Add notes about the song" {...field} />
+                <Textarea {...field} />
               </FormControl>
             </FormItem>
           )}

--- a/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
+++ b/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
@@ -142,7 +142,7 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
           name="preferredKey"
           render={({ field }) => (
             <FormItem className="flex flex-col gap-2">
-              <FormLabel>Song name</FormLabel>
+              <FormLabel>Preferred key *</FormLabel>
               <FormControl>
                 <Select
                   onValueChange={field.onChange}


### PR DESCRIPTION
## Background
This PR is to tidy up the create new song dialog since all the fields have the "Song name" label 🤦🏻‍♂️  This PR fixes so the fields all have the right level and this also removes the placeholder for the Song notes texture.

| Before | After |
| ------ | ----- |
| ![SWY-62__before](https://github.com/user-attachments/assets/e424d54e-047b-4f51-a167-6498a61ca569) | ![SWY-62__after](https://github.com/user-attachments/assets/3be1b7a6-62aa-43e4-8e32-851f576222ef) |

## What's changed
### Sets module
- Updated `CreateSongForm`'s field labels and placeholder text as described above

@coderabbitai summary
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- **Bug Fixes**
  - Corrected form field labels to accurately describe their purpose.
  - Ensured the `preferredKey` field is now required in the song creation form.

- **Style**
  - Improved form clarity and user experience through precise labeling.
  - Removed unnecessary placeholder text in the notes textarea.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
Click the `New` button in the sidebar and switch the dialog to `New song`. Compare the dialog field labels and ensure they say (respectively):
- Song name
- Preferred key
- Song notes
The song notes field also should no longer have any placeholder text.