### PR TITLE
[SWY-73] Adds replace song action

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -34,6 +34,7 @@ type CommandDialogProps = DialogProps & {
   hasDialogContentComponentStyling?: boolean;
   animated?: DialogContentProps["animated"];
   minimalPadding?: boolean;
+  className?: string;
 };
 const CommandDialog: React.FC<CommandDialogProps> = ({
   children,
@@ -43,6 +44,7 @@ const CommandDialog: React.FC<CommandDialogProps> = ({
   hasDialogContentComponentStyling,
   animated,
   minimalPadding,
+  className,
   ...props
 }) => {
   return (
@@ -65,6 +67,7 @@ const CommandDialog: React.FC<CommandDialogProps> = ({
             "md:mt-0": fixed,
             "md:top-[12%]": fixed,
           },
+          className,
         )}
       >
         <Command

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -92,3 +92,6 @@ export const deleteSetSectionSongSchema = setSectionSongIdSchema;
 export const swapSetSectionSongSchema = setSectionSongIdSchema;
 export const moveSetSectionSongToAdjacentSetSectionSchema =
   setSectionSongIdSchema;
+export const replaceSetSectionSongSongSchema = setSectionSongIdSchema.extend({
+  replacementSong: z.string().uuid(),
+});

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -28,6 +28,7 @@ import {
   type SwapSongDirection,
 } from "@server/mutations";
 import { useParams, useRouter } from "next/navigation";
+import { ReplaceSongDialog } from "@modules/songs/components/ReplaceSongDialog";
 
 type SongActionMenuProps = {
   /** set section song object */
@@ -65,6 +66,8 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
   const [isSongActionMenuOpen, setIsSongActionMenuOpen] =
     useState<boolean>(false);
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] =
+    useState<boolean>(false);
+  const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] =
     useState<boolean>(false);
 
   const params = useParams<{ organization: string }>();
@@ -216,7 +219,15 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
           />
           <DropdownMenuSeparator />
           <SongActionMenuItem icon="PianoKeys" label="Change key" />
-          <SongActionMenuItem icon="Swap" label="Replace song" />
+          <SongActionMenuItem
+            icon="Swap"
+            label="Replace song"
+            disabled={isMutationPending}
+            onClick={() => {
+              setIsSongActionMenuOpen(false);
+              setIsSongSearchDialogOpen(true);
+            }}
+          />
           <DropdownMenuSeparator />
           {!isOnlySong && (
             <>
@@ -298,6 +309,12 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      <ReplaceSongDialog
+        open={isSongSearchDialogOpen}
+        setOpen={setIsSongSearchDialogOpen}
+        currentSong={setSectionSong}
+        setId={setId}
+      />
     </>
   );
 };

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -62,7 +62,8 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
     null,
   );
 
-  const replaceSongMutation = api.setSectionSong.replaceSong.useMutation();
+  const replaceSongMutation =
+    api.setSectionSong.replaceSong.useMutation<Error>();
 
   if (!userData || !userMembership) {
     return null;

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -140,7 +140,7 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
         <SongSearch onSongSelect={handleSongSelect} />
       )}
       {dialogStep === "confirm" && !!selectedSong && (
-        <CommandList className="text-center">
+        <CommandList className="max-h-[calc(100dvh_-_24px)] text-center md:max-h-[calc(100dvh_-_12dvh_-_5dvh)]">
           <CommandGroup>
             <div className="grid grid-cols-[40px_1fr_40px] items-center">
               <Button
@@ -152,28 +152,39 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
               </Button>
               <DialogTitle className="text-center">Replace song</DialogTitle>
             </div>
-            <DialogDescription className="mt-6 flex flex-col gap-6">
-              <VStack className="gap-2 text-slate-900">
-                <HStack className="items-center gap-4 rounded bg-red-100 px-4 py-1 text-slate-600">
-                  <Text asElement="span">-</Text>
-                  <Text asElement="span" className="font-medium">
-                    {currentSong.song.name}
-                  </Text>
-                </HStack>
-                <ArrowDown className="self-center" />
-                <HStack className="gap-4 rounded bg-green-100 px-4 py-1">
-                  <Text asElement="span">+</Text>
-                  <Text asElement="span" className="font-medium">
-                    {selectedSong.name}
-                  </Text>
+            <DialogDescription className="mt-2" asChild>
+              <VStack className="gap-8 px-4">
+                <Text className="text-slate-900">
+                  Are you sure you want to replace the current song with the
+                  selected one?
+                </Text>
+                <div className="grid grid-cols-[1fr_16px_1fr] gap-2">
+                  <Text className="text-slate-500">Current song</Text>
+                  <Text className="col-start-3 text-slate-900">New song</Text>
+                  <div className="flex h-full items-center gap-4 rounded border border-slate-200 px-2 py-1 text-slate-500 md:px-4 md:py-2">
+                    {/* <Text asElement="span">-</Text> */}
+                    <Text asElement="span" className="font-medium">
+                      {currentSong.song.name}
+                    </Text>
+                  </div>
+                  <ArrowRight
+                    className="self-center text-slate-900"
+                    size={16}
+                  />
+                  <div className="flex h-full items-center gap-4 rounded border border-slate-400 px-2 py-1 text-slate-900 md:px-4 md:py-2">
+                    {/* <Text asElement="span">+</Text> */}
+                    <Text asElement="span" className="font-medium">
+                      {selectedSong.name}
+                    </Text>
+                  </div>
+                </div>
+                <HStack className="justify-end gap-2">
+                  <Button variant="outline" onClick={handleCloseDialog}>
+                    Cancel
+                  </Button>
+                  <Button onClick={handleOnConfirm}>Replace song</Button>
                 </HStack>
               </VStack>
-              <HStack className="justify-center gap-2">
-                <Button variant="outline" onClick={handleCloseDialog}>
-                  Cancel
-                </Button>
-                <Button onClick={handleOnConfirm}>Replace song</Button>
-              </HStack>
             </DialogDescription>
           </CommandGroup>
         </CommandList>

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "@modules/songs/components/SongSearch";
 import { type SetSectionSongWithSongData } from "@lib/types";
 import { Button } from "@components/ui/button";
-import { ArrowDown, ArrowRight, CaretLeft } from "@phosphor-icons/react";
+import { ArrowRight, CaretLeft } from "@phosphor-icons/react";
 import { DialogDescription, DialogTitle } from "@components/ui/dialog";
 import { HStack } from "@components/HStack";
 import { api } from "@/trpc/react";
@@ -46,11 +46,11 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
   setOpen,
   onSongSelect,
   currentSong,
+  setId,
 }) => {
   const apiUtils = api.useUtils();
   const {
     data: userData,
-    error: userQueryError,
     isLoading: userQueryLoading,
     isAuthLoaded,
   } = useUserQuery();
@@ -69,11 +69,17 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
   }
 
   if (!isAuthLoaded || userQueryLoading) {
-    return <Text>Loading...</Text>;
+    return (
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <HStack className="items-center justify-center p-4">
+          <Text>Loading...</Text>
+        </HStack>
+      </CommandDialog>
+    );
   }
 
   const handleSongSelect = (song?: SongSearchResult) => {
-    if (!!song) {
+    if (song) {
       setSelectedSong(song);
       setDialogStep("confirm");
       onSongSelect?.(song);
@@ -105,7 +111,7 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
             toast.dismiss();
             toast.success("Song replaced");
             handleCloseDialog();
-            await apiUtils.set.get.invalidate({});
+            await apiUtils.set.get.invalidate({ setId });
           },
 
           async onError() {
@@ -162,7 +168,6 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
                   <Text className="text-slate-500">Current song</Text>
                   <Text className="col-start-3 text-slate-900">New song</Text>
                   <div className="flex h-full items-center gap-4 rounded border border-slate-200 px-2 py-1 text-slate-500 md:px-4 md:py-2">
-                    {/* <Text asElement="span">-</Text> */}
                     <Text asElement="span" className="font-medium">
                       {currentSong.song.name}
                     </Text>
@@ -172,7 +177,6 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
                     size={16}
                   />
                   <div className="flex h-full items-center gap-4 rounded border border-slate-400 px-2 py-1 text-slate-900 md:px-4 md:py-2">
-                    {/* <Text asElement="span">+</Text> */}
                     <Text asElement="span" className="font-medium">
                       {selectedSong.name}
                     </Text>

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import {
+  CommandDialog,
+  CommandGroup,
+  CommandList,
+} from "@components/ui/command";
+import { Text } from "@components/Text";
+import { useState } from "react";
+import {
+  SongSearch,
+  type SongSearchResult,
+} from "@modules/songs/components/SongSearch";
+import { type SetSectionSongWithSongData } from "@lib/types";
+import { Button } from "@components/ui/button";
+import { ArrowDown, ArrowRight, CaretLeft } from "@phosphor-icons/react";
+import { DialogDescription, DialogTitle } from "@components/ui/dialog";
+import { HStack } from "@components/HStack";
+import { api } from "@/trpc/react";
+import { useUserQuery } from "@modules/users/api/queries";
+import { toast } from "sonner";
+import { cn } from "@lib/utils";
+import { VStack } from "@components/VStack";
+
+export type ReplaceSongDialogSteps = "search" | "confirm";
+
+type ReplaceSongDialogProps = {
+  /** is the dialog open? */
+  open: boolean;
+
+  /** callback to set the open state of the dialog */
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /** event callback when a song is selected during the search step */
+  onSongSelect?: (selectedSong?: SongSearchResult) => void;
+
+  /** set section song object */
+  currentSong: SetSectionSongWithSongData;
+
+  /** the ID of the set the set section song is attached to */
+  setId: string;
+};
+
+export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
+  open,
+  setOpen,
+  onSongSelect,
+  currentSong,
+}) => {
+  const apiUtils = api.useUtils();
+  const {
+    data: userData,
+    error: userQueryError,
+    isLoading: userQueryLoading,
+    isAuthLoaded,
+  } = useUserQuery();
+  const userMembership = userData?.memberships[0];
+
+  const [dialogStep, setDialogStep] =
+    useState<ReplaceSongDialogSteps>("search");
+  const [selectedSong, setSelectedSong] = useState<SongSearchResult | null>(
+    null,
+  );
+
+  const replaceSongMutation = api.setSectionSong.replaceSong.useMutation();
+
+  if (!userData || !userMembership) {
+    return null;
+  }
+
+  if (!isAuthLoaded || userQueryLoading) {
+    return <Text>Loading...</Text>;
+  }
+
+  const handleSongSelect = (song?: SongSearchResult) => {
+    if (!!song) {
+      setSelectedSong(song);
+      setDialogStep("confirm");
+      onSongSelect?.(song);
+    }
+  };
+
+  const handleCloseDialog = () => {
+    setOpen(false);
+    setSelectedSong(null);
+  };
+
+  const handleOnConfirm = () => {
+    toast.loading("Replacing song...");
+    if (selectedSong) {
+      if (selectedSong.songId === currentSong.songId) {
+        toast.dismiss();
+      }
+
+      replaceSongMutation.mutate(
+        {
+          organizationId: userMembership.organizationId,
+          setSectionSongId: currentSong.id,
+          replacementSong: selectedSong?.songId,
+        },
+        {
+          async onSuccess() {
+            toast.dismiss();
+            toast.success("Song replaced");
+            await apiUtils.set.get.invalidate({});
+          },
+
+          async onError() {
+            toast.dismiss();
+            toast.error("Song could not be replaced");
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={(open) => {
+        setOpen(open);
+
+        if (!open) {
+          setSelectedSong(null);
+        }
+
+        setDialogStep("search");
+      }}
+      shouldFilter={false}
+      fixed
+      hasDialogContentComponentStyling={dialogStep === "confirm"}
+      animated={dialogStep !== "confirm"}
+      minimalPadding
+      className={cn([dialogStep === "confirm" && "max-w-lg"])}
+    >
+      {dialogStep === "search" && (
+        <SongSearch onSongSelect={handleSongSelect} />
+      )}
+      {dialogStep === "confirm" && !!selectedSong && (
+        <CommandList className="text-center">
+          <CommandGroup>
+            <div className="grid grid-cols-[40px_1fr_40px] items-center">
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={() => setDialogStep("search")}
+              >
+                <CaretLeft />
+              </Button>
+              <DialogTitle className="text-center">Replace song</DialogTitle>
+            </div>
+            <DialogDescription className="mt-6 flex flex-col gap-6">
+              <VStack className="gap-2 text-slate-900">
+                <HStack className="items-center gap-4 rounded bg-red-100 px-4 py-1 text-slate-600">
+                  <Text asElement="span">-</Text>
+                  <Text asElement="span" className="font-medium">
+                    {currentSong.song.name}
+                  </Text>
+                </HStack>
+                <ArrowDown className="self-center" />
+                <HStack className="gap-4 rounded bg-green-100 px-4 py-1">
+                  <Text asElement="span">+</Text>
+                  <Text asElement="span" className="font-medium">
+                    {selectedSong.name}
+                  </Text>
+                </HStack>
+              </VStack>
+              <HStack className="justify-center gap-2">
+                <Button variant="outline" onClick={handleCloseDialog}>
+                  Cancel
+                </Button>
+                <Button onClick={handleOnConfirm}>Replace song</Button>
+              </HStack>
+            </DialogDescription>
+          </CommandGroup>
+        </CommandList>
+      )}
+    </CommandDialog>
+  );
+};

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -83,6 +83,7 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
   const handleCloseDialog = () => {
     setOpen(false);
     setSelectedSong(null);
+    setDialogStep("search");
   };
 
   const handleOnConfirm = () => {
@@ -102,6 +103,7 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
           async onSuccess() {
             toast.dismiss();
             toast.success("Song replaced");
+            handleCloseDialog();
             await apiUtils.set.get.invalidate({});
           },
 

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -87,12 +87,13 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
   };
 
   const handleOnConfirm = () => {
-    toast.loading("Replacing song...");
     if (selectedSong) {
       if (selectedSong.songId === currentSong.songId) {
-        toast.dismiss();
+        toast.error("Cannot replace a song with itself");
+        return;
       }
 
+      toast.loading("Replacing song...");
       replaceSongMutation.mutate(
         {
           organizationId: userMembership.organizationId,

--- a/src/modules/songs/components/ReplaceSongDialog/index.ts
+++ b/src/modules/songs/components/ReplaceSongDialog/index.ts
@@ -1,0 +1,1 @@
+export * from "./ReplaceSongDialog";

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -176,6 +176,13 @@ export const setSectionSongRouter = createTRPCRouter({
         const setSectionSong =
           await replaceTransaction.query.setSectionSongs.findFirst({
             where: eq(setSectionSongs.id, input.setSectionSongId),
+            with: {
+              setSection: {
+                with: {
+                  set: true,
+                },
+              },
+            },
           });
 
         if (!setSectionSong) {
@@ -186,6 +193,20 @@ export const setSectionSongRouter = createTRPCRouter({
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "Cannot find the set section song",
+          });
+        }
+
+        if (
+          setSectionSong.setSection.set.organizationId !==
+          ctx.user.membership.organizationId
+        ) {
+          console.error(
+            `🤖 - [setSectionSong/replaceSong] - could not find set section song ${input.setSectionSongId}`,
+          );
+
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Not authorized to replace this song",
           });
         }
 

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -201,7 +201,7 @@ export const setSectionSongRouter = createTRPCRouter({
           ctx.user.membership.organizationId
         ) {
           console.error(
-            `🤖 - [setSectionSong/replaceSong] - could not find set section song ${input.setSectionSongId}`,
+            `🤖 - [setSectionSong/replaceSong] - User ${ctx.user.id} not authorized to replace song on ${setSectionSong.id}`,
           );
 
           throw new TRPCError({
@@ -229,6 +229,10 @@ export const setSectionSongRouter = createTRPCRouter({
           replacementSong.organizationId !==
           setSectionSong.setSection.set.organizationId
         ) {
+          console.error(
+            `🤖 - [setSectionSong/replaceSong] - Cannot update setSectionSong ${setSectionSong.id} with a song from a different organization: ${replacementSong.id}`,
+          );
+
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "Cannot replace with a song from a different organization",

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -225,6 +225,16 @@ export const setSectionSongRouter = createTRPCRouter({
           });
         }
 
+        if (
+          replacementSong.organizationId !==
+          setSectionSong.setSection.set.organizationId
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Cannot replace with a song from a different organization",
+          });
+        }
+
         await replaceTransaction
           .update(setSectionSongs)
           .set({ songId: input.replacementSong })


### PR DESCRIPTION
## Background
This PR is to implement the replace song action. This allows the user to replace a song in a set in place (the new song goes right where the old one was)

| Mobile | Desktop |
| ------- | -------- |
| ![SWY-73__after--mobile](https://github.com/user-attachments/assets/83554f14-dfb4-45ea-8173-790d585ed579) | ![SWY-73__after--desktop](https://github.com/user-attachments/assets/9fc72bf6-3b79-40ae-a70c-ec34c12cdf71) |

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New Features**
	- Enhanced dialog styling by allowing custom CSS classes for improved visual adaptability.
	- Introduced an interactive song replacement workflow, enabling users to search for and confirm a replacement song within set sections.
	- Added a new mutation for replacing songs in set sections, enhancing backend support for song replacement actions with reliable error handling.
	- New schema for specifying a replacement song alongside existing song IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
1. Go to a set that has a song (or add a song to an empty set).
2. Open that song's action menu and select the "Replace song" action.
3. Search for a song to replace the current song with and select one.
4. Confirm replacement in the confirmation dialog.
5. The set should be updated to reflect the song has been successfully updated.