### PR TITLE
[SWY-76] Add delete set section song action

### DIFF
--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -103,6 +103,7 @@ export default async function Dashboard({
                           <SongItem
                             index={indexStart + setSectionSong.position}
                             setSectionSong={setSectionSong}
+                            setSectionType={section.type.name}
                             setId={orgSet.id}
                             withActionsMenu={false}
                           />

--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -102,11 +102,8 @@ export default async function Dashboard({
                         >
                           <SongItem
                             index={indexStart + setSectionSong.position}
-                            songKey={setSectionSong.key}
-                            name={setSectionSong.song.name}
-                            {...(setSectionSong.notes && {
-                              notes: setSectionSong.notes,
-                            })}
+                            setSectionSong={setSectionSong}
+                            setId={orgSet.id}
                             withActionsMenu={false}
                           />
                         </Link>

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -84,4 +84,8 @@ export const getSectionsForSet = z.object({ setId: z.string().uuid() });
 /**
  * Set section songs schemas
  */
+const setSectionSongIdSchema = z.object({
+  setSectionSongId: z.string().uuid(),
+});
 export const insertSetSectionSongSchema = createInsertSchema(setSectionSongs);
+export const deleteSetSectionSongSchema = setSectionSongIdSchema;

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -55,16 +55,17 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
 
   const deleteSetSectionSongMutation = api.setSectionSong.delete.useMutation();
   const removeSong = (organizationId: string, setSectionSongId: string) => {
-    console.log("🤖 - SongActionMenu ~ removeSong");
-
+    toast.loading("Removing song...");
     deleteSetSectionSongMutation.mutate(
       { organizationId, setSectionSongId },
       {
         async onSuccess() {
+          toast.dismiss();
           toast.success("Song removed");
           await apiUtils.set.get.invalidate({ setId });
         },
         onError(error) {
+          toast.dismiss();
           toast.error(`Song could not be removed: ${error.message}`);
         },
       },

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -13,21 +13,36 @@ import { SongActionMenuItem } from "@modules/SetListCard/components/SongActionMe
 import { api } from "@/trpc/react";
 import { toast } from "sonner";
 import { useUserQuery } from "@modules/users/api/queries";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@components/ui/alert-dialog";
+import { type SetSectionSongWithSongData } from "@lib/types";
 
 type SongActionMenuProps = {
-  /** ID of the specific set section song these actions related to */
-  setSectionSongId: string;
+  /** set section song object */
+  setSectionSong: SetSectionSongWithSongData;
+
+  /** the type of set section this song is attached to */
+  setSectionType: string;
 
   /** the ID of the set the set section song is attached to */
   setId: string;
 };
 
 export const SongActionMenu: React.FC<SongActionMenuProps> = ({
-  setSectionSongId,
+  setSectionSong,
+  setSectionType,
   setId,
 }) => {
   const apiUtils = api.useUtils();
   const [isSongActionMenuOpen, setIsSongActionMenuOpen] =
+    useState<boolean>(false);
+  const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] =
     useState<boolean>(false);
 
   const {
@@ -41,7 +56,6 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
   const deleteSetSectionSongMutation = api.setSectionSong.delete.useMutation();
   const removeSong = (organizationId: string, setSectionSongId: string) => {
     console.log("🤖 - SongActionMenu ~ removeSong");
-    // TODO: add confirmation dialog for removing song
 
     deleteSetSectionSongMutation.mutate(
       { organizationId, setSectionSongId },
@@ -68,36 +82,70 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
   }
 
   return (
-    <DropdownMenu
-      open={isSongActionMenuOpen}
-      onOpenChange={setIsSongActionMenuOpen}
-    >
-      <DropdownMenuTrigger>
-        <Button variant="ghost" size="sm">
-          <DotsThree className="text-slate-900" size={16} />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <SongActionMenuItem icon="PianoKeys" label="Change key" />
-        <SongActionMenuItem icon="Swap" label="Replace song" />
-        <DropdownMenuSeparator />
-        <SongActionMenuItem icon="ArrowUp" label="Move up" />
-        <SongActionMenuItem icon="ArrowDown" label="Move down" />
-        <SongActionMenuItem
-          icon="ArrowLineUp"
-          label="Move to previous section"
-        />
-        <SongActionMenuItem icon="ArrowLineDown" label="Move to next section" />
-        <DropdownMenuSeparator />
-        <SongActionMenuItem
-          icon="Trash"
-          label="Remove from section"
-          onClick={() => {
-            removeSong(userMembership?.organizationId, setSectionSongId);
-          }}
-          destructive
-        />
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu
+        open={isSongActionMenuOpen}
+        onOpenChange={setIsSongActionMenuOpen}
+      >
+        <DropdownMenuTrigger>
+          <Button variant="ghost" size="sm">
+            <DotsThree className="text-slate-900" size={16} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <SongActionMenuItem icon="PianoKeys" label="Change key" />
+          <SongActionMenuItem icon="Swap" label="Replace song" />
+          <DropdownMenuSeparator />
+          <SongActionMenuItem icon="ArrowUp" label="Move up" />
+          <SongActionMenuItem icon="ArrowDown" label="Move down" />
+          <SongActionMenuItem
+            icon="ArrowLineUp"
+            label="Move to previous section"
+          />
+          <SongActionMenuItem
+            icon="ArrowLineDown"
+            label="Move to next section"
+          />
+          <DropdownMenuSeparator />
+          <SongActionMenuItem
+            icon="Trash"
+            label="Remove from section"
+            onClick={() => {
+              setIsConfirmationDialogOpen(true);
+              setIsSongActionMenuOpen(false);
+            }}
+            destructive
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AlertDialog
+        open={isConfirmationDialogOpen}
+        onOpenChange={setIsConfirmationDialogOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-lg font-semibold">
+              Remove &quot;{setSectionSong.song.name}&quot; from the{" "}
+              {setSectionType} section?
+            </AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              onClick={() => setIsConfirmationDialogOpen(false)}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              onClick={() =>
+                removeSong(userMembership?.organizationId, setSectionSong.id)
+              }
+            >
+              Remove song
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 };

--- a/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
+++ b/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
@@ -30,6 +30,7 @@ type SongActionMenuItemProps = {
   icon: keyof typeof iconMap;
   destructive?: boolean;
   disabled?: boolean;
+  onClick?: () => void;
 };
 
 export const SongActionMenuItem: React.FC<SongActionMenuItemProps> = ({
@@ -37,12 +38,17 @@ export const SongActionMenuItem: React.FC<SongActionMenuItemProps> = ({
   icon,
   destructive = false,
   disabled = false,
+  onClick,
 }) => {
   const Icon = iconMap[icon];
 
   return (
     <DropdownMenuItem asChild disabled={disabled}>
-      <HStack className="gap-2" aria-label={`${label} action`}>
+      <HStack
+        className="gap-2"
+        aria-label={`${label} action`}
+        onClick={onClick}
+      >
         <Icon
           size={16}
           className={cn(

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -1,36 +1,39 @@
+"use client";
+
 import { HStack } from "@components/HStack";
-import { SongKey, type SongKeyProps } from "@components/SongKey";
+import { SongKey } from "@components/SongKey";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
 import { SongActionMenu } from "../SongActionMenu/SongActionMenu";
+import { type SetSectionSongWithSongData } from "@lib/types";
+import Link from "next/link";
+import { useParams } from "next/navigation";
 
 export type SongItemProps = {
+  /** set section song object */
+  setSectionSong: SetSectionSongWithSongData;
+
+  /** ID of the set this set section song is attached to  */
+  setId: string;
+
   /** index of song in the set list */
   index: number;
-
-  /** what key the song will be played in */
-  songKey: SongKeyProps["songKey"];
-
-  /** name of song */
-  name: string;
-
-  /** song notes */
-  notes?: string | null;
 
   /** should the song item show the action menu? */
   withActionsMenu?: boolean;
 };
 
 export const SongItem: React.FC<SongItemProps> = ({
+  setSectionSong,
+  setId,
   index,
-  songKey,
-  name,
-  notes,
   withActionsMenu = true,
 }) => {
+  const params = useParams<{ organization: string }>();
+
   return (
     <HStack className="items-center justify-between rounded-lg px-6 py-3 shadow lg:py-4">
-      <HStack className="items-baseline gap-3 text-xs font-semibold">
+      <HStack className="w-full items-baseline gap-3 text-xs font-semibold">
         <Text
           style="header-medium-semibold"
           align="right"
@@ -38,21 +41,28 @@ export const SongItem: React.FC<SongItemProps> = ({
         >
           {index}.
         </Text>
-        <VStack className="flex flex-col gap-2">
+        <VStack className="flex flex-grow flex-col gap-2">
           <HStack className="flex items-baseline gap-2">
-            <SongKey songKey={songKey} />
-            <Text fontWeight="semibold" className="text-sm">
-              {name}
-            </Text>
+            <SongKey songKey={setSectionSong.key} />
+            <Link
+              href={`/${params.organization}/songs/${setSectionSong.song.id}`}
+              className="w-full"
+            >
+              <Text fontWeight="semibold" className="text-sm">
+                {setSectionSong.song.name}
+              </Text>
+            </Link>
           </HStack>
-          {notes ? (
+          {setSectionSong.notes ? (
             <Text style="small" color="slate-700">
-              {notes}
+              {setSectionSong.notes}
             </Text>
           ) : null}
         </VStack>
       </HStack>
-      {withActionsMenu && <SongActionMenu />}
+      {withActionsMenu && (
+        <SongActionMenu setSectionSongId={setSectionSong.id} setId={setId} />
+      )}
     </HStack>
   );
 };

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -19,6 +19,9 @@ export type SongItemProps = {
   /** index of song in the set list */
   index: number;
 
+  /** the type of set section this song is attached to */
+  setSectionType: string;
+
   /** should the song item show the action menu? */
   withActionsMenu?: boolean;
 };
@@ -27,6 +30,7 @@ export const SongItem: React.FC<SongItemProps> = ({
   setSectionSong,
   setId,
   index,
+  setSectionType,
   withActionsMenu = true,
 }) => {
   const params = useParams<{ organization: string }>();
@@ -61,7 +65,11 @@ export const SongItem: React.FC<SongItemProps> = ({
         </VStack>
       </HStack>
       {withActionsMenu && (
-        <SongActionMenu setSectionSongId={setSectionSong.id} setId={setId} />
+        <SongActionMenu
+          setSectionSong={setSectionSong}
+          setId={setId}
+          setSectionType={setSectionType}
+        />
       )}
     </HStack>
   );

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -52,6 +52,7 @@ export const SetSectionCard: FC<SetSectionProps> = ({
               setSectionSong={setSectionSong}
               index={sectionStartIndex + setSectionSong.position}
               setId={setId}
+              setSectionType={type.name}
             />
           ))}
       </VStack>

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -2,7 +2,6 @@ import { type FC } from "react";
 import { type SetSectionWithSongs } from "@lib/types";
 import { DotsThree, Plus } from "@phosphor-icons/react/dist/ssr";
 import { SongItem } from "@modules/SetListCard";
-import Link from "next/link";
 import { Text } from "@components/Text";
 import { Button } from "@components/ui/button";
 import { VStack } from "@components/VStack";
@@ -17,7 +16,7 @@ export const SetSectionCard: FC<SetSectionProps> = ({
   section,
   sectionStartIndex,
 }) => {
-  const { id, type, songs } = section;
+  const { id, type, songs, setId } = section;
   return (
     <VStack
       key={id}
@@ -47,23 +46,14 @@ export const SetSectionCard: FC<SetSectionProps> = ({
       <VStack className="gap-y-4">
         {songs &&
           songs.length > 0 &&
-          section.songs.map((setSectionSong) => {
-            return (
-              <Link
-                key={setSectionSong.songId}
-                href={`../songs/${setSectionSong.songId}`}
-              >
-                <SongItem
-                  index={sectionStartIndex + setSectionSong.position}
-                  songKey={setSectionSong.key}
-                  name={setSectionSong.song.name}
-                  {...(setSectionSong.notes && {
-                    notes: setSectionSong.notes,
-                  })}
-                />
-              </Link>
-            );
-          })}
+          section.songs.map((setSectionSong) => (
+            <SongItem
+              key={setSectionSong.id}
+              setSectionSong={setSectionSong}
+              index={sectionStartIndex + setSectionSong.position}
+              setId={setId}
+            />
+          ))}
       </VStack>
     </VStack>
   );

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -42,7 +42,7 @@ export const setSectionSongRouter = createTRPCRouter({
     .input(deleteSetSectionSongSchema)
     .mutation(async ({ ctx, input }) => {
       console.log(
-        "🤖 - [setSectionSong/delete] - song to delete:",
+        "🤖 - [setSectionSong/delete] - Attempting to delete:",
         input.setSectionSongId,
       );
 
@@ -53,12 +53,12 @@ export const setSectionSongRouter = createTRPCRouter({
 
       if (deletedSetSectionSong) {
         console.info(
-          `🤖 - [set/delete] - Set ID ${deletedSetSectionSong.id} was successfully deleted`,
+          `🤖 - [setSectionSong/delete] - SetSectionSong ID ${deletedSetSectionSong.id} was successfully deleted`,
         );
         return deletedSetSectionSong;
       } else {
         console.error(
-          `🤖 - [set/delete] - Set ID ${input.setSectionSongId} could not be deleted`,
+          `🤖 - [setSectionSong/delete] - SetSectionSong ID ${input.setSectionSongId} could not be deleted`,
         );
       }
     }),

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -1,8 +1,12 @@
 import { type NewSetSectionSong } from "@lib/types";
-import { insertSetSectionSongSchema } from "@lib/types/zod";
+import {
+  deleteSetSectionSongSchema,
+  insertSetSectionSongSchema,
+} from "@lib/types/zod";
 import { createTRPCRouter, organizationProcedure } from "@server/api/trpc";
 import { setSectionSongs } from "@server/db/schema";
 import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 
 export const setSectionSongRouter = createTRPCRouter({
   create: organizationProcedure
@@ -33,5 +37,29 @@ export const setSectionSongRouter = createTRPCRouter({
         .insert(setSectionSongs)
         .values(newSetSectionSong)
         .returning();
+    }),
+  delete: organizationProcedure
+    .input(deleteSetSectionSongSchema)
+    .mutation(async ({ ctx, input }) => {
+      console.log(
+        "🤖 - [setSectionSong/delete] - song to delete:",
+        input.setSectionSongId,
+      );
+
+      const [deletedSetSectionSong] = await ctx.db
+        .delete(setSectionSongs)
+        .where(eq(setSectionSongs.id, input.setSectionSongId))
+        .returning();
+
+      if (deletedSetSectionSong) {
+        console.info(
+          `🤖 - [set/delete] - Set ID ${deletedSetSectionSong.id} was successfully deleted`,
+        );
+        return deletedSetSectionSong;
+      } else {
+        console.error(
+          `🤖 - [set/delete] - Set ID ${input.setSectionSongId} could not be deleted`,
+        );
+      }
     }),
 });


### PR DESCRIPTION
## Background
This PR is to hook up the song action menu's "Remove from section" item UI with the actual back-end action to remove the song from the section (deleting the set section song).

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New Features**
  - Introduced a new option for users to remove songs directly from a section, complete with immediate feedback notifications.
  - Added a new schema for validating song deletions.

- **Improvements**
  - Streamlined the song display for clearer information and easier navigation.
  - Enhanced user validation to ensure that only authorized actions modify song sections.
  - Updated backend processes for a more responsive and reliable song management experience.
  - Consolidated data handling for song items to improve performance and maintainability.
  - Added support for confirming deletion actions to enhance user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
1. Go to any set details page and add any song to the set (if there aren't yet any songs)
2. Click the song actions menu (...) on any of the songs in the set and select "Remove from section"
3. Confirm that you want to remove the song in the confirmation dialog
4. The set details page should automatically refetch the set data and show the updated state without the song just removed