### PR TITLE
[SWY-81] Add delete set section action

### DIFF
--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -77,6 +77,9 @@ export const insertSetSectionTypeSchema = createInsertSchema(setSectionTypes);
 /**
  * Set section schemas
  */
+export const setSectionIdSchema = z.object({
+  setSectionId: z.string().uuid(),
+});
 export const insertSetSectionSchema = createInsertSchema(setSections);
 export const getSectionsForSet = z.object({ setId: z.string().uuid() });
 export const updateSetSectionType = insertSetSectionSchema
@@ -87,9 +90,8 @@ export const updateSetSectionType = insertSetSectionSchema
   .required({
     id: true,
   });
-export const swapSetSectionPositionSchema = z.object({
-  setSectionId: z.string().uuid(),
-});
+export const swapSetSectionPositionSchema = setSectionIdSchema;
+export const deleteSetSectionSchema = setSectionIdSchema;
 
 /**
  * Set section songs schemas

--- a/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
+++ b/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
@@ -36,13 +36,13 @@ type SetSectionActionMenuProps = {
   /** the ID of the set the set section song is attached to */
   // setId: string;
 
-  /** is this song in the first section of the set? */
+  /** is this the first section of the set? */
   isInFirstSection: SongItemWithActionsMenuProps["isInFirstSection"];
 
-  /** is this song in the last section of the set? */
+  /** is this the last section of the set? */
   isInLastSection: SongItemWithActionsMenuProps["isInLastSection"];
 
-  /** call back to set if the song item is in edit mode */
+  /** call back to set if the setSection item is in edit mode */
   setIsEditingSectionType: Dispatch<SetStateAction<boolean>>;
 };
 
@@ -94,7 +94,11 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
   }
 
   const moveSection = (direction: SwapSetSectionPositionDirection) => {
-    toast.loading(`Moving section ${direction}`);
+    const isSwapUpdate = direction === "up" || direction === "down";
+
+    isSwapUpdate
+      ? toast.loading(`Moving section ${direction}`)
+      : toast.loading(`Moving section to the ${direction} position`);
 
     const moveSectionMutation = (() => {
       switch (direction) {
@@ -112,8 +116,6 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
         }
       }
     })();
-
-    const isSwapUpdate = direction === "up" || direction === "down";
 
     moveSectionMutation.mutate(
       {

--- a/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
+++ b/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
@@ -72,13 +72,12 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
   const userMembership = userData?.memberships[0];
 
   const swapSetSectionWithPreviousMutation =
-    api.setSection.swapSectionWithPrevious.useMutation();
+    api.setSection.swapWithPrevious.useMutation();
   const swapSetSectionWithNextMutation =
-    api.setSection.swapSectionWithNext.useMutation();
+    api.setSection.swapWithNext.useMutation();
   const moveSetSectionToFirstMutation =
-    api.setSection.moveSectionToFirst.useMutation();
-  const moveSetSectionToLastMutation =
-    api.setSection.moveSectionToLast.useMutation();
+    api.setSection.moveToFirst.useMutation();
+  const moveSetSectionToLastMutation = api.setSection.moveToLast.useMutation();
 
   if (
     !!userQueryError ||

--- a/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
+++ b/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
@@ -173,6 +173,7 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
 
           await apiUtils.set.get.invalidate({
             setId: setSection.setId,
+            organizationId: userMembership.organizationId,
           });
         },
         onError(error) {

--- a/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
+++ b/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
@@ -256,7 +256,7 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="text-lg font-semibold">
-              Remove {setSection.type.name.toLowerCase()} section
+              Remove {setSection.type.name} section
             </AlertDialogTitle>
             <AlertDialogDescription>
               <VStack className="gap-2 text-slate-700">

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -301,7 +301,13 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
             >
               Cancel
             </AlertDialogCancel>
-            <Button variant="destructive" onClick={() => removeSong()}>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setIsConfirmationDialogOpen(false);
+                removeSong();
+              }}
+            >
               Remove song
             </Button>
           </AlertDialogFooter>

--- a/src/modules/setSections/api/mutations.ts
+++ b/src/modules/setSections/api/mutations.ts
@@ -9,10 +9,16 @@ export type SwapSetSectionPositionResult = {
   message?: string;
 };
 
+// TODO: add TRPCErrors - especially if the user is not authorized to update set section
 export const updateSetSectionPosition = async (
   setSectionToUpdate: string,
   direction: SwapSetSectionPositionDirection,
 ): Promise<SwapSetSectionPositionResult> => {
+  console.log(
+    `🤖 - [setSection/swapWithPrevious/${direction}] - attempting to update set section`,
+    { setSectionId: setSectionToUpdate },
+  );
+
   return db.transaction(async (updateTransaction) => {
     const [setSection] = await updateTransaction
       .select()

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -520,7 +520,7 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                         isLoading={createSetSectionMutation.isPending}
                         className={cn(textSize)}
                       >
-                        Add
+                        Add section to set
                       </Button>
                     </div>
                   </>

--- a/src/server/api/routers/setSection.ts
+++ b/src/server/api/routers/setSection.ts
@@ -131,25 +131,25 @@ export const setSectionRouter = createTRPCRouter({
       });
     }),
 
-  swapSectionWithPrevious: organizationProcedure
+  swapWithPrevious: organizationProcedure
     .input(swapSetSectionPositionSchema)
     .mutation(async ({ input }) => {
       return await updateSetSectionPosition(input.setSectionId, "up");
     }),
 
-  swapSectionWithNext: organizationProcedure
+  swapWithNext: organizationProcedure
     .input(swapSetSectionPositionSchema)
     .mutation(async ({ input }) => {
       return await updateSetSectionPosition(input.setSectionId, "down");
     }),
 
-  moveSectionToFirst: organizationProcedure
+  moveToFirst: organizationProcedure
     .input(swapSetSectionPositionSchema)
     .mutation(async ({ input }) => {
       return await updateSetSectionPosition(input.setSectionId, "first");
     }),
 
-  moveSectionToLast: organizationProcedure
+  moveToLast: organizationProcedure
     .input(swapSetSectionPositionSchema)
     .mutation(async ({ input }) => {
       return await updateSetSectionPosition(input.setSectionId, "last");

--- a/src/server/api/routers/setSection.ts
+++ b/src/server/api/routers/setSection.ts
@@ -1,15 +1,20 @@
 import { type NewSetSection } from "@lib/types";
 import {
+  deleteSetSectionSchema,
   getSectionsForSet,
   insertSetSectionSchema,
   swapSetSectionPositionSchema,
   updateSetSectionType,
 } from "@lib/types/zod";
 import { updateSetSectionPosition } from "@modules/setSections/api/mutations";
-import { createTRPCRouter, organizationProcedure } from "@server/api/trpc";
+import {
+  adminProcedure,
+  createTRPCRouter,
+  organizationProcedure,
+} from "@server/api/trpc";
 import { setSections, setSectionTypes } from "@server/db/schema";
 import { TRPCError } from "@trpc/server";
-import { eq } from "drizzle-orm";
+import { and, eq, gt, sql } from "drizzle-orm";
 
 export const setSectionRouter = createTRPCRouter({
   create: organizationProcedure
@@ -154,5 +159,96 @@ export const setSectionRouter = createTRPCRouter({
     .input(swapSetSectionPositionSchema)
     .mutation(async ({ input }) => {
       return await updateSetSectionPosition(input.setSectionId, "last");
+    }),
+
+  delete: adminProcedure
+    .input(deleteSetSectionSchema)
+    .mutation(async ({ ctx, input }) => {
+      console.log(
+        `🤖 - [setSection/delete] - attempting to delete set section`,
+        { ...input },
+      );
+
+      try {
+        const deletedSetSection = await ctx.db.transaction(
+          async (deleteTransaction) => {
+            const setSectionToDelete =
+              await deleteTransaction.query.setSections.findFirst({
+                where: eq(setSections.id, input.setSectionId),
+              });
+
+            if (!setSectionToDelete) {
+              console.error(
+                `🤖 - [setSection/delete] - could not find sets section ${input.setSectionId}`,
+              );
+
+              throw new TRPCError({
+                code: "NOT_FOUND",
+                message: "Cannot find set section",
+              });
+            }
+
+            if (
+              setSectionToDelete.organizationId !==
+              ctx.user.membership.organizationId
+            ) {
+              console.error(
+                `🤖 - [setSection/delete] - User ${ctx.user.id} is not authorized to delete set section ${input.setSectionId}`,
+              );
+
+              throw new TRPCError({
+                code: "FORBIDDEN",
+                message: "Not authorized to delete this set section",
+              });
+            }
+
+            const [deletedSection] = await deleteTransaction
+              .delete(setSections)
+              .where(eq(setSections.id, input.setSectionId))
+              .returning();
+
+            if (!deletedSection) {
+              console.error(
+                `🤖 - [setSection/delete] - Could not delete set section ${input.setSectionId}. Aborting remaining sections reorder.`,
+              );
+
+              throw new TRPCError({
+                code: "INTERNAL_SERVER_ERROR",
+                message: "Failed to delete set section",
+              });
+            }
+
+            await deleteTransaction
+              .update(setSections)
+              .set({ position: sql`position - 1` })
+              .where(
+                and(
+                  eq(setSections.setId, deletedSection.setId),
+                  gt(setSections.position, deletedSection.position),
+                ),
+              );
+
+            return deletedSection;
+          },
+        );
+
+        console.info(
+          `🤖 - [setSection/delete] - SetSection ID ${deletedSetSection.id} was successfully deleted`,
+        );
+        return deletedSetSection;
+      } catch (deleteError) {
+        console.error(
+          `🤖 - [setSectionSong/delete] - Could not delete set section ${input.setSectionId}`,
+        );
+
+        if (deleteError instanceof TRPCError) {
+          throw deleteError;
+        }
+
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Failed to delete set section ${input.setSectionId}`,
+        });
+      }
     }),
 });

--- a/src/server/api/routers/setSection.ts
+++ b/src/server/api/routers/setSection.ts
@@ -17,12 +17,13 @@ export const setSectionRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       console.log("🤖 - [setSectionType/create] - input:", input);
 
-      const { setId, sectionTypeId, position } = input;
+      const { setId, sectionTypeId, position, organizationId } = input;
 
       const newSetSection: NewSetSection = {
         setId,
         sectionTypeId,
         position,
+        organizationId,
       };
 
       return ctx.db.insert(setSections).values(newSetSection).returning();

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -87,7 +87,7 @@ export const setSectionSongRouter = createTRPCRouter({
       }
 
       try {
-        const [deletedSong] = await ctx.db.transaction(async (transaction) => {
+        const deletedSong = await ctx.db.transaction(async (transaction) => {
           const [deletedSetSectionSong] = await transaction
             .delete(setSectionSongs)
             .where(eq(setSectionSongs.id, input.setSectionSongId))
@@ -118,7 +118,7 @@ export const setSectionSongRouter = createTRPCRouter({
                 gt(setSectionSongs.position, deletedSetSectionSong.position),
               ),
             );
-          return [deletedSetSectionSong];
+          return deletedSetSectionSong;
         });
         console.info(
           `🤖 - [setSectionSong/delete] - SetSectionSong ID ${deletedSong.id} was successfully deleted`,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -203,7 +203,7 @@ export const setSections = createTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     setId: uuid("set_id")
-      .references(() => sets.id)
+      .references(() => sets.id, { onDelete: "cascade" })
       .notNull(),
     position: integer("position").notNull(),
     sectionTypeId: uuid("section_type_id")
@@ -213,6 +213,9 @@ export const setSections = createTable(
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
     updatedAt,
+    organizationId: uuid("organization_id")
+      .references(() => organizations.id)
+      .notNull(),
   },
   (setSectionsTable) => {
     return {
@@ -224,7 +227,7 @@ export const setSections = createTable(
 export const setSectionSongs = createTable("set_section_songs", {
   id: uuid("id").primaryKey().defaultRandom(),
   setSectionId: uuid("set_section_id")
-    .references(() => setSections.id)
+    .references(() => setSections.id, { onDelete: "cascade" })
     .notNull(),
   songId: uuid("song_id")
     .references(() => songs.id)
@@ -324,6 +327,10 @@ export const setSectionsRelations = relations(setSections, ({ one, many }) => ({
   type: one(setSectionTypes, {
     fields: [setSections.sectionTypeId],
     references: [setSectionTypes.id],
+  }),
+  organization: one(organizations, {
+    fields: [setSections.organizationId],
+    references: [organizations.id],
   }),
 }));
 

--- a/src/server/db/seed.ts
+++ b/src/server/db/seed.ts
@@ -313,6 +313,7 @@ const seed = async () => {
         setId: set.id,
         position: index,
         sectionTypeId: sectionType.id,
+        organizationId: organization!.id,
       }),
     );
 


### PR DESCRIPTION
## Background
This PR is to add the UI action and TRPC route to delete a set section. This PR makes some db schema changes so you should run `pnpm db:update:prod`.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New Features**
  - Enabled administrators to delete set sections with enhanced error handling and reordering of remaining sections.
  - Introduced a new mutation for deleting set sections and improved user notifications during section removal.

- **Refactor**
  - Improved loading feedback during section movements.
  - Updated button text for adding sections to clearly indicate its purpose.
  - Adjusted the song removal process to close confirmation dialogs more seamlessly.

- **Chores**
  - Enhanced data consistency through updated deletion rules and refined associations in the database schema.
  - Added new schemas to improve validation and reusability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
### Functional Testing
1. **Basic Deletion**:
   - Navigate to any set with multiple sections
   - Click the action menu on any section
   - Select "Delete section" from the dropdown
   - Verify that a confirmation dialog appears showing the section type
   - Confirm deletion by clicking "Remove section"
   - Verify the section is removed and toast notification confirms success

2. **Position Reordering**:
   - Create a set with at least 3 sections (e.g., Full band, Prayer, Lord's Supper)
   - Delete the middle section (Prayer)
   - Verify the remaining sections are reordered correctly (Lord's Supper should now be at position 1)

3. **Authorization Testing**:
   - Login with a non-admin user account
   - Verify the delete section option is not available
   - (Or if visible but should fail) attempt to delete a section and verify it's rejected

4. **Error Handling**:
   - If possible, create a race condition where a section is being deleted while another operation is in progress
   - Verify appropriate error messages are displayed

5. **Cache Invalidation**:
   - Delete a section from a set
   - Navigate away from the set
   - Return to the set
   - Verify the section is still deleted (cache was properly invalidated)

### Edge Cases
1. **Last Section**:
   - Delete all sections except one from a set
   - Delete the final section
   - Verify the set still exists but has no sections

2. **Section with Songs**:
   - Add multiple songs to a section
   - Delete the section
   - Verify all associated songs in that section are removed as well
