### PR TITLE
[SWY-77] Add View Song Details action

### DIFF
--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -23,7 +23,8 @@ import {
 } from "@components/ui/alert-dialog";
 import { type SetSectionSongWithSongData } from "@lib/types";
 import { type SongItemWithActionsMenuProps } from "@modules/SetListCard/components/SongItem";
-import { SwapSongDirection } from "@server/mutations";
+import { type SwapSongDirection } from "@server/mutations";
+import { useParams, useRouter } from "next/navigation";
 
 type SongActionMenuProps = {
   /** set section song object */
@@ -62,6 +63,9 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
     useState<boolean>(false);
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] =
     useState<boolean>(false);
+
+  const params = useParams<{ organization: string }>();
+  const router = useRouter();
 
   const {
     data: userData,
@@ -156,7 +160,17 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
             <DotsThree className="text-slate-900" size={16} />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
+        <DropdownMenuContent avoidCollisions align="end" side="bottom">
+          <SongActionMenuItem
+            icon="Article"
+            label="View song details"
+            onClick={() =>
+              router.push(
+                `/${params.organization}/songs/${setSectionSong.song.id}`,
+              )
+            }
+          />
+          <DropdownMenuSeparator />
           <SongActionMenuItem icon="PianoKeys" label="Change key" />
           <SongActionMenuItem icon="Swap" label="Replace song" />
           <DropdownMenuSeparator />

--- a/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
+++ b/src/modules/SetListCard/components/SongActionMenuItem/SongActionMenuItem.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLineDown,
   ArrowLineUp,
   ArrowUp,
+  Article,
   Pencil,
   Swap,
   Trash,
@@ -19,6 +20,7 @@ const iconMap = {
   ArrowLineDown,
   ArrowLineUp,
   ArrowUp,
+  Article,
   Pencil,
   Swap,
   Trash,
@@ -50,9 +52,9 @@ export const SongActionMenuItem: React.FC<SongActionMenuItemProps> = ({
         onClick={onClick}
       >
         <Icon
-          size={16}
+          size={18}
           className={cn(
-            "text-slate-500",
+            "text-slate-700",
             [destructive && "text-red-500"],
             [disabled && "text-slate-400"],
           )}

--- a/src/modules/SetListCard/components/SongContent/SongContent.tsx
+++ b/src/modules/SetListCard/components/SongContent/SongContent.tsx
@@ -3,8 +3,6 @@ import { SongKey } from "@components/SongKey";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
 import { type SetSectionSongWithSongData } from "@lib/types";
-import Link from "next/link";
-import { useParams } from "next/navigation";
 
 export type SongContentProps = {
   /** The set section song object containing song details and metadata */
@@ -22,8 +20,6 @@ export const SongContent: React.FC<SongContentProps> = ({
   setSectionSong,
   index,
 }) => {
-  const params = useParams<{ organization: string }>();
-
   return (
     <HStack className="w-full items-baseline gap-3 text-xs font-semibold">
       <Text
@@ -36,14 +32,9 @@ export const SongContent: React.FC<SongContentProps> = ({
       <VStack className="flex flex-grow flex-col gap-2">
         <HStack className="flex items-baseline gap-2">
           <SongKey songKey={setSectionSong.key} />
-          <Link
-            href={`/${params.organization}/songs/${setSectionSong.song.id}`}
-            className="w-full"
-          >
-            <Text fontWeight="semibold" className="text-sm">
-              {setSectionSong.song.name}
-            </Text>
-          </Link>
+          <Text fontWeight="semibold" className="text-sm">
+            {setSectionSong.song.name}
+          </Text>
         </HStack>
         {setSectionSong.notes ? (
           <Text style="small" color="slate-700">


### PR DESCRIPTION
## Background
[SWY-77](https://linear.app/paranoid-android/issue/SWY-77/view-song-details)
This PR is to add the View Song Details action to the song actions menu. This will also remove the song details link from the song item title text.

Bonus: this PR fixes the song actions menu positioning to be aligned to end of the dropdown (instead of center), made the action icons slightly larger, and slightly darker.

![SWY-77__after](https://github.com/user-attachments/assets/78408ed1-21d4-4b39-bb08-2639f1c27505)


## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New Features**
  - Introduced a new menu option that lets users navigate to song details directly.
- **Enhancements**
  - Improved dropdown menu positioning for a smoother interaction.
  - Refined icon visuals with a larger size and updated color for enhanced clarity.
- **Refactor**
  - Simplified song display by replacing the interactive link with plain text for a more straightforward view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
1. Go to a set that has songs (or add songs to an empty set)
2. Click the song title in the song item card. It should no longer navigate you to the appropriate song details page.
3. Click the song action menu (...) and select View Song Details. You should be navigated to that song's details page.