### PR TITLE
[SWY-75] Add move song to adjacent section action

### DIFF
--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -90,3 +90,5 @@ const setSectionSongIdSchema = z.object({
 export const insertSetSectionSongSchema = createInsertSchema(setSectionSongs);
 export const deleteSetSectionSongSchema = setSectionSongIdSchema;
 export const swapSetSectionSongSchema = setSectionSongIdSchema;
+export const moveSetSectionSongToAdjacentSetSectionSchema =
+  setSectionSongIdSchema;

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -186,6 +186,12 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
 
   const isOnlySong = isFirstSong && isLastSong;
   const isInOnlySection = isInFirstSection && isInLastSection;
+  const isMutationPending =
+    swapSongWithPreviousMutation.isPending ||
+    swapSongWithNextMutation.isPending ||
+    moveSongToPreviousSectionMutation.isPending ||
+    moveSongToNextSectionMutation.isPending ||
+    deleteSetSectionSongMutation.isPending;
 
   return (
     <>
@@ -217,7 +223,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
               <SongActionMenuItem
                 icon="ArrowUp"
                 label="Move up"
-                disabled={isFirstSong}
+                disabled={isFirstSong || isMutationPending}
                 onClick={() => {
                   moveSong("up");
                   setIsSongActionMenuOpen(false);
@@ -226,7 +232,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
               <SongActionMenuItem
                 icon="ArrowDown"
                 label="Move down"
-                disabled={isLastSong}
+                disabled={isLastSong || isMutationPending}
                 onClick={() => {
                   moveSong("down");
                   setIsSongActionMenuOpen(false);
@@ -239,10 +245,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
               <SongActionMenuItem
                 icon="ArrowLineUp"
                 label="Move to previous section"
-                disabled={
-                  isInFirstSection ||
-                  moveSongToPreviousSectionMutation.isPending
-                }
+                disabled={isInFirstSection || isMutationPending}
                 onClick={() => {
                   moveSongToAdjacentSection("previous");
                   setIsSongActionMenuOpen(false);
@@ -251,9 +254,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
               <SongActionMenuItem
                 icon="ArrowLineDown"
                 label="Move to next section"
-                disabled={
-                  isInLastSection || moveSongToNextSectionMutation.isPending
-                }
+                disabled={isInLastSection || isMutationPending}
                 onClick={() => {
                   moveSongToAdjacentSection("next");
                   setIsSongActionMenuOpen(false);
@@ -265,6 +266,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
           <SongActionMenuItem
             icon="Trash"
             label="Remove from section"
+            disabled={isMutationPending}
             onClick={() => {
               setIsConfirmationDialogOpen(true);
               setIsSongActionMenuOpen(false);

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -83,8 +83,10 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
     api.setSectionSong.swapSongWithPrevious.useMutation();
   const swapSongWithNextMutation =
     api.setSectionSong.swapSongWithNext.useMutation();
-  const moveSongToAdjacentSectionMutation =
+  const moveSongToPreviousSectionMutation =
     api.setSectionSong.moveSongToPreviousSection.useMutation();
+  const moveSongToNextSectionMutation =
+    api.setSectionSong.moveSongToNextSection.useMutation();
 
   if (
     !!userQueryError ||
@@ -155,6 +157,12 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
 
   const moveSongToAdjacentSection = (direction: MoveSectionDirection) => {
     toast.loading(`Moving song to the ${direction} section...`);
+
+    const moveSongToAdjacentSectionMutation =
+      direction === "previous"
+        ? moveSongToPreviousSectionMutation
+        : moveSongToNextSectionMutation;
+
     moveSongToAdjacentSectionMutation.mutate(
       {
         organizationId: userMembership.organizationId,
@@ -233,7 +241,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
                 label="Move to previous section"
                 disabled={
                   isInFirstSection ||
-                  moveSongToAdjacentSectionMutation.isPending
+                  moveSongToPreviousSectionMutation.isPending
                 }
                 onClick={() => {
                   moveSongToAdjacentSection("previous");
@@ -243,7 +251,13 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
               <SongActionMenuItem
                 icon="ArrowLineDown"
                 label="Move to next section"
-                disabled={isInLastSection}
+                disabled={
+                  isInLastSection || moveSongToNextSectionMutation.isPending
+                }
+                onClick={() => {
+                  moveSongToAdjacentSection("next");
+                  setIsSongActionMenuOpen(false);
+                }}
               />
             </>
           )}

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -157,4 +157,10 @@ export const setSectionSongRouter = createTRPCRouter({
         "previous",
       );
     }),
+
+  moveSongToNextSection: organizationProcedure
+    .input(moveSetSectionSongToAdjacentSetSectionSchema)
+    .mutation(async ({ input }) => {
+      return await moveSongToAdjacentSection(input.setSectionSongId, "next");
+    }),
 });

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -2,6 +2,7 @@ import { type NewSetSectionSong } from "@lib/types";
 import {
   deleteSetSectionSongSchema,
   insertSetSectionSongSchema,
+  moveSetSectionSongToAdjacentSetSectionSchema,
   swapSetSectionSongSchema,
 } from "@lib/types/zod";
 import {
@@ -10,7 +11,7 @@ import {
   organizationProcedure,
 } from "@server/api/trpc";
 import { setSectionSongs } from "@server/db/schema";
-import { swapSongPosition } from "@server/mutations";
+import { moveSongToAdjacentSection, swapSongPosition } from "@server/mutations";
 import { TRPCError } from "@trpc/server";
 import { and, eq, gt, sql } from "drizzle-orm";
 
@@ -146,5 +147,14 @@ export const setSectionSongRouter = createTRPCRouter({
     .input(swapSetSectionSongSchema)
     .mutation(async ({ input }) => {
       return await swapSongPosition(input.setSectionSongId, "down");
+    }),
+
+  moveSongToPreviousSection: organizationProcedure
+    .input(moveSetSectionSongToAdjacentSetSectionSchema)
+    .mutation(async ({ input }) => {
+      return await moveSongToAdjacentSection(
+        input.setSectionSongId,
+        "previous",
+      );
     }),
 });

--- a/src/server/mutations.ts
+++ b/src/server/mutations.ts
@@ -156,7 +156,7 @@ export const moveSongToAdjacentSection = async (
       .where(eq(setSectionSongs.setSectionId, targetSetSection.id));
 
     const songPositionAfterMove =
-      (highestSongPositionInTargetSection?.maxPosition ?? 0) + 1;
+      (highestSongPositionInTargetSection?.maxPosition ?? -1) + 1;
 
     // Update the songs after the target song's position to fill in the hole
     await moveTransaction

--- a/src/server/mutations.ts
+++ b/src/server/mutations.ts
@@ -1,8 +1,9 @@
 "use server";
 
 import { db } from "@server/db";
-import { setSectionSongs } from "@server/db/schema";
-import { and, eq, sql } from "drizzle-orm";
+import { setSections, setSectionSongs } from "@server/db/schema";
+import { TRPCError } from "@trpc/server";
+import { and, eq, gt, sql } from "drizzle-orm";
 
 export type SwapSongDirection = "up" | "down";
 
@@ -96,6 +97,94 @@ export const swapSongPosition = async (
     return {
       success: true,
       message: `Successfully moved song ${setSectionSongToSwapId} ${direction}`,
+    };
+  });
+};
+
+export type MoveSectionDirection = "previous" | "next";
+
+export const moveSongToAdjacentSection = async (
+  setSectionSongId: string,
+  direction: MoveSectionDirection,
+) => {
+  return await db.transaction(async (moveTransaction) => {
+    const targetSetSectionSong =
+      await moveTransaction.query.setSectionSongs.findFirst({
+        where: eq(setSectionSongs.id, setSectionSongId),
+        with: {
+          setSection: true,
+        },
+      });
+
+    if (!targetSetSectionSong) {
+      console.error(
+        `🤖 - [setSectionSongs/moveSongToAdjacentSection/${direction}] - Could not find set section song ${setSectionSongId}`,
+      );
+
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Cannot find set section song",
+      });
+    }
+
+    // Find the set section to move the song to
+    const targetSetSection = await moveTransaction.query.setSections.findFirst({
+      where: and(
+        eq(setSections.setId, targetSetSectionSong.setSection.setId),
+        eq(
+          setSections.position,
+          targetSetSectionSong.setSection.position +
+            (direction === "next" ? 1 : -1),
+        ),
+      ),
+    });
+
+    if (!targetSetSection) {
+      console.error(
+        `🤖 - [setSectionSongs/moveSongToAdjacentSection/${direction}] - Could not find a set section ${direction} to ${targetSetSectionSong.setSectionId}`,
+      );
+
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Cannot find ${direction} set section`,
+      });
+    }
+
+    const [highestSongPositionInTargetSection] = await moveTransaction
+      .select({ maxPosition: sql<number>`COALESCE(MAX(position), -1)` })
+      .from(setSectionSongs)
+      .where(eq(setSectionSongs.setSectionId, targetSetSection.id));
+
+    const songPositionAfterMove =
+      (highestSongPositionInTargetSection?.maxPosition ?? 0) + 1;
+
+    // Update the songs after the target song's position to fill in the hole
+    await moveTransaction
+      .update(setSectionSongs)
+      .set({ position: sql`position - 1` })
+      .where(
+        and(
+          eq(setSectionSongs.setSectionId, targetSetSectionSong.setSectionId),
+          gt(setSectionSongs.position, targetSetSectionSong.position),
+        ),
+      );
+
+    await moveTransaction
+      .update(setSectionSongs)
+      .set({
+        setSectionId: targetSetSection.id,
+        position: songPositionAfterMove,
+      })
+      .where(eq(setSectionSongs.id, setSectionSongId));
+
+    console.info(
+      `🤖 - [setSectionSongs/moveSongToAdjacentSection/${direction}] - Successfully moved ${setSectionSongId} to ${direction} set section, ${targetSetSection.id}, with position ${songPositionAfterMove}`,
+    );
+
+    return {
+      success: true,
+      newSetSectionId: targetSetSection.id,
+      newPosition: songPositionAfterMove,
     };
   });
 };


### PR DESCRIPTION
## Background
This PR is to implement the "move to previous/next section" song actions to allow the user to move the song between sections of the same set.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New Features**
  - Enabled users to move songs between adjacent sections (previous/next) directly from the interface.
  - Enhanced validation and error feedback during song move operations.
  - Improved user experience with loading indicators and disabled controls while actions are processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
1. Go to a set that has multiple sections (or create one and fill it in appropriately)
2. Select a song's action menu.
  - If the song is in the set's only section, the "move to previous/next section" actions should not appear on the menu
  - If the song is in the first section, the "Move to previous section" action should be disabled
  - If the song is in the last section, the "Move to next section" action should be disabled
 3. Chose one of the move section actions and ensure that:
   - The song moves to the correct section
   - The song moves to be the last song in the target section
   - The songs that came after the selected song update their positions accordingly so there's no numbers skipped