### PR TITLE
[SWY-79] Add change set section type action

### DIFF
--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -31,7 +31,7 @@ export type ComboboxOption = {
   label: string;
 };
 
-type ComboboxProps = {
+export type ComboboxProps = {
   placeholder: string;
   hasSearch?: boolean;
   searchPlaceholder?: string;

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -81,6 +81,15 @@ export const insertSetSectionSchema = createInsertSchema(setSections);
 
 export const getSectionsForSet = z.object({ setId: z.string().uuid() });
 
+export const updateSetSectionType = insertSetSectionSchema
+  .pick({
+    id: true,
+    sectionTypeId: true,
+  })
+  .required({
+    id: true,
+  });
+
 /**
  * Set section songs schemas
  */

--- a/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
+++ b/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
@@ -43,7 +43,7 @@ type SetSectionActionMenuProps = {
   isInLastSection: SongItemWithActionsMenuProps["isInLastSection"];
 
   /** call back to set if the song item is in edit mode */
-  // setIsEditingDetails: Dispatch<SetStateAction<boolean>>;
+  setIsEditingSectionType: Dispatch<SetStateAction<boolean>>;
 };
 
 export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
@@ -54,7 +54,7 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
   // setId,
   isInFirstSection,
   isInLastSection,
-  // setIsEditingDetails,
+  setIsEditingSectionType,
 }) => {
   const apiUtils = api.useUtils();
   const [isActionMenuOpen, setIsActionMenuOpen] = useState<boolean>(false);
@@ -89,7 +89,11 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
   return (
     <>
       <ActionMenu isOpen={isActionMenuOpen} setIsOpen={setIsActionMenuOpen}>
-        <ActionMenuItem icon="Swap" label="Change section type" />
+        <ActionMenuItem
+          icon="Swap"
+          label="Change section type"
+          onClick={() => setIsEditingSectionType(true)}
+        />
         <DropdownMenuSeparator />
         {!isInOnlySection && (
           <>

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -19,10 +19,11 @@ import { cn } from "@lib/utils";
 import { SongItem } from "@modules/SetListCard";
 import { SetSectionActionMenu } from "@modules/SetListCard/components/SetSectionActionMenu";
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { useUserQuery } from "@modules/users/api/queries";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
 import { redirect } from "next/navigation";
-import { useEffect, useState, type FC } from "react";
+import { useState, type FC } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { toast } from "sonner";
 import { useMediaQuery } from "usehooks-ts";
@@ -70,9 +71,6 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
 
   const [isEditingSectionType, setIsEditingSectionType] =
     useState<boolean>(false);
-  const [setSectionTypesOptions, setSetSectionTypesOptions] = useState<
-    ComboboxOption[]
-  >([]);
   const [isAddSectionComboboxOpen, setIsAddSectionComboboxOpen] =
     useState<boolean>(false);
 
@@ -100,33 +98,9 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   }
 
   const {
-    data: setSectionTypesData,
-    error: setSectionTypesQueryError,
+    options: setSectionTypesOptions,
     isLoading: isSetSectionTypesQueryLoading,
-  } = api.setSectionType.getTypes.useQuery(
-    { organizationId: userMembership.organizationId },
-    { enabled: !!userMembership },
-  );
-
-  useEffect(() => {
-    if (
-      !isSetSectionTypesQueryLoading &&
-      !setSectionTypesQueryError &&
-      setSectionTypesData
-    ) {
-      const setSectionTypes: ComboboxOption[] =
-        setSectionTypesData?.map((setSectionType) => ({
-          id: setSectionType.id,
-          label: setSectionType.name,
-        })) ?? [];
-
-      setSetSectionTypesOptions(setSectionTypes);
-    }
-  }, [
-    isSetSectionTypesQueryLoading,
-    setSectionTypesData,
-    setSectionTypesQueryError,
-  ]);
+  } = useSectionTypesOptions(userMembership.organizationId);
 
   const handleUpdateSetSection: SubmitHandler<
     UpdateSetSectionFormFields
@@ -184,57 +158,54 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
                 </Text>
               )}
               {isEditingSectionType && (
-                <>
-                  <FormField
-                    control={updateSetSectionForm.control}
-                    name="sectionTypeId"
-                    render={({ field }) => {
-                      const matchingSetSectionType =
-                        setSectionTypesOptions.find(
-                          (setSectionType) => setSectionType.id === field.value,
-                        );
+                <FormField
+                  control={updateSetSectionForm.control}
+                  name="sectionTypeId"
+                  render={({ field }) => {
+                    const matchingSetSectionType = setSectionTypesOptions.find(
+                      (setSectionType) => setSectionType.id === field.value,
+                    );
 
-                      const value: ComboboxOption = {
-                        id: matchingSetSectionType?.id ?? "",
-                        label: matchingSetSectionType?.label ?? "",
-                      };
+                    const value: ComboboxOption = {
+                      id: matchingSetSectionType?.id ?? "",
+                      label: matchingSetSectionType?.label ?? "",
+                    };
 
-                      return (
-                        <FormItem>
-                          <VStack className="gap-2">
-                            <FormLabel>
-                              <Text
-                                asElement="h3"
-                                style="header-medium-semibold"
-                                className="flex-wrap"
-                              >
-                                Section type
-                              </Text>
-                            </FormLabel>
-                            <FormControl>
-                              <SetSectionTypeCombobox
-                                options={setSectionTypesOptions}
-                                value={value}
-                                onChange={(selectedValue) => {
-                                  field.onChange(selectedValue?.id);
-                                }}
-                                open={isAddSectionComboboxOpen}
-                                setOpen={setIsAddSectionComboboxOpen}
-                                loading={isSetSectionTypesListLoading}
-                                disabled={isSetSectionTypesQueryLoading}
-                                textStyles={cn("text-slate-700", textSize)}
-                                organizationId={userMembership.organizationId}
-                                onCreateSuccess={(newSectionType) =>
-                                  field.onChange(newSectionType.id)
-                                }
-                              />
-                            </FormControl>
-                          </VStack>
-                        </FormItem>
-                      );
-                    }}
-                  />
-                </>
+                    return (
+                      <FormItem>
+                        <VStack className="gap-2">
+                          <FormLabel>
+                            <Text
+                              asElement="h3"
+                              style="header-medium-semibold"
+                              className="flex-wrap"
+                            >
+                              Section type
+                            </Text>
+                          </FormLabel>
+                          <FormControl>
+                            <SetSectionTypeCombobox
+                              options={setSectionTypesOptions}
+                              value={value}
+                              onChange={(selectedValue) => {
+                                field.onChange(selectedValue?.id);
+                              }}
+                              open={isAddSectionComboboxOpen}
+                              setOpen={setIsAddSectionComboboxOpen}
+                              loading={isSetSectionTypesListLoading}
+                              disabled={isSetSectionTypesQueryLoading}
+                              textStyles={cn("text-slate-700", textSize)}
+                              organizationId={userMembership.organizationId}
+                              onCreateSuccess={(newSectionType) =>
+                                field.onChange(newSectionType.id)
+                              }
+                            />
+                          </FormControl>
+                        </VStack>
+                      </FormItem>
+                    );
+                  }}
+                />
               )}
               <HStack className="flex items-start gap-2">
                 {!isEditingSectionType && (

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -61,7 +61,8 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   sectionStartIndex,
   withActionsMenu,
 }) => {
-  const { id, type, songs, setId, position } = section;
+  const { id, type, songs, setId, position, sectionTypeId } = section;
+
   const isFirstSection = position === 0;
   const isLastSection = position === setSectionsLength - 1;
 
@@ -81,7 +82,7 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   const updateSetSectionForm = useForm<UpdateSetSectionFormFields>({
     resolver: zodResolver(updateSetSectionSchema),
     defaultValues: {
-      sectionTypeId: section.sectionTypeId,
+      sectionTypeId,
     },
   });
 
@@ -342,7 +343,9 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
                       size="sm"
                       variant="outline"
                       onClick={() => {
-                        resetForm();
+                        resetForm({
+                          sectionTypeId,
+                        });
                         setIsEditingSectionType(false);
                       }}
                     >

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -147,6 +147,7 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
             setId: section.setId,
             organizationId: userMembership.organizationId,
           });
+          setIsEditingSectionType(false);
         },
 
         async onError(updateError) {
@@ -155,9 +156,6 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
         },
       },
     );
-
-    toast.dismiss();
-    setIsEditingSectionType(false);
   };
 
   const shouldUpdateSectionButtonBeDisabled =

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -147,8 +147,8 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
           <form
             onSubmit={updateSetSectionForm.handleSubmit(handleUpdateSetSection)}
           >
-            <HStack className="items-baseline justify-between gap-4 lg:gap-16">
-              {!isEditingSectionType && (
+            {!isEditingSectionType && (
+              <HStack className="flex-wrap items-baseline justify-between gap-4 lg:gap-16">
                 <Text
                   asElement="h3"
                   style="header-medium-semibold"
@@ -156,8 +156,25 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
                 >
                   {type.name}
                 </Text>
-              )}
-              {isEditingSectionType && (
+                <HStack className="flex items-start gap-2">
+                  <Button size="sm" variant="outline">
+                    <Plus className="text-slate-900" size={16} />
+                    <span className="hidden sm:inline">Add song</span>
+                  </Button>
+                  {withActionsMenu && (
+                    <SetSectionActionMenu
+                      setSection={section}
+                      setSectionsLength={setSectionsLength}
+                      isInFirstSection={isFirstSection}
+                      isInLastSection={isLastSection}
+                      setIsEditingSectionType={setIsEditingSectionType}
+                    />
+                  )}
+                </HStack>
+              </HStack>
+            )}
+            {isEditingSectionType && (
+              <VStack className="gap-4">
                 <FormField
                   control={updateSetSectionForm.control}
                   name="sectionTypeId"
@@ -206,51 +223,30 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
                     );
                   }}
                 />
-              )}
-              <HStack className="flex items-start gap-2">
-                {!isEditingSectionType && (
-                  <>
-                    <Button size="sm" variant="outline">
-                      <Plus className="text-slate-900" size={16} />
-                      <span className="hidden sm:inline">Add song</span>
-                    </Button>
-                    {withActionsMenu && (
-                      <SetSectionActionMenu
-                        setSection={section}
-                        setSectionsLength={setSectionsLength}
-                        isInFirstSection={isFirstSection}
-                        isInLastSection={isLastSection}
-                        setIsEditingSectionType={setIsEditingSectionType}
-                      />
-                    )}
-                  </>
-                )}
-                {isEditingSectionType && (
-                  <>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => {
-                        resetForm({
-                          sectionTypeId,
-                        });
-                        setIsEditingSectionType(false);
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      size="sm"
-                      type="submit"
-                      disabled={shouldUpdateSectionButtonBeDisabled}
-                      isLoading={isSubmitting}
-                    >
-                      Update section
-                    </Button>
-                  </>
-                )}
-              </HStack>
-            </HStack>
+                <HStack className="flex items-start gap-2 self-end">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      resetForm({
+                        sectionTypeId,
+                      });
+                      setIsEditingSectionType(false);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    type="submit"
+                    disabled={shouldUpdateSectionButtonBeDisabled}
+                    isLoading={isSubmitting}
+                  >
+                    Update section
+                  </Button>
+                </HStack>
+              </VStack>
+            )}
           </form>
         </Form>
         <hr className="bg-slate-100" />

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -1,4 +1,4 @@
-import { type FC } from "react";
+import { useEffect, useState, type FC } from "react";
 import { type SetSectionWithSongs } from "@lib/types";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
 import { SongItem } from "@modules/SetListCard";
@@ -7,6 +7,33 @@ import { Button } from "@components/ui/button";
 import { VStack } from "@components/VStack";
 import { HStack } from "@components/HStack";
 import { SetSectionActionMenu } from "@modules/SetListCard/components/SetSectionActionMenu";
+import { insertSetSectionSchema } from "@lib/types/zod";
+import { type z } from "zod";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@components/ui/form";
+import { Combobox, type ComboboxOption } from "@components/ui/combobox";
+import { CommandGroup } from "@components/ui/command";
+import { Input } from "@components/ui/input";
+import { cn } from "@lib/utils";
+import { api } from "@/trpc/react";
+import { useUserQuery } from "@modules/users/api/queries";
+import { useMediaQuery } from "usehooks-ts";
+import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
+import { redirect } from "next/navigation";
+
+const updateSetSectionSchema = insertSetSectionSchema.pick({
+  sectionTypeId: true,
+});
+
+export type UpdateSetSectionFormFields = z.infer<typeof updateSetSectionSchema>;
 
 export type SetSectionCardProps = {
   /** The section data including songs, type, and position */
@@ -38,38 +65,303 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   const isFirstSection = position === 0;
   const isLastSection = position === setSectionsLength - 1;
 
+  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const textSize = isDesktop ? "text-base" : "text-xs";
+
+  const [isEditingSectionType, setIsEditingSectionType] =
+    useState<boolean>(false);
+  const [setSectionTypesOptions, setSetSectionTypesOptions] = useState<
+    ComboboxOption[]
+  >([]);
+  const [isAddSectionComboboxOpen, setIsAddSectionComboboxOpen] =
+    useState<boolean>(false);
+  const [newSetSectionInputValue, setNewSetSectionInputValue] =
+    useState<string>("");
+
+  const updateSetSectionForm = useForm<UpdateSetSectionFormFields>({
+    resolver: zodResolver(updateSetSectionSchema),
+    defaultValues: {
+      sectionTypeId: section.sectionTypeId,
+    },
+  });
+
+  const {
+    formState: { isDirty, isSubmitting, isValid },
+    reset: resetForm,
+  } = updateSetSectionForm;
+
+  const createSetSectionTypeMutation = api.setSectionType.create.useMutation();
+  const changeSetSectionTypeMutation = api.setSection.changeType.useMutation();
+  const apiUtils = api.useUtils();
+
+  const { data: userData, isLoading: isUserQueryLoading } = useUserQuery();
+
+  const userMembership = userData?.memberships[0];
+
+  if (!userMembership) {
+    redirect("/sign-in");
+  }
+
+  const {
+    data: setSectionTypesData,
+    error: setSectionTypesQueryError,
+    isLoading: isSetSectionTypesQueryLoading,
+  } = api.setSectionType.getTypes.useQuery(
+    { organizationId: userMembership.organizationId },
+    { enabled: !!userMembership },
+  );
+
+  useEffect(() => {
+    if (
+      !isSetSectionTypesQueryLoading &&
+      !setSectionTypesQueryError &&
+      setSectionTypesData
+    ) {
+      const setSectionTypes: ComboboxOption[] =
+        setSectionTypesData?.map((setSectionType) => ({
+          id: setSectionType.id,
+          label: setSectionType.name,
+        })) ?? [];
+
+      setSetSectionTypesOptions(setSectionTypes);
+    }
+  }, [
+    isSetSectionTypesQueryLoading,
+    setSectionTypesData,
+    setSectionTypesQueryError,
+  ]);
+
+  const handleCreateNewSetSectionType = async (
+    fieldOnChange: (setSectionTypeId: string) => void,
+  ) => {
+    const trimmedInput = newSetSectionInputValue.trim();
+
+    await createSetSectionTypeMutation.mutateAsync(
+      { name: trimmedInput, organizationId: userMembership.organizationId },
+      {
+        async onSuccess(createSetSectionTypeMutationResult) {
+          const [newSetSectionType] = createSetSectionTypeMutationResult;
+
+          if (newSetSectionType) {
+            toast.success(`${newSetSectionType.name} set section type created`);
+
+            console.log(
+              "🤖 [createSetSectionTypeMutation/onSuccess] ~ mutation result:",
+              createSetSectionTypeMutationResult,
+            );
+
+            fieldOnChange(newSetSectionType.id);
+
+            await apiUtils.setSectionType.getTypes.invalidate({
+              organizationId: userMembership.organizationId,
+            });
+          }
+        },
+      },
+    );
+
+    setIsAddSectionComboboxOpen(false);
+    setNewSetSectionInputValue("");
+  };
+
+  const handleUpdateSetSection: SubmitHandler<
+    UpdateSetSectionFormFields
+  > = async (formValues: UpdateSetSectionFormFields) => {
+    toast.loading("Updating section...");
+
+    changeSetSectionTypeMutation.mutate(
+      {
+        id: section.id,
+        sectionTypeId: formValues.sectionTypeId,
+        organizationId: userMembership.organizationId,
+      },
+      {
+        async onSuccess() {
+          toast.dismiss();
+          toast.success("Updated section");
+          await apiUtils.set.get.invalidate({
+            setId: section.setId,
+            organizationId: userMembership.organizationId,
+          });
+        },
+
+        async onError(updateError) {
+          toast.dismiss();
+          toast.error(`Could not update section: ${updateError.message}`);
+        },
+      },
+    );
+
+    toast.dismiss();
+    setIsEditingSectionType(false);
+  };
+
+  const shouldUpdateSectionButtonBeDisabled =
+    !isDirty || !isValid || isSubmitting;
+  const isSetSectionTypesListLoading =
+    isUserQueryLoading || isSetSectionTypesQueryLoading;
+
   return (
     <VStack
       key={id}
       className="gap-4 rounded-lg border p-4 shadow lg:gap-8 lg:p-8"
     >
       <VStack as="header" className="gap-4 lg:gap-6">
-        <HStack className="items-center justify-between gap-4 lg:gap-16">
-          <Text
-            asElement="h3"
-            style="header-medium-semibold"
-            className="flex-wrap text-xl"
+        <Form {...updateSetSectionForm}>
+          <form
+            onSubmit={updateSetSectionForm.handleSubmit(handleUpdateSetSection)}
           >
-            {type.name}
-          </Text>
-          <HStack className="flex gap-2 self-center">
-            <Button size="sm" variant="outline">
-              <Plus className="text-slate-900" size={16} />
-              <span className="hidden sm:inline">Add song</span>
-            </Button>
-            {withActionsMenu && (
-              <SetSectionActionMenu
-                setSection={section}
-                setSectionsLength={setSectionsLength}
-                isInFirstSection={isFirstSection}
-                isInLastSection={isLastSection}
-              />
-            )}
-            {/* <Button size="sm" variant="ghost">
-              <DotsThree className="text-slate-900" size={16} />
-            </Button> */}
-          </HStack>
-        </HStack>
+            <HStack className="items-baseline justify-between gap-4 lg:gap-16">
+              {!isEditingSectionType && (
+                <Text
+                  asElement="h3"
+                  style="header-medium-semibold"
+                  className="flex-wrap text-xl"
+                >
+                  {type.name}
+                </Text>
+              )}
+              {isEditingSectionType && (
+                <>
+                  <FormField
+                    control={updateSetSectionForm.control}
+                    name="sectionTypeId"
+                    render={({ field }) => {
+                      const matchingSetSectionType =
+                        setSectionTypesOptions.find(
+                          (setSectionType) => setSectionType.id === field.value,
+                        );
+
+                      const value: ComboboxOption = {
+                        id: matchingSetSectionType?.id ?? "",
+                        label: matchingSetSectionType?.label ?? "",
+                      };
+
+                      return (
+                        <FormItem>
+                          <VStack className="gap-2">
+                            <FormLabel
+                            // onClick={() =>
+                            //   setIsAddSectionComboboxOpen(
+                            //     (isCurrentlyOpen) => !isCurrentlyOpen,
+                            //   )
+                            // }
+                            >
+                              <Text
+                                asElement="h3"
+                                style="header-medium-semibold"
+                                className="flex-wrap"
+                              >
+                                Section type
+                              </Text>
+                            </FormLabel>
+                            <FormControl>
+                              <Combobox
+                                placeholder="Add a set section"
+                                options={setSectionTypesOptions}
+                                value={value}
+                                onChange={(selectedValue) => {
+                                  // setNewSetSectionType(selectedValue);
+                                  field.onChange(selectedValue?.id);
+                                }}
+                                open={isAddSectionComboboxOpen}
+                                setOpen={setIsAddSectionComboboxOpen}
+                                loading={isSetSectionTypesListLoading}
+                                disabled={isSetSectionTypesQueryLoading}
+                                textStyles={cn("text-slate-700", textSize)}
+                              >
+                                <CommandGroup heading="Create new section type">
+                                  <div
+                                    className={cn(
+                                      "flex gap-2",
+                                      "relative cursor-default select-none items-center gap-2 rounded-sm px-2 py-2 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+                                    )}
+                                  >
+                                    <Input
+                                      size="small"
+                                      className="flex-1"
+                                      value={newSetSectionInputValue}
+                                      onChange={(changeEvent) =>
+                                        setNewSetSectionInputValue(
+                                          changeEvent.target.value,
+                                        )
+                                      }
+                                    />
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="flex-grow-0"
+                                      onClick={() =>
+                                        handleCreateNewSetSectionType(
+                                          field.onChange,
+                                        )
+                                      }
+                                      isLoading={
+                                        createSetSectionTypeMutation.isPending
+                                      }
+                                      disabled={
+                                        newSetSectionInputValue === "" ||
+                                        createSetSectionTypeMutation.isPending
+                                      }
+                                    >
+                                      <Plus />
+                                      Create
+                                    </Button>
+                                  </div>
+                                </CommandGroup>
+                              </Combobox>
+                            </FormControl>
+                          </VStack>
+                        </FormItem>
+                      );
+                    }}
+                  />
+                </>
+              )}
+              <HStack className="flex items-start gap-2">
+                {!isEditingSectionType && (
+                  <>
+                    <Button size="sm" variant="outline">
+                      <Plus className="text-slate-900" size={16} />
+                      <span className="hidden sm:inline">Add song</span>
+                    </Button>
+                    {withActionsMenu && (
+                      <SetSectionActionMenu
+                        setSection={section}
+                        setSectionsLength={setSectionsLength}
+                        isInFirstSection={isFirstSection}
+                        isInLastSection={isLastSection}
+                        setIsEditingSectionType={setIsEditingSectionType}
+                      />
+                    )}
+                  </>
+                )}
+                {isEditingSectionType && (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        resetForm();
+                        setIsEditingSectionType(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      size="sm"
+                      type="submit"
+                      disabled={shouldUpdateSectionButtonBeDisabled}
+                      isLoading={isSubmitting}
+                    >
+                      Update section
+                    </Button>
+                  </>
+                )}
+              </HStack>
+            </HStack>
+          </form>
+        </Form>
         <hr className="bg-slate-100" />
       </VStack>
       <VStack className="gap-y-4">

--- a/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
+++ b/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
@@ -129,6 +129,16 @@ export const SetSectionTypeCombobox: React.FC<SetSectionTypeComboboxProps> = ({
             onChange={(changeEvent) =>
               setNewSetSectionInputValue(changeEvent.target.value)
             }
+            onKeyDown={async (e) => {
+              if (
+                e.key === "Enter" &&
+                newSetSectionInputValue.trim() !== "" &&
+                !createSetSectionTypeMutation.isPending
+              ) {
+                e.preventDefault();
+                await handleCreateNewSetSectionType();
+              }
+            }}
           />
           <Button
             variant="ghost"

--- a/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
+++ b/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import {
+  Combobox,
+  type ComboboxProps,
+  type ComboboxOption,
+} from "@components/ui/combobox";
+import { Input } from "@components/ui/input";
+import { Button } from "@components/ui/button";
+import { CommandGroup } from "@components/ui/command";
+import { Plus } from "@phosphor-icons/react/dist/ssr";
+import { cn } from "@lib/utils";
+import { api } from "@/trpc/react";
+import { toast } from "sonner";
+
+export type SetSectionTypeComboboxProps = {
+  /** Available set section type options */
+  options: ComboboxOption[];
+
+  /** Currently selected value */
+  value: ComboboxOption | null;
+
+  /** Callback when value changes */
+  onChange: (value: ComboboxOption | null) => void;
+
+  /** Whether the combobox is open */
+  open: boolean;
+
+  /** Callback to set open state */
+  setOpen: React.Dispatch<React.SetStateAction<ComboboxProps["open"]>>;
+
+  /** Whether the combobox is loading */
+  loading?: boolean;
+
+  /** Whether the combobox is disabled */
+  disabled?: boolean;
+
+  /** Organization ID for creating new section types */
+  organizationId: string;
+
+  /** Optional text styles to apply to the combobox */
+  textStyles?: string;
+
+  /** Placeholder text */
+  placeholder?: string;
+
+  /** Optional callback after a new section type is created */
+  onCreateSuccess?: (newSectionType: { id: string; name: string }) => void;
+};
+
+export const SetSectionTypeCombobox: React.FC<SetSectionTypeComboboxProps> = ({
+  options,
+  value,
+  onChange,
+  open,
+  setOpen,
+  loading = false,
+  disabled = false,
+  organizationId,
+  textStyles = "text-slate-700",
+  placeholder = "Add a set section",
+  onCreateSuccess,
+}) => {
+  const [newSetSectionInputValue, setNewSetSectionInputValue] =
+    useState<string>("");
+
+  const createSetSectionTypeMutation = api.setSectionType.create.useMutation();
+  const apiUtils = api.useUtils();
+
+  const handleCreateNewSetSectionType = async () => {
+    const trimmedInput = newSetSectionInputValue.trim();
+
+    if (!trimmedInput) return;
+
+    await createSetSectionTypeMutation.mutateAsync(
+      { name: trimmedInput, organizationId },
+      {
+        async onSuccess(createSetSectionTypeMutationResult) {
+          const [newSetSectionType] = createSetSectionTypeMutationResult;
+
+          if (newSetSectionType) {
+            toast.success(`${newSetSectionType.name} set section type created`);
+
+            // If a callback was provided, call it with the new section type
+            if (onCreateSuccess) {
+              onCreateSuccess(newSetSectionType);
+            }
+
+            // Update the selected value
+            onChange({
+              id: newSetSectionType.id,
+              label: newSetSectionType.name,
+            });
+
+            await apiUtils.setSectionType.getTypes.invalidate({
+              organizationId,
+            });
+          }
+        },
+      },
+    );
+
+    setOpen(false);
+    setNewSetSectionInputValue("");
+  };
+
+  return (
+    <Combobox
+      placeholder={placeholder}
+      options={options}
+      value={value}
+      onChange={onChange}
+      open={open}
+      setOpen={setOpen}
+      loading={loading}
+      disabled={disabled}
+      textStyles={cn(textStyles)}
+    >
+      <CommandGroup heading="Create new section type">
+        <div
+          className={cn(
+            "flex gap-2",
+            "relative cursor-default select-none items-center gap-2 rounded-sm px-2 py-2 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+          )}
+        >
+          <Input
+            size="small"
+            className="flex-1"
+            value={newSetSectionInputValue}
+            onChange={(changeEvent) =>
+              setNewSetSectionInputValue(changeEvent.target.value)
+            }
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="flex-grow-0"
+            onClick={handleCreateNewSetSectionType}
+            isLoading={createSetSectionTypeMutation.isPending}
+            disabled={
+              newSetSectionInputValue === "" ||
+              createSetSectionTypeMutation.isPending
+            }
+          >
+            <Plus />
+            Create
+          </Button>
+        </div>
+      </CommandGroup>
+    </Combobox>
+  );
+};

--- a/src/modules/sets/components/SetSectionTypeCombobox/index.ts
+++ b/src/modules/sets/components/SetSectionTypeCombobox/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetSectionTypeCombobox";

--- a/src/modules/sets/hooks/useSetSectionTypes.ts
+++ b/src/modules/sets/hooks/useSetSectionTypes.ts
@@ -1,0 +1,30 @@
+import { api } from "@/trpc/react";
+import { type ComboboxOption } from "@components/ui/combobox";
+import { useEffect, useState } from "react";
+
+export function useSectionTypesOptions(organizationId: string) {
+  const [options, setOptions] = useState<ComboboxOption[]>([]);
+
+  const { data, error, isLoading } = api.setSectionType.getTypes.useQuery(
+    { organizationId },
+    { enabled: !!organizationId },
+  );
+
+  useEffect(() => {
+    if (!isLoading && !error && data) {
+      const mappedOptions =
+        data.map((type) => ({
+          id: type.id,
+          label: type.name,
+        })) ?? [];
+
+      setOptions(mappedOptions);
+    }
+  }, [isLoading, data, error]);
+
+  return {
+    options,
+    isLoading,
+    error,
+  };
+}

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -31,6 +31,7 @@ import { type SetSectionWithSongs } from "@lib/types";
 import { insertSetSectionSongSchema } from "@lib/types/zod";
 import { cn } from "@lib/utils";
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { SongListItem } from "@modules/songs/components/SongListItem";
 import { type SongSearchResult } from "@modules/songs/components/SongSearch";
 import { type SongSearchDialogSteps } from "@modules/songs/components/SongSearchDialog";
@@ -43,7 +44,7 @@ import {
   Plus,
 } from "@phosphor-icons/react/dist/ssr";
 import { redirect } from "next/navigation";
-import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { type Dispatch, type SetStateAction, useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { useMediaQuery } from "usehooks-ts";
@@ -84,10 +85,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
 }) => {
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
   const textSize = isDesktop ? "text-base" : "text-xs";
-
-  const [setSectionTypesOptions, setSetSectionTypesOptions] = useState<
-    ComboboxOption[]
-  >([]);
 
   const [newSetSectionType, setNewSetSectionType] =
     useState<ComboboxOption | null>(null);
@@ -131,20 +128,16 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
     redirect("/sign-in");
   }
 
+  const {
+    options: setSectionTypesOptions,
+    isLoading: isSetSectionTypesQueryLoading,
+  } = useSectionTypesOptions(userMembership.organizationId);
+
   const { data: lastPlayInstance, isLoading: isLastPlayInstanceQueryLoading } =
     api.song.getLastPlayInstance.useQuery({
       organizationId: userMembership.organizationId,
       songId: selectedSong.songId,
     });
-
-  const {
-    data: setSectionTypesData,
-    error: setSectionTypesQueryError,
-    isLoading: isSetSectionTypesQueryLoading,
-  } = api.setSectionType.getTypes.useQuery(
-    { organizationId: userMembership.organizationId },
-    { enabled: !!userMembership },
-  );
 
   const {
     data: sectionsForSetData,
@@ -161,26 +154,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
       !!sectionsForSetData &&
       sectionsForSetData.length === 0,
   );
-
-  useEffect(() => {
-    if (
-      !isSetSectionTypesQueryLoading &&
-      !setSectionTypesQueryError &&
-      setSectionTypesData
-    ) {
-      const setSectionTypes: ComboboxOption[] =
-        setSectionTypesData?.map((setSectionType) => ({
-          id: setSectionType.id,
-          label: setSectionType.name,
-        })) ?? [];
-
-      setSetSectionTypesOptions(setSectionTypes);
-    }
-  }, [
-    isSetSectionTypesQueryLoading,
-    setSectionTypesData,
-    setSectionTypesQueryError,
-  ]);
 
   if (
     isSectionsForSetQueryLoading ||

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -1,41 +1,10 @@
-import { Combobox, type ComboboxOption } from "@components/ui/combobox";
-import { Input } from "@components/ui/input";
-import { DESKTOP_MEDIA_QUERY_STRING, songKeys } from "@lib/constants";
-import { formatSongKey } from "@lib/string/formatSongKey";
-import { cn } from "@lib/utils";
-import {
-  CaretLeft,
-  ClockCounterClockwise,
-  Heart,
-  Plus,
-  CircleNotch,
-} from "@phosphor-icons/react/dist/ssr";
-import { DialogTitle, DialogDescription } from "@components/ui/dialog";
-import { RadioGroupItem, RadioGroup } from "@components/ui/radio-group";
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from "@components/ui/select";
-import { Switch } from "@components/ui/switch";
-import { SongListItem } from "@modules/songs/components/SongListItem";
-import { Button } from "@components/ui/button";
-import { Text } from "@components/Text";
-import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
-import { type SetSectionWithSongs } from "@lib/types";
-import { type SongSearchResult } from "@modules/songs/components/SongSearch";
-import { type SongSearchDialogSteps } from "@modules/songs/components/SongSearchDialog";
-import { useUserQuery } from "@modules/users/api/queries";
-import { redirect } from "next/navigation";
 import { api } from "@/trpc/react";
 import { HStack } from "@components/HStack";
+import { Text } from "@components/Text";
+import { Button } from "@components/ui/button";
+import { type ComboboxOption } from "@components/ui/combobox";
 import { CommandGroup, CommandList } from "@components/ui/command";
-import { type SubmitHandler, useForm } from "react-hook-form";
-import { insertSetSectionSongSchema } from "@lib/types/zod";
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { DialogDescription, DialogTitle } from "@components/ui/dialog";
 import {
   Form,
   FormControl,
@@ -44,10 +13,41 @@ import {
   FormLabel,
   FormMessage,
 } from "@components/ui/form";
-import { toast } from "sonner";
-import { DevTool } from "@hookform/devtools";
-import { useMediaQuery } from "usehooks-ts";
+import { RadioGroup, RadioGroupItem } from "@components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@components/ui/select";
+import { Switch } from "@components/ui/switch";
 import { Textarea } from "@components/ui/textarea";
+import { DevTool } from "@hookform/devtools";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { DESKTOP_MEDIA_QUERY_STRING, songKeys } from "@lib/constants";
+import { formatSongKey } from "@lib/string/formatSongKey";
+import { type SetSectionWithSongs } from "@lib/types";
+import { insertSetSectionSongSchema } from "@lib/types/zod";
+import { cn } from "@lib/utils";
+import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { SongListItem } from "@modules/songs/components/SongListItem";
+import { type SongSearchResult } from "@modules/songs/components/SongSearch";
+import { type SongSearchDialogSteps } from "@modules/songs/components/SongSearchDialog";
+import { useUserQuery } from "@modules/users/api/queries";
+import {
+  CaretLeft,
+  CircleNotch,
+  ClockCounterClockwise,
+  Heart,
+  Plus,
+} from "@phosphor-icons/react/dist/ssr";
+import { redirect } from "next/navigation";
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { useMediaQuery } from "usehooks-ts";
+import { z } from "zod";
 
 const createSetSectionSongsSchema = insertSetSectionSongSchema
   .pick({
@@ -85,9 +85,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
   const textSize = isDesktop ? "text-base" : "text-xs";
 
-  const [newSetSectionInputValue, setNewSetSectionInputValue] =
-    useState<string>("");
-
   const [setSectionTypesOptions, setSetSectionTypesOptions] = useState<
     ComboboxOption[]
   >([]);
@@ -119,7 +116,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   const shouldAddSongBeDisabled = !isDirty || !isValid || isSubmitting;
 
   const addSetSectionSongMutation = api.setSectionSong.create.useMutation();
-  const createSetSectionTypeMutation = api.setSectionType.create.useMutation();
   const createSetSectionMutation = api.setSection.create.useMutation();
   const apiUtils = api.useUtils();
 
@@ -135,14 +131,11 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
     redirect("/sign-in");
   }
 
-  const {
-    data: lastPlayInstance,
-    isLoading: isLastPlayInstanceQueryLoading,
-    error: lastPlayInstanceQueryError,
-  } = api.song.getLastPlayInstance.useQuery({
-    organizationId: userMembership.organizationId,
-    songId: selectedSong.songId,
-  });
+  const { data: lastPlayInstance, isLoading: isLastPlayInstanceQueryLoading } =
+    api.song.getLastPlayInstance.useQuery({
+      organizationId: userMembership.organizationId,
+      songId: selectedSong.songId,
+    });
 
   const {
     data: setSectionTypesData,
@@ -205,8 +198,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   const handleAddSetSection = async (
     clickEvent: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
-    // console.log("🚀 ~ handleAddSetSection ~ clickEvent:", clickEvent);
-
     clickEvent.preventDefault();
 
     if (!newSetSectionType) {
@@ -220,10 +211,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
 
     if (!setAlreadyHasSelectedSection) {
       const positionForNewSetSection = sectionsForSetData.length;
-      console.log(
-        "🚀 ~ handleAddSetSection ~ positionForNewSetSection:",
-        positionForNewSetSection,
-      );
 
       await createSetSectionMutation.mutateAsync(
         {
@@ -235,11 +222,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
         {
           async onSuccess(createSetSectionMutationResult) {
             const [newSetSection] = createSetSectionMutationResult;
-
-            console.log(
-              "🤖 - [createSetSectionMutation/onSuccess] ~ mutation result: ",
-              createSetSectionMutationResult,
-            );
 
             if (newSetSection) {
               setValue("setSectionId", newSetSection.id, {
@@ -271,55 +253,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
         message: "Section already exists on set",
       });
     }
-  };
-
-  // FIXME: this would need to be updated to delete setSection from DB - should this be done here?
-  // const handleRemoveTempSetSection = (setSectionIdToRemove: string) => {
-  //   const modifiedSetSectionsList = setSectionsList.filter(
-  //     (setSection) => setSection.id !== setSectionIdToRemove,
-  //   );
-
-  //   if (getValues("setSectionId") === setSectionIdToRemove) {
-  //     setValue("setSectionId", "", {
-  //       shouldValidate: false,
-  //       shouldDirty: true,
-  //       shouldTouch: true,
-  //     });
-  //   }
-  // };
-
-  const handleCreateNewSetSectionType = async () => {
-    const trimmedInput = newSetSectionInputValue.trim();
-
-    await createSetSectionTypeMutation.mutateAsync(
-      { name: trimmedInput, organizationId: userMembership.organizationId },
-      {
-        async onSuccess(createSetSectionTypeMutationResult) {
-          const [newSetSectionType] = createSetSectionTypeMutationResult;
-
-          if (newSetSectionType) {
-            toast.success(`${newSetSectionType.name} set section type created`);
-
-            console.log(
-              "🤖 [createSetSectionTypeMutation/onSuccess] ~ mutation result:",
-              createSetSectionTypeMutationResult,
-            );
-
-            setNewSetSectionType({
-              id: newSetSectionType.id,
-              label: newSetSectionType.name,
-            });
-
-            await apiUtils.setSectionType.getTypes.invalidate({
-              organizationId: userMembership.organizationId,
-            });
-          }
-        },
-      },
-    );
-
-    setIsAddSectionComboboxOpen(false);
-    setNewSetSectionInputValue("");
   };
 
   const handleAddSongToSetSubmit: SubmitHandler<
@@ -573,53 +506,18 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                 )}
                 {isAddingSection && (
                   <>
-                    <Combobox
+                    <SetSectionTypeCombobox
                       placeholder="Add a set section"
                       options={setSectionTypesOptions}
                       value={newSetSectionType}
-                      onChange={(selectedValue) => {
-                        setNewSetSectionType(selectedValue);
-                      }}
+                      onChange={setNewSetSectionType}
                       open={isAddSectionComboboxOpen}
                       setOpen={setIsAddSectionComboboxOpen}
                       loading={isSetSectionTypesQueryLoading}
                       disabled={isSetSectionTypesQueryLoading}
                       textStyles={cn("text-slate-700", textSize)}
-                    >
-                      <CommandGroup heading="Create new section type">
-                        <div
-                          className={cn(
-                            "flex gap-2",
-                            "relative cursor-default select-none items-center gap-2 rounded-sm px-2 py-2 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-                          )}
-                        >
-                          <Input
-                            size="small"
-                            className="flex-1"
-                            value={newSetSectionInputValue}
-                            onChange={(changeEvent) =>
-                              setNewSetSectionInputValue(
-                                changeEvent.target.value,
-                              )
-                            }
-                          />
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="flex-grow-0"
-                            onClick={handleCreateNewSetSectionType}
-                            isLoading={createSetSectionTypeMutation.isPending}
-                            disabled={
-                              newSetSectionInputValue === "" ||
-                              createSetSectionTypeMutation.isPending
-                            }
-                          >
-                            <Plus />
-                            Create
-                          </Button>
-                        </div>
-                      </CommandGroup>
-                    </Combobox>
+                      organizationId={userMembership.organizationId}
+                    />
                     <div className="mt-2 flex justify-end gap-2">
                       {sectionsForSetData.length > 0 && (
                         <Button

--- a/src/server/api/routers/setSection.ts
+++ b/src/server/api/routers/setSection.ts
@@ -1,7 +1,12 @@
 import { type NewSetSection } from "@lib/types";
-import { getSectionsForSet, insertSetSectionSchema } from "@lib/types/zod";
+import {
+  getSectionsForSet,
+  insertSetSectionSchema,
+  updateSetSectionType,
+} from "@lib/types/zod";
 import { createTRPCRouter, organizationProcedure } from "@server/api/trpc";
-import { setSections } from "@server/db/schema";
+import { setSections, setSectionTypes } from "@server/db/schema";
+import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 
 export const setSectionRouter = createTRPCRouter({
@@ -47,5 +52,80 @@ export const setSectionRouter = createTRPCRouter({
       );
 
       return sectionsForSetData;
+    }),
+
+  changeType: organizationProcedure
+    .input(updateSetSectionType)
+    .mutation(async ({ ctx, input }) => {
+      const { id, sectionTypeId } = input;
+
+      console.log(
+        `🤖 - [setSection/changeType] - attempting to update set section`,
+        { id, sectionTypeId },
+      );
+
+      return await ctx.db.transaction(async (updateTransaction) => {
+        const setSection = await updateTransaction.query.setSections.findFirst({
+          where: eq(setSections.id, id),
+          with: {
+            set: true,
+          },
+        });
+
+        if (!setSection) {
+          console.error(
+            `🤖 - [setSection/changeType] - could not find set section ${id}`,
+          );
+
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Cannot find the set section",
+          });
+        }
+
+        if (
+          setSection.set.organizationId !== ctx.user.membership.organizationId
+        ) {
+          console.error(
+            `🤖 - [setSection/changeType] - User ${ctx.user.id} not authorized to update set section ${setSection.id}`,
+          );
+
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Not authorized to update this set section",
+          });
+        }
+
+        const setSectionType =
+          await updateTransaction.query.setSectionTypes.findFirst({
+            where: eq(setSectionTypes.id, sectionTypeId),
+          });
+
+        if (!setSectionType) {
+          console.error(
+            `🤖 - [setSection/changeType] - could not find set section type ${sectionTypeId}`,
+          );
+
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Cannot find the set section type",
+          });
+        }
+
+        await updateTransaction
+          .update(setSections)
+          .set({ sectionTypeId })
+          .where(eq(setSections.id, id));
+
+        console.info(
+          `🤖 - [setSection/changeType] - Successfully updated ${id}'s section type to ${sectionTypeId}`,
+        );
+
+        return {
+          success: true,
+          setSection: id,
+          sectionType: sectionTypeId,
+        };
+      });
     }),
 });


### PR DESCRIPTION
## Background
This PR is to add the change section type action to allow the user to update a set section's type.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New Features**
  - Enhanced the editing experience for section types with a new interactive form.
  - Updated the action menu to now initiate section type editing.
  - Introduced a new component for selecting and creating set section types.
  - Implemented a focused schema for updating set section types, emphasizing required fields.
  - Added a new mutation method to update section types in the backend.
  - Introduced a custom hook for managing section type options based on organization ID.

- **Bug Fixes**
  - Streamlined logic for adding new set sections, improving overall functionality.

- **Documentation**
  - Exported new types for better accessibility and consistency in type-checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
1. **Accessing the Change Section Type Feature**
   - Navigate to a set that contains at least one section
   - Locate the section action menu (three dots) in the top-right corner of any section
   - Click on the action menu
   - Verify that "Change section type" option is now present in the dropdown menu

2. **Opening the Edit Section Type Form**
   - Click on the "Change section type" option in the action menu
   - Verify that the section header transforms into an editable form
   - Confirm that:
     - The current section type is pre-selected in the dropdown
     - "Cancel" and "Update section" buttons are visible
     - The "Update section" button is initially disabled (since no changes have been made yet)

3. **Selecting an Existing Section Type**
   - Click on the section type dropdown
   - Verify that all available section types for your organization are listed
   - Select a different section type from the list
   - Verify that the "Update section" button becomes enabled
   - Click "Update section"
   - Verify that:
     - A loading indicator appears during the update process
     - A success toast message appears when the update completes
     - The section header updates to display the new section type
     - The form disappears and returns to the normal section view

4. **Creating a New Section Type**
   - Click on the section action menu and select "Change section type" again
   - Click on the section type dropdown
   - Locate the "Create new section type" area with input field
   - Enter a name for a new section type (e.g., "New Test Section")
   - Click the "Create" button
   - Verify that:
     - The new section type is created and selected in the dropdown
     - A success toast message confirms the creation
     - The "Update section" button becomes enabled
   - Click "Update section"
   - Verify the section updates with the newly created section type

5. **Canceling the Edit Operation**
   - Click on the section action menu and select "Change section type"
   - Select a different section type
   - Click the "Cancel" button
   - Verify that:
     - The form disappears
     - The section reverts to its previous state without changes
     - No update occurs in the database