### PR TITLE
[SWY-80] Add update set section position action

### DIFF
--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -78,9 +78,7 @@ export const insertSetSectionTypeSchema = createInsertSchema(setSectionTypes);
  * Set section schemas
  */
 export const insertSetSectionSchema = createInsertSchema(setSections);
-
 export const getSectionsForSet = z.object({ setId: z.string().uuid() });
-
 export const updateSetSectionType = insertSetSectionSchema
   .pick({
     id: true,
@@ -89,6 +87,9 @@ export const updateSetSectionType = insertSetSectionSchema
   .required({
     id: true,
   });
+export const swapSetSectionPositionSchema = z.object({
+  setSectionId: z.string().uuid(),
+});
 
 /**
  * Set section songs schemas

--- a/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
+++ b/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
@@ -103,11 +103,14 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
           return moveSetSectionToFirstMutation;
         case "last":
           return moveSetSectionToLastMutation;
-        default:
+        default: {
           const _exhaustiveCheck: never = direction;
           return _exhaustiveCheck;
+        }
       }
     })();
+
+    const isSwapUpdate = direction === "up" || direction === "down";
 
     moveSectionMutation.mutate(
       {
@@ -117,8 +120,6 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
       {
         async onSuccess(swapSetSectionResult) {
           toast.dismiss();
-
-          const isSwapUpdate = direction === "up" || direction === "down";
 
           if (!swapSetSectionResult.success) {
             isSwapUpdate
@@ -140,8 +141,6 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
         },
         async onError(swapError) {
           toast.dismiss();
-
-          const isSwapUpdate = direction === "up" || direction === "down";
 
           isSwapUpdate
             ? toast.error(

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -134,12 +134,12 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
         setSectionSongId: setSectionSong.id,
       },
       {
-        async onSuccess(swapSongWithNextResult) {
+        async onSuccess(moveSongResult) {
           toast.dismiss();
 
-          if (!swapSongWithNextResult.success) {
+          if (!moveSongResult.success) {
             toast.error(
-              `Could not move song ${direction}: ${swapSongWithNextResult.message}`,
+              `Could not move song ${direction}: ${moveSongResult.message}`,
             );
           } else {
             toast.success(`Moved song ${direction}`);

--- a/src/modules/setSections/api/mutations.ts
+++ b/src/modules/setSections/api/mutations.ts
@@ -1,0 +1,156 @@
+import { db } from "@server/db";
+import { setSections } from "@server/db/schema";
+import { and, eq, lt, gt, sql } from "drizzle-orm";
+
+export type SwapSetSectionPositionDirection = "first" | "up" | "down" | "last";
+
+export type SwapSetSectionPositionResult = {
+  success: boolean;
+  message?: string;
+};
+
+export const updateSetSectionPosition = async (
+  setSectionToUpdate: string,
+  direction: SwapSetSectionPositionDirection,
+): Promise<SwapSetSectionPositionResult> => {
+  return await db.transaction(async (updateTransaction) => {
+    const [setSection] = await updateTransaction
+      .select()
+      .from(setSections)
+      .where(eq(setSections.id, setSectionToUpdate))
+      .limit(1);
+    if (!setSection) {
+      console.error(
+        `🤖 - [setSection/updateSetSectionPosition/${direction}] - Set section ${setSectionToUpdate} not found`,
+      );
+      return {
+        success: false,
+        message: `Set section not found`,
+      };
+    }
+
+    const { position } = setSection;
+
+    const [maxSetSectionPositionResult] = await updateTransaction
+      .select({ maxSetSectionPosition: sql<number>`MAX(position)` })
+      .from(setSections)
+      .where(eq(setSections.setId, setSection.setId));
+
+    if (!maxSetSectionPositionResult?.maxSetSectionPosition) {
+      console.error(
+        `🤖 - [setSection/updateSetSectionPosition/${direction}] - Cannot determine max section position value for set ${setSection.setId}`,
+      );
+      return {
+        success: false,
+        message: `Cannot determine max section position for matching set`,
+      };
+    }
+
+    if (
+      (direction === "up" && position === 0) ||
+      (direction === "down" &&
+        position === maxSetSectionPositionResult?.maxSetSectionPosition)
+    ) {
+      console.error(
+        `🤖 - [setSection/updateSetSectionPosition/${direction}] - Cannot swap set section ${direction} from position ${position}`,
+      );
+      return {
+        success: false,
+        message: `Cannot move ${direction} from current position`,
+      };
+    }
+
+    // const targetPosition = direction === "up" ? position - 1 : position + 1;
+    const targetPosition: number = (() => {
+      if (direction === "up") {
+        return position - 1;
+      }
+
+      if (direction === "down") {
+        return position + 1;
+      }
+
+      if (direction === "last") {
+        return maxSetSectionPositionResult.maxSetSectionPosition;
+      }
+
+      return 0;
+    })();
+
+    const isSwapUpdate = direction === "up" || direction == "down";
+
+    if (isSwapUpdate) {
+      const [setSectionToSwap] = await updateTransaction
+        .select()
+        .from(setSections)
+        .where(
+          and(
+            eq(setSections.setId, setSection.setId),
+            eq(setSections.position, targetPosition),
+          ),
+        )
+        .limit(1);
+
+      if (!setSectionToSwap) {
+        console.error(
+          `🤖 - [setSection/updateSetSectionPosition/${direction}] - No set section to swap with ${direction}`,
+        );
+        return {
+          success: false,
+          message: `No set section to swap with ${direction}`,
+        };
+      }
+
+      console.info(
+        `🤖 - [setSection/updateSetSectionPosition/${direction}] - Preparing to move set section ${direction}, swapping with ${setSectionToSwap.id}`,
+      );
+
+      await updateTransaction
+        .update(setSections)
+        .set({ position })
+        .where(eq(setSections.id, setSectionToSwap.id));
+
+      await updateTransaction
+        .update(setSections)
+        .set({ position: targetPosition })
+        .where(eq(setSections.id, setSection.id));
+
+      console.info(
+        `🤖 - [setSection/updateSetSectionPosition/${direction}] - Successfully moved set section ${direction}:\n${setSectionToUpdate} new position: ${targetPosition}.\n${setSectionToSwap.id} new position: ${position}`,
+      );
+    } else {
+      console.info(
+        `🤖 - [setSection/updateSetSectionPosition/${direction}] - Preparing to move set section the ${direction} position`,
+      );
+
+      await updateTransaction
+        .update(setSections)
+        .set({
+          position:
+            direction === "first" ? sql`position + 1` : sql`position - 1`,
+        })
+        .where(
+          and(
+            eq(setSections.setId, setSection.setId),
+            direction === "first"
+              ? lt(setSections.position, position)
+              : gt(setSections.position, position),
+          ),
+        );
+
+      await updateTransaction
+        .update(setSections)
+        .set({ position: targetPosition })
+        .where(eq(setSections.id, setSection.id));
+
+      console.info(
+        `🤖 - [setSection/updateSetSectionPosition/${direction}] - Successfully moved set section to the ${direction} position:\n${setSectionToUpdate} new position: ${targetPosition}.`,
+      );
+    }
+
+    return {
+      success: true,
+      message: `Successfully moved set section ${setSectionToUpdate} ${direction}`,
+    };
+  });
+};

--- a/src/modules/setSections/api/mutations.ts
+++ b/src/modules/setSections/api/mutations.ts
@@ -13,7 +13,7 @@ export const updateSetSectionPosition = async (
   setSectionToUpdate: string,
   direction: SwapSetSectionPositionDirection,
 ): Promise<SwapSetSectionPositionResult> => {
-  return await db.transaction(async (updateTransaction) => {
+  return db.transaction(async (updateTransaction) => {
     const [setSection] = await updateTransaction
       .select()
       .from(setSections)
@@ -77,7 +77,7 @@ export const updateSetSectionPosition = async (
       return 0;
     })();
 
-    const isSwapUpdate = direction === "up" || direction == "down";
+    const isSwapUpdate = direction === "up" || direction === "down";
 
     if (isSwapUpdate) {
       const [setSectionToSwap] = await updateTransaction

--- a/src/server/api/routers/setSection.ts
+++ b/src/server/api/routers/setSection.ts
@@ -2,8 +2,10 @@ import { type NewSetSection } from "@lib/types";
 import {
   getSectionsForSet,
   insertSetSectionSchema,
+  swapSetSectionPositionSchema,
   updateSetSectionType,
 } from "@lib/types/zod";
+import { updateSetSectionPosition } from "@modules/setSections/api/mutations";
 import { createTRPCRouter, organizationProcedure } from "@server/api/trpc";
 import { setSections, setSectionTypes } from "@server/db/schema";
 import { TRPCError } from "@trpc/server";
@@ -127,5 +129,29 @@ export const setSectionRouter = createTRPCRouter({
           sectionType: sectionTypeId,
         };
       });
+    }),
+
+  swapSectionWithPrevious: organizationProcedure
+    .input(swapSetSectionPositionSchema)
+    .mutation(async ({ input }) => {
+      return await updateSetSectionPosition(input.setSectionId, "up");
+    }),
+
+  swapSectionWithNext: organizationProcedure
+    .input(swapSetSectionPositionSchema)
+    .mutation(async ({ input }) => {
+      return await updateSetSectionPosition(input.setSectionId, "down");
+    }),
+
+  moveSectionToFirst: organizationProcedure
+    .input(swapSetSectionPositionSchema)
+    .mutation(async ({ input }) => {
+      return await updateSetSectionPosition(input.setSectionId, "first");
+    }),
+
+  moveSectionToLast: organizationProcedure
+    .input(swapSetSectionPositionSchema)
+    .mutation(async ({ input }) => {
+      return await updateSetSectionPosition(input.setSectionId, "last");
     }),
 });


### PR DESCRIPTION
## Background
This PR is to add the mutations related to the set section action menu items that update the section's position in the set.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced section reordering directly from the action menu, allowing users to reposition sections by moving them up, down, to the beginning, or to the end of a set.
  - Added a new schema for validating section position swaps.

- **Bug Fixes / Improvements**
  - Refined feedback messaging for song repositioning to provide more consistent and clear notifications during move operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
#### 1. Moving section up/down
- Open any set with multiple sections
- For each section (except the first), click the action menu and select "Move section up"
  - Verify the section moves up one position
  - Verify a success toast appears
- For each section (except the last), click the action menu and select "Move section down"
  - Verify the section moves down one position
  - Verify a success toast appears

#### 2. Moving section to the first/last position
- For the first section:
  - Open its action menu and select "Move section to top"
  - Verify the section moves to the top (first) position
  - Verify a success toast appears
- For the last section:
  - Open its action menu and select "Move section to bottom"
  - Verify the section moves to the bottom (last) position
  - Verify a success toast appears 