### PR TITLE
[SWY-69] Add set section song action menu

### DIFF
--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -107,6 +107,7 @@ export default async function Dashboard({
                             {...(setSectionSong.notes && {
                               notes: setSectionSong.notes,
                             })}
+                            withActionsMenu={false}
                           />
                         </Link>
                       );

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -28,9 +28,11 @@ export const SongActionMenu: React.FC = () => {
         <SongActionMenuItem icon="Pencil">Edit song</SongActionMenuItem>
         <SongActionMenuItem icon="Swap">Replace song</SongActionMenuItem>
         <DropdownMenuSeparator />
-        <SongActionMenuItem icon="ArrowUp">Move up</SongActionMenuItem>
+        <SongActionMenuItem icon="ArrowUp" disabled>
+          Move up
+        </SongActionMenuItem>
         <SongActionMenuItem icon="ArrowDown">Move down</SongActionMenuItem>
-        <SongActionMenuItem icon="ArrowLineUp">
+        <SongActionMenuItem icon="ArrowLineUp" disabled>
           Move to previous section
         </SongActionMenuItem>
         <SongActionMenuItem icon="ArrowLineDown">

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -25,7 +25,7 @@ export const SongActionMenu: React.FC = () => {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <SongActionMenuItem icon="Pencil" label="Edit song" />
+        <SongActionMenuItem icon="PianoKeys" label="Change key" />
         <SongActionMenuItem icon="Swap" label="Replace song" />
         <DropdownMenuSeparator />
         <SongActionMenuItem icon="ArrowUp" label="Move up" />

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Button } from "@components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@components/ui/dropdown-menu";
+import { useState } from "react";
+import { DotsThree } from "@phosphor-icons/react";
+import { SongActionMenuItem } from "@modules/SetListCard/components/SongActionMenuItem";
+
+export const SongActionMenu: React.FC = () => {
+  const [isSongActionMenuOpen, setIsSongActionMenuOpen] =
+    useState<boolean>(false);
+  return (
+    <DropdownMenu
+      open={isSongActionMenuOpen}
+      onOpenChange={setIsSongActionMenuOpen}
+    >
+      <DropdownMenuTrigger>
+        <Button variant="ghost" size="sm">
+          <DotsThree className="text-slate-900" size={16} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <SongActionMenuItem icon="Pencil">Edit song</SongActionMenuItem>
+        <SongActionMenuItem icon="Swap">Replace song</SongActionMenuItem>
+        <DropdownMenuSeparator />
+        <SongActionMenuItem icon="ArrowUp">Move up</SongActionMenuItem>
+        <SongActionMenuItem icon="ArrowDown">Move down</SongActionMenuItem>
+        <SongActionMenuItem icon="ArrowLineUp">
+          Move to previous section
+        </SongActionMenuItem>
+        <SongActionMenuItem icon="ArrowLineDown">
+          Move to next section
+        </SongActionMenuItem>
+        <DropdownMenuSeparator />
+        <SongActionMenuItem icon="Trash" destructive>
+          Remove from section
+        </SongActionMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -25,23 +25,22 @@ export const SongActionMenu: React.FC = () => {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <SongActionMenuItem icon="Pencil">Edit song</SongActionMenuItem>
-        <SongActionMenuItem icon="Swap">Replace song</SongActionMenuItem>
+        <SongActionMenuItem icon="Pencil" label="Edit song" />
+        <SongActionMenuItem icon="Swap" label="Replace song" />
         <DropdownMenuSeparator />
-        <SongActionMenuItem icon="ArrowUp" disabled>
-          Move up
-        </SongActionMenuItem>
-        <SongActionMenuItem icon="ArrowDown">Move down</SongActionMenuItem>
-        <SongActionMenuItem icon="ArrowLineUp" disabled>
-          Move to previous section
-        </SongActionMenuItem>
-        <SongActionMenuItem icon="ArrowLineDown">
-          Move to next section
-        </SongActionMenuItem>
+        <SongActionMenuItem icon="ArrowUp" label="Move up" />
+        <SongActionMenuItem icon="ArrowDown" label="Move down" />
+        <SongActionMenuItem
+          icon="ArrowLineUp"
+          label="Move to previous section"
+        />
+        <SongActionMenuItem icon="ArrowLineDown" label="Move to next section" />
         <DropdownMenuSeparator />
-        <SongActionMenuItem icon="Trash" destructive>
-          Remove from section
-        </SongActionMenuItem>
+        <SongActionMenuItem
+          icon="Trash"
+          label="Remove from section"
+          destructive
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/modules/SetListCard/components/SongActionMenu/index.ts
+++ b/src/modules/SetListCard/components/SongActionMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./SongActionMenu";

--- a/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
+++ b/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
@@ -26,22 +26,35 @@ const iconMap = {
 type SongActionMenuItemProps = React.PropsWithChildren<{
   icon: keyof typeof iconMap;
   destructive?: boolean;
+  disabled?: boolean;
 }>;
 
 export const SongActionMenuItem: React.FC<SongActionMenuItemProps> = ({
   icon,
   destructive = false,
+  disabled = false,
   children,
 }) => {
   const Icon = iconMap[icon];
 
   return (
-    <DropdownMenuItem asChild>
+    <DropdownMenuItem asChild disabled={disabled}>
       <HStack className="gap-2">
         <Icon
-          className={cn("text-slate-500", [destructive && "text-slate-300"])}
+          size={16}
+          className={cn(
+            "text-slate-500",
+            [destructive && "text-red-500"],
+            [disabled && "text-slate-400"],
+          )}
         />
-        <Text className={cn("text-sm", [destructive && "text-slate-400"])}>
+        <Text
+          className={cn(
+            "text-sm",
+            [destructive && "text-red-500"],
+            [disabled && "text-slate-400"],
+          )}
+        >
           {children}
         </Text>
       </HStack>

--- a/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
+++ b/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
@@ -39,7 +39,7 @@ export const SongActionMenuItem: React.FC<SongActionMenuItemProps> = ({
 
   return (
     <DropdownMenuItem asChild disabled={disabled}>
-      <HStack className="gap-2">
+      <HStack className="gap-2" aria-label={`${children} action`}>
         <Icon
           size={16}
           className={cn(

--- a/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
+++ b/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
@@ -23,23 +23,24 @@ const iconMap = {
   Trash,
 } as const;
 
-type SongActionMenuItemProps = React.PropsWithChildren<{
+type SongActionMenuItemProps = {
+  label: string;
   icon: keyof typeof iconMap;
   destructive?: boolean;
   disabled?: boolean;
-}>;
+};
 
 export const SongActionMenuItem: React.FC<SongActionMenuItemProps> = ({
+  label,
   icon,
   destructive = false,
   disabled = false,
-  children,
 }) => {
   const Icon = iconMap[icon];
 
   return (
     <DropdownMenuItem asChild disabled={disabled}>
-      <HStack className="gap-2" aria-label={`${children} action`}>
+      <HStack className="gap-2" aria-label={`${label} action`}>
         <Icon
           size={16}
           className={cn(
@@ -55,7 +56,7 @@ export const SongActionMenuItem: React.FC<SongActionMenuItemProps> = ({
             [disabled && "text-slate-400"],
           )}
         >
-          {children}
+          {label}
         </Text>
       </HStack>
     </DropdownMenuItem>

--- a/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
+++ b/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
@@ -1,0 +1,50 @@
+import { HStack } from "@components/HStack";
+import { Text } from "@components/Text";
+import React from "react";
+import {
+  ArrowDown,
+  ArrowLineDown,
+  ArrowLineUp,
+  ArrowUp,
+  Pencil,
+  Swap,
+  Trash,
+} from "@phosphor-icons/react/dist/ssr";
+import { DropdownMenuItem } from "@components/ui/dropdown-menu";
+import { cn } from "@lib/utils";
+
+const iconMap = {
+  ArrowDown,
+  ArrowLineDown,
+  ArrowLineUp,
+  ArrowUp,
+  Pencil,
+  Swap,
+  Trash,
+} as const;
+
+type SongActionMenuItemProps = React.PropsWithChildren<{
+  icon: keyof typeof iconMap;
+  destructive?: boolean;
+}>;
+
+export const SongActionMenuItem: React.FC<SongActionMenuItemProps> = ({
+  icon,
+  destructive = false,
+  children,
+}) => {
+  const Icon = iconMap[icon];
+
+  return (
+    <DropdownMenuItem asChild>
+      <HStack className="gap-2">
+        <Icon
+          className={cn("text-slate-500", [destructive && "text-slate-300"])}
+        />
+        <Text className={cn("text-sm", [destructive && "text-slate-400"])}>
+          {children}
+        </Text>
+      </HStack>
+    </DropdownMenuItem>
+  );
+};

--- a/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
+++ b/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
@@ -9,6 +9,7 @@ import {
   Pencil,
   Swap,
   Trash,
+  PianoKeys,
 } from "@phosphor-icons/react/dist/ssr";
 import { DropdownMenuItem } from "@components/ui/dropdown-menu";
 import { cn } from "@lib/utils";
@@ -21,6 +22,7 @@ const iconMap = {
   Pencil,
   Swap,
   Trash,
+  PianoKeys,
 } as const;
 
 type SongActionMenuItemProps = {

--- a/src/modules/SetListCard/components/SongActionMenuItem/index.ts
+++ b/src/modules/SetListCard/components/SongActionMenuItem/index.ts
@@ -1,0 +1,1 @@
+export * from "./SongActionMenuItem";

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -2,6 +2,7 @@ import { HStack } from "@components/HStack";
 import { SongKey, type SongKeyProps } from "@components/SongKey";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
+import { SongActionMenu } from "../SongActionMenu/SongActionMenu";
 
 export type SongItemProps = {
   /** index of song in the set list */
@@ -15,6 +16,9 @@ export type SongItemProps = {
 
   /** song notes */
   notes?: string | null;
+
+  /** should the song item show the action menu? */
+  withActionsMenu?: boolean;
 };
 
 export const SongItem: React.FC<SongItemProps> = ({
@@ -22,29 +26,33 @@ export const SongItem: React.FC<SongItemProps> = ({
   songKey,
   name,
   notes,
+  withActionsMenu = true,
 }) => {
   return (
-    <HStack className="flex items-baseline gap-3 rounded-lg px-6 py-3 text-xs font-semibold shadow lg:py-4">
-      <Text
-        style="header-medium-semibold"
-        align="right"
-        className="text-slate-400"
-      >
-        {index}.
-      </Text>
-      <VStack className="flex flex-col gap-2">
-        <HStack className="flex items-baseline gap-2">
-          <SongKey songKey={songKey} />
-          <Text fontWeight="semibold" className="text-sm">
-            {name}
-          </Text>
-        </HStack>
-        {notes ? (
-          <Text style="small" color="slate-700">
-            {notes}
-          </Text>
-        ) : null}
-      </VStack>
+    <HStack className="items-center justify-between rounded-lg px-6 py-3 shadow lg:py-4">
+      <HStack className="items-baseline gap-3 text-xs font-semibold">
+        <Text
+          style="header-medium-semibold"
+          align="right"
+          className="text-slate-400"
+        >
+          {index}.
+        </Text>
+        <VStack className="flex flex-col gap-2">
+          <HStack className="flex items-baseline gap-2">
+            <SongKey songKey={songKey} />
+            <Text fontWeight="semibold" className="text-sm">
+              {name}
+            </Text>
+          </HStack>
+          {notes ? (
+            <Text style="small" color="slate-700">
+              {notes}
+            </Text>
+          ) : null}
+        </VStack>
+      </HStack>
+      {withActionsMenu && <SongActionMenu />}
     </HStack>
   );
 };

--- a/src/modules/SetListCard/components/index.ts
+++ b/src/modules/SetListCard/components/index.ts
@@ -4,3 +4,5 @@ export * from "./SetListCardHeader";
 export * from "./SetListCard";
 export * from "./ResourceCard";
 export * from "./PlayHistoryItem";
+export * from "./SongActionMenu";
+export * from "./SongActionMenuItem";


### PR DESCRIPTION
## Background
This PR is to add the UI portion of the song action menu. The functionality of those menu actions will come in future PRs.

| Before | After |
| ------ | ----- |
| ![SWY-69__before](https://github.com/user-attachments/assets/514f0d5a-ff0d-4319-8d07-e296394591ee) | ![SWY-69__after--set-section-card](https://github.com/user-attachments/assets/2f55021e-4f47-4499-9157-bf2562e68fa9) |
| | ![SWY-69__after--song-actions-menu](https://github.com/user-attachments/assets/ec88a7fd-0caa-4b79-b684-9eb84198fa47) |

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an interactive actions menu for managing songs, offering quick options like edit, replace, reorder, and remove.
	- Added the ability to conditionally render the actions menu in the song item component.
- **Refactor**
	- Enhanced the layout and styling of song items for a cleaner, more intuitive dashboard experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
The song action menu should only be added to the song items on the set details page and not on the dashboard page.
Go into a set and verify you can see the action menu on the song items. Click the button (...) to see the action menu.