### PR TITLE
[SWY-74] Implement update song position actions

### DIFF
--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -105,7 +105,6 @@ export default async function Dashboard({
                             setSectionSong={setSectionSong}
                             setSectionType={section.type.name}
                             setId={orgSet.id}
-                            withActionsMenu={false}
                           />
                         </Link>
                       );

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -161,6 +161,10 @@ export default function SetListPage({ params }: SetListPageProps) {
                   key={section.id}
                   section={section as SetSectionWithSongs}
                   sectionStartIndex={sectionStartIndex}
+                  isFirstSection={section.position === 0}
+                  isLastSection={
+                    section.position === setData.sections.length - 1
+                  }
                 />
               );
             })}

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -89,3 +89,4 @@ const setSectionSongIdSchema = z.object({
 });
 export const insertSetSectionSongSchema = createInsertSchema(setSectionSongs);
 export const deleteSetSectionSongSchema = setSectionSongIdSchema;
+export const swapSetSectionSongSchema = setSectionSongIdSchema;

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -114,16 +114,20 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
           <SongActionMenuItem icon="PianoKeys" label="Change key" />
           <SongActionMenuItem icon="Swap" label="Replace song" />
           <DropdownMenuSeparator />
-          <SongActionMenuItem
-            icon="ArrowUp"
-            label="Move up"
-            disabled={isFirstSong}
-          />
-          <SongActionMenuItem
-            icon="ArrowDown"
-            label="Move down"
-            disabled={isLastSong}
-          />
+          {!(isFirstSong && isLastSong) && (
+            <>
+              <SongActionMenuItem
+                icon="ArrowUp"
+                label="Move up"
+                disabled={isFirstSong}
+              />
+              <SongActionMenuItem
+                icon="ArrowDown"
+                label="Move down"
+                disabled={isLastSong}
+              />
+            </>
+          )}
           {!(isInFirstSection && isInLastSection) && (
             <>
               <SongActionMenuItem

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -22,7 +22,7 @@ import {
   AlertDialogTitle,
 } from "@components/ui/alert-dialog";
 import { type SetSectionSongWithSongData } from "@lib/types";
-import { type SongItemProps } from "@modules/SetListCard/components/SongItem";
+import { type SongItemWithActionsMenuProps } from "@modules/SetListCard/components/SongItem";
 
 type SongActionMenuProps = {
   /** set section song object */
@@ -35,16 +35,16 @@ type SongActionMenuProps = {
   setId: string;
 
   /** is this song in the first section of the set? */
-  isInFirstSection: SongItemProps["isInFirstSection"];
+  isInFirstSection: SongItemWithActionsMenuProps["isInFirstSection"];
 
   /** is this song in the last section of the set? */
-  isInLastSection: SongItemProps["isInLastSection"];
+  isInLastSection: SongItemWithActionsMenuProps["isInLastSection"];
 
   /** is this song the first song of the section? */
-  isFirstSong: SongItemProps["isFirstSong"];
+  isFirstSong: SongItemWithActionsMenuProps["isFirstSong"];
 
   /** is this song the last song of the section? */
-  isLastSong: SongItemProps["isLastSong"];
+  isLastSong: SongItemWithActionsMenuProps["isLastSong"];
 };
 
 export const SongActionMenu: React.FC<SongActionMenuProps> = ({
@@ -124,16 +124,20 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
             label="Move down"
             disabled={isLastSong}
           />
-          <SongActionMenuItem
-            icon="ArrowLineUp"
-            label="Move to previous section"
-            disabled={isInFirstSection}
-          />
-          <SongActionMenuItem
-            icon="ArrowLineDown"
-            label="Move to next section"
-            disabled={isInLastSection}
-          />
+          {!(isInFirstSection && isInLastSection) && (
+            <>
+              <SongActionMenuItem
+                icon="ArrowLineUp"
+                label="Move to previous section"
+                disabled={isInFirstSection}
+              />
+              <SongActionMenuItem
+                icon="ArrowLineDown"
+                label="Move to next section"
+                disabled={isInLastSection}
+              />
+            </>
+          )}
           <DropdownMenuSeparator />
           <SongActionMenuItem
             icon="Trash"

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -22,6 +22,7 @@ import {
   AlertDialogTitle,
 } from "@components/ui/alert-dialog";
 import { type SetSectionSongWithSongData } from "@lib/types";
+import { type SongItemProps } from "@modules/SetListCard/components/SongItem";
 
 type SongActionMenuProps = {
   /** set section song object */
@@ -32,12 +33,28 @@ type SongActionMenuProps = {
 
   /** the ID of the set the set section song is attached to */
   setId: string;
+
+  /** is this song in the first section of the set? */
+  isInFirstSection: SongItemProps["isInFirstSection"];
+
+  /** is this song in the last section of the set? */
+  isInLastSection: SongItemProps["isInLastSection"];
+
+  /** is this song the first song of the section? */
+  isFirstSong: SongItemProps["isFirstSong"];
+
+  /** is this song the last song of the section? */
+  isLastSong: SongItemProps["isLastSong"];
 };
 
 export const SongActionMenu: React.FC<SongActionMenuProps> = ({
   setSectionSong,
   setSectionType,
   setId,
+  isFirstSong,
+  isLastSong,
+  isInFirstSection,
+  isInLastSection,
 }) => {
   const apiUtils = api.useUtils();
   const [isSongActionMenuOpen, setIsSongActionMenuOpen] =
@@ -97,15 +114,25 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
           <SongActionMenuItem icon="PianoKeys" label="Change key" />
           <SongActionMenuItem icon="Swap" label="Replace song" />
           <DropdownMenuSeparator />
-          <SongActionMenuItem icon="ArrowUp" label="Move up" />
-          <SongActionMenuItem icon="ArrowDown" label="Move down" />
+          <SongActionMenuItem
+            icon="ArrowUp"
+            label="Move up"
+            disabled={isFirstSong}
+          />
+          <SongActionMenuItem
+            icon="ArrowDown"
+            label="Move down"
+            disabled={isLastSong}
+          />
           <SongActionMenuItem
             icon="ArrowLineUp"
             label="Move to previous section"
+            disabled={isInFirstSection}
           />
           <SongActionMenuItem
             icon="ArrowLineDown"
             label="Move to next section"
+            disabled={isInLastSection}
           />
           <DropdownMenuSeparator />
           <SongActionMenuItem

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -89,6 +89,33 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
     );
   };
 
+  const swapSongWithNextMutation =
+    api.setSectionSong.swapSongWithNext.useMutation();
+  const moveSongDown = (organizationId: string, setSectionSongId: string) => {
+    toast.loading("Moving song down...");
+    swapSongWithNextMutation.mutate(
+      { organizationId, setSectionSongId },
+      {
+        async onSuccess(swapSongWithNextResult) {
+          toast.dismiss();
+
+          if (!swapSongWithNextResult.success) {
+            toast.error(
+              `Could not move song down: ${swapSongWithNextResult.message}`,
+            );
+          } else {
+            toast.success("Moved song down");
+            await apiUtils.set.get.invalidate({ setId });
+          }
+        },
+        onError(error) {
+          toast.dismiss();
+          toast.error("Song could not be moved down");
+        },
+      },
+    );
+  };
+
   if (
     !!userQueryError ||
     !isAuthLoaded ||
@@ -128,6 +155,13 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
                 icon="ArrowDown"
                 label="Move down"
                 disabled={isLastSong}
+                onClick={() => {
+                  moveSongDown(
+                    userMembership.organizationId,
+                    setSectionSong.id,
+                  );
+                  setIsSongActionMenuOpen(false);
+                }}
               />
             </>
           )}

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -99,6 +99,9 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
     return null;
   }
 
+  const isOnlySong = isFirstSong && isLastSong;
+  const isInOnlySection = isInFirstSection && isInLastSection;
+
   return (
     <>
       <DropdownMenu
@@ -114,7 +117,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
           <SongActionMenuItem icon="PianoKeys" label="Change key" />
           <SongActionMenuItem icon="Swap" label="Replace song" />
           <DropdownMenuSeparator />
-          {!(isFirstSong && isLastSong) && (
+          {!isOnlySong && (
             <>
               <SongActionMenuItem
                 icon="ArrowUp"
@@ -128,7 +131,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
               />
             </>
           )}
-          {!(isInFirstSection && isInLastSection) && (
+          {!isInOnlySection && (
             <>
               <SongActionMenuItem
                 icon="ArrowLineUp"
@@ -142,7 +145,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
               />
             </>
           )}
-          <DropdownMenuSeparator />
+          {!(isOnlySong && isInOnlySection) && <DropdownMenuSeparator />}
           <SongActionMenuItem
             icon="Trash"
             label="Remove from section"

--- a/src/modules/SetListCard/components/SongContent/SongContent.tsx
+++ b/src/modules/SetListCard/components/SongContent/SongContent.tsx
@@ -1,0 +1,56 @@
+import { HStack } from "@components/HStack";
+import { SongKey } from "@components/SongKey";
+import { Text } from "@components/Text";
+import { VStack } from "@components/VStack";
+import { type SetSectionSongWithSongData } from "@lib/types";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+export type SongContentProps = {
+  /** The set section song object containing song details and metadata */
+  setSectionSong: SetSectionSongWithSongData;
+
+  /** The 1-based index position of this song in the overall set list */
+  index: number;
+};
+
+/**
+ * Displays the core content of a song item including index number, key, title and notes
+ * Used as an internal component within SongItem
+ */
+export const SongContent: React.FC<SongContentProps> = ({
+  setSectionSong,
+  index,
+}) => {
+  const params = useParams<{ organization: string }>();
+
+  return (
+    <HStack className="w-full items-baseline gap-3 text-xs font-semibold">
+      <Text
+        style="header-medium-semibold"
+        align="right"
+        className="text-slate-400"
+      >
+        {index}.
+      </Text>
+      <VStack className="flex flex-grow flex-col gap-2">
+        <HStack className="flex items-baseline gap-2">
+          <SongKey songKey={setSectionSong.key} />
+          <Link
+            href={`/${params.organization}/songs/${setSectionSong.song.id}`}
+            className="w-full"
+          >
+            <Text fontWeight="semibold" className="text-sm">
+              {setSectionSong.song.name}
+            </Text>
+          </Link>
+        </HStack>
+        {setSectionSong.notes ? (
+          <Text style="small" color="slate-700">
+            {setSectionSong.notes}
+          </Text>
+        ) : null}
+      </VStack>
+    </HStack>
+  );
+};

--- a/src/modules/SetListCard/components/SongContent/index.ts
+++ b/src/modules/SetListCard/components/SongContent/index.ts
@@ -1,0 +1,1 @@
+export * from "./SongContent";

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -8,6 +8,7 @@ import { SongActionMenu } from "../SongActionMenu/SongActionMenu";
 import { type SetSectionSongWithSongData } from "@lib/types";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { type SetSectionCardProps } from "@modules/sets/components/SetSectionCard";
 
 export type SongItemProps = {
   /** set section song object */
@@ -24,6 +25,18 @@ export type SongItemProps = {
 
   /** should the song item show the action menu? */
   withActionsMenu?: boolean;
+
+  /** is this song in the first section of the set? */
+  isInFirstSection: SetSectionCardProps["isFirstSection"];
+
+  /** is this song in the last section of the set? */
+  isInLastSection: SetSectionCardProps["isLastSection"];
+
+  /** is this song the first song of the section? */
+  isFirstSong: boolean;
+
+  /** is this song the last song of the section? */
+  isLastSong: boolean;
 };
 
 export const SongItem: React.FC<SongItemProps> = ({
@@ -32,6 +45,10 @@ export const SongItem: React.FC<SongItemProps> = ({
   index,
   setSectionType,
   withActionsMenu = true,
+  isFirstSong,
+  isLastSong,
+  isInFirstSection,
+  isInLastSection,
 }) => {
   const params = useParams<{ organization: string }>();
 
@@ -69,6 +86,10 @@ export const SongItem: React.FC<SongItemProps> = ({
           setSectionSong={setSectionSong}
           setId={setId}
           setSectionType={setSectionType}
+          isFirstSong={isFirstSong}
+          isLastSong={isLastSong}
+          isInFirstSection={isInFirstSection}
+          isInLastSection={isInLastSection}
         />
       )}
     </HStack>

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -1,16 +1,12 @@
 "use client";
 
 import { HStack } from "@components/HStack";
-import { SongKey } from "@components/SongKey";
-import { Text } from "@components/Text";
-import { VStack } from "@components/VStack";
 import { SongActionMenu } from "../SongActionMenu/SongActionMenu";
 import { type SetSectionSongWithSongData } from "@lib/types";
-import Link from "next/link";
-import { useParams } from "next/navigation";
 import { type SetSectionCardProps } from "@modules/sets/components/SetSectionCard";
+import { SongContent } from "@modules/SetListCard/components/SongContent";
 
-export type SongItemProps = {
+type BaseSongItemProps = {
   /** set section song object */
   setSectionSong: SetSectionSongWithSongData;
 
@@ -25,6 +21,10 @@ export type SongItemProps = {
 
   /** should the song item show the action menu? */
   withActionsMenu?: boolean;
+};
+
+export type SongItemWithActionsMenuProps = BaseSongItemProps & {
+  withActionsMenu: true;
 
   /** is this song in the first section of the set? */
   isInFirstSection: SetSectionCardProps["isFirstSection"];
@@ -39,57 +39,33 @@ export type SongItemProps = {
   isLastSong: boolean;
 };
 
+type SongItemWithoutActionsMenuProps = BaseSongItemProps & {
+  withActionsMenu?: false;
+};
+
+export type SongItemProps =
+  | SongItemWithActionsMenuProps
+  | SongItemWithoutActionsMenuProps;
+
 export const SongItem: React.FC<SongItemProps> = ({
   setSectionSong,
   setId,
   index,
   setSectionType,
-  withActionsMenu = true,
-  isFirstSong,
-  isLastSong,
-  isInFirstSection,
-  isInLastSection,
+  ...props
 }) => {
-  const params = useParams<{ organization: string }>();
-
   return (
     <HStack className="items-center justify-between rounded-lg px-6 py-3 shadow lg:py-4">
-      <HStack className="w-full items-baseline gap-3 text-xs font-semibold">
-        <Text
-          style="header-medium-semibold"
-          align="right"
-          className="text-slate-400"
-        >
-          {index}.
-        </Text>
-        <VStack className="flex flex-grow flex-col gap-2">
-          <HStack className="flex items-baseline gap-2">
-            <SongKey songKey={setSectionSong.key} />
-            <Link
-              href={`/${params.organization}/songs/${setSectionSong.song.id}`}
-              className="w-full"
-            >
-              <Text fontWeight="semibold" className="text-sm">
-                {setSectionSong.song.name}
-              </Text>
-            </Link>
-          </HStack>
-          {setSectionSong.notes ? (
-            <Text style="small" color="slate-700">
-              {setSectionSong.notes}
-            </Text>
-          ) : null}
-        </VStack>
-      </HStack>
-      {withActionsMenu && (
+      <SongContent setSectionSong={setSectionSong} index={index} />
+      {props.withActionsMenu && (
         <SongActionMenu
           setSectionSong={setSectionSong}
           setId={setId}
           setSectionType={setSectionType}
-          isFirstSong={isFirstSong}
-          isLastSong={isLastSong}
-          isInFirstSection={isInFirstSection}
-          isInLastSection={isInLastSection}
+          isFirstSong={props.isFirstSong}
+          isLastSong={props.isLastSong}
+          isInFirstSection={props.isInFirstSection}
+          isInLastSection={props.isInLastSection}
         />
       )}
     </HStack>

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -7,14 +7,25 @@ import { Button } from "@components/ui/button";
 import { VStack } from "@components/VStack";
 import { HStack } from "@components/HStack";
 
-export type SetSectionProps = {
+export type SetSectionCardProps = {
+  /** The section data including songs, type, and position */
   section: SetSectionWithSongs;
+
+  /** The 1-based index where this section's songs start in the overall set */
   sectionStartIndex: number;
+
+  /** Whether this is the first section in the set */
+  isFirstSection: boolean;
+
+  /** Whether this is the last section in the set */
+  isLastSection: boolean;
 };
 
-export const SetSectionCard: FC<SetSectionProps> = ({
+export const SetSectionCard: FC<SetSectionCardProps> = ({
   section,
   sectionStartIndex,
+  isFirstSection,
+  isLastSection,
 }) => {
   const { id, type, songs, setId } = section;
   return (
@@ -53,6 +64,10 @@ export const SetSectionCard: FC<SetSectionProps> = ({
               index={sectionStartIndex + setSectionSong.position}
               setId={setId}
               setSectionType={type.name}
+              isInFirstSection={isFirstSection}
+              isInLastSection={isLastSection}
+              isFirstSong={setSectionSong.position === 0}
+              isLastSong={setSectionSong.position === section.songs.length - 1}
             />
           ))}
       </VStack>

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -68,6 +68,7 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
               isInLastSection={isLastSection}
               isFirstSong={setSectionSong.position === 0}
               isLastSong={setSectionSong.position === section.songs.length - 1}
+              withActionsMenu
             />
           ))}
       </VStack>

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -136,6 +136,12 @@ export const setSectionSongRouter = createTRPCRouter({
       }
     }),
 
+  swapSongWithPrevious: organizationProcedure
+    .input(swapSetSectionSongSchema)
+    .mutation(async ({ input }) => {
+      return await swapSongPosition(input.setSectionSongId, "up");
+    }),
+
   swapSongWithNext: organizationProcedure
     .input(swapSetSectionSongSchema)
     .mutation(async ({ input }) => {

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -2,6 +2,7 @@ import { type NewSetSectionSong } from "@lib/types";
 import {
   deleteSetSectionSongSchema,
   insertSetSectionSongSchema,
+  swapSetSectionSongSchema,
 } from "@lib/types/zod";
 import {
   adminProcedure,
@@ -9,6 +10,7 @@ import {
   organizationProcedure,
 } from "@server/api/trpc";
 import { setSectionSongs } from "@server/db/schema";
+import { swapSongPosition } from "@server/mutations";
 import { TRPCError } from "@trpc/server";
 import { and, eq, gt, sql } from "drizzle-orm";
 
@@ -132,5 +134,11 @@ export const setSectionSongRouter = createTRPCRouter({
           message: `Failed to delete set section song ${input.setSectionSongId}`,
         });
       }
+    }),
+
+  swapSongWithNext: organizationProcedure
+    .input(swapSetSectionSongSchema)
+    .mutation(async ({ input }) => {
+      return await swapSongPosition(input.setSectionSongId, "down");
     }),
 });

--- a/src/server/mutations.ts
+++ b/src/server/mutations.ts
@@ -1,25 +1,101 @@
 "use server";
 
-import { api } from "@/trpc/server";
-import { TRPCError } from "@trpc/server";
-import { redirect } from "next/navigation";
-import { toast } from "sonner";
+import { db } from "@server/db";
+import { setSectionSongs } from "@server/db/schema";
+import { and, eq, sql } from "drizzle-orm";
 
-export async function deleteSet(setId: string, organizationId: string) {
-  try {
-    await api.set.delete({ setId, organizationId });
-    toast.success("Set deleted");
-    redirect(`/${organizationId}`);
-  } catch (deleteSetError) {
-    if (deleteSetError instanceof TRPCError) {
-      switch (deleteSetError.code) {
-        case "FORBIDDEN":
-        default:
-          console.error(
-            `🤖 - [mutations/deleteSet/${setId}]: ${deleteSetError.message}`,
-          );
-          toast.error("Set could not be deleted");
-      }
+export type SwapSongDirection = "up" | "down";
+
+export type SwapSongsPositionResult = {
+  success: boolean;
+  message?: string;
+};
+
+export const swapSongPosition = async (
+  setSectionSongToSwapId: string,
+  direction: SwapSongDirection,
+): Promise<SwapSongsPositionResult> => {
+  return await db.transaction(async (swapTransaction) => {
+    const [currentSong] = await swapTransaction
+      .select()
+      .from(setSectionSongs)
+      .where(eq(setSectionSongs.id, setSectionSongToSwapId))
+      .limit(1);
+    if (!currentSong) {
+      console.error(
+        `🤖 - [setSectionSongs/swapSongPosition/${direction}] - Song ${setSectionSongToSwapId} not found`,
+      );
+      return {
+        success: false,
+        message: `Song not found`,
+      };
     }
-  }
-}
+
+    const { setSectionId, position } = currentSong;
+
+    const [maxSongPositionResult] = await swapTransaction
+      .select({ maxSongPosition: sql<number>`MAX(position)` })
+      .from(setSectionSongs)
+      .where(eq(setSectionSongs.setSectionId, setSectionId));
+
+    if (
+      (direction === "up" && position === 0) ||
+      (direction === "down" &&
+        position === maxSongPositionResult?.maxSongPosition)
+    ) {
+      console.error(
+        `🤖 - [setSectionSongs/swapSongPosition/${direction}] - Cannot swap song ${direction} from position ${position}`,
+      );
+      return {
+        success: false,
+        message: `Cannot move ${direction} from current position`,
+      };
+    }
+
+    const targetPosition = direction === "up" ? position - 1 : position + 1;
+
+    const [songToSwap] = await swapTransaction
+      .select()
+      .from(setSectionSongs)
+      .where(
+        and(
+          eq(setSectionSongs.setSectionId, setSectionId),
+          eq(setSectionSongs.position, targetPosition),
+        ),
+      )
+      .limit(1);
+
+    if (!songToSwap) {
+      console.error(
+        `🤖 - [setSectionSongs/swapSongPosition/${direction}] - No song to swap with ${direction}`,
+      );
+      return {
+        success: false,
+        message: `No song to swap with ${direction}`,
+      };
+    }
+
+    console.info(
+      `🤖 - [setSectionSongs/swapSongPosition/${direction}] - Preparing to move song ${direction}, swapping with ${songToSwap.id}`,
+    );
+
+    await swapTransaction
+      .update(setSectionSongs)
+      .set({ position: targetPosition })
+      .where(eq(setSectionSongs.id, setSectionSongToSwapId));
+
+    await swapTransaction
+      .update(setSectionSongs)
+      .set({ position })
+      .where(eq(setSectionSongs.id, songToSwap.id));
+
+    console.info(
+      `🤖 - [setSectionSongs/swapSongPosition/${direction}] - Successfully moved song ${direction}. ${setSectionSongToSwapId} new position: ${targetPosition}. ${songToSwap.id} new position: ${position}`,
+    );
+
+    return {
+      success: true,
+      message: `Successfully moved song ${setSectionSongToSwapId} ${direction}`,
+    };
+  });
+};

--- a/src/server/mutations.ts
+++ b/src/server/mutations.ts
@@ -90,7 +90,7 @@ export const swapSongPosition = async (
       .where(eq(setSectionSongs.id, songToSwap.id));
 
     console.info(
-      `🤖 - [setSectionSongs/swapSongPosition/${direction}] - Successfully moved song ${direction}. ${setSectionSongToSwapId} new position: ${targetPosition}. ${songToSwap.id} new position: ${position}`,
+      `🤖 - [setSectionSongs/swapSongPosition/${direction}] - Successfully moved song ${direction}:\n${setSectionSongToSwapId} new position: ${targetPosition}.\n${songToSwap.id} new position: ${position}`,
     );
 
     return {


### PR DESCRIPTION
## Background
This PR is to implement the "move song up/down" actions in the song actions menu

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced set display with clear indicators for the beginning and end of each section.
  - Updated navigation controls to automatically disable move actions when rearranging songs at section boundaries.
  - Introduced a new component to display core song details, improving the presentation of song items within a set list.
  - Improved overall user experience when viewing and editing sets through added contextual cues.
  - Added contextual information for song items based on their position within sections.
  - Introduced mutations for swapping song positions within a set section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
- Go to a set that has songs (or add songs to an empty set)
- In the song actions menu:
  - If the song is first in its section, the move song up action should be disabled
  - If the song is last in its section, the move song down action should be disabled
  - If the song is in the first section, the move song to previous section action should be disabled
  - If the song is in the last section, the move song to next section action should be disabled
  - If the set only has one section, the move song to previous section and move song to next section actions should not appear in the action menu
- Using the action menu, you should be able to move songs up and down.