### PR TITLE
[SWY-82] Add "add song to section" action

### DIFF
--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -22,7 +22,7 @@ import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeC
 import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { useUserQuery } from "@modules/users/api/queries";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
-import { redirect } from "next/navigation";
+import { redirect, useSearchParams } from "next/navigation";
 import { useState, type FC } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { toast } from "sonner";
@@ -62,6 +62,7 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   withActionsMenu,
 }) => {
   const { id, type, songs, setId, position, sectionTypeId } = section;
+  const searchParams = useSearchParams();
 
   const isFirstSection = position === 0;
   const isLastSection = position === setSectionsLength - 1;
@@ -132,6 +133,13 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
     );
   };
 
+  const openAddSongDialogWithPrePopulatedSection = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("addSongDialogOpen", "1");
+    params.set("setSectionId", section.id);
+    window.history.pushState(null, "", `?${params.toString()}`);
+  };
+
   const shouldUpdateSectionButtonBeDisabled =
     !isDirty || !isValid || isSubmitting;
   const isSetSectionTypesListLoading =
@@ -157,7 +165,14 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
                   {type.name}
                 </Text>
                 <HStack className="flex items-start gap-2">
-                  <Button size="sm" variant="outline">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={(clickEvent) => {
+                      clickEvent.preventDefault();
+                      openAddSongDialogWithPrePopulatedSection();
+                    }}
+                  >
                     <Plus className="text-slate-900" size={16} />
                     <span className="hidden sm:inline">Add song</span>
                   </Button>

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -113,16 +113,23 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
     setError,
     clearErrors,
   } = addSongToSetForm;
-  const shouldAddSongBeDisabled = !isDirty || !isValid || isSubmitting;
 
   useEffect(() => {
     if (prePopulatedSetSectionId) {
       setValue("setSectionId", prePopulatedSetSectionId, {
         shouldDirty: true,
+        shouldValidate: true,
       });
     }
-  }, [prePopulatedSetSectionId]);
+  }, [prePopulatedSetSectionId, setValue]);
 
+  const shouldAddSongBeDisabled = !isDirty || !isValid || isSubmitting;
+
+  console.log("🚀 ~ ConfigureSongForSet.tsx:112 ~ formState:", {
+    isDirty,
+    isSubmitting,
+    isValid,
+  });
   const addSetSectionSongMutation = api.setSectionSong.create.useMutation();
   const createSetSectionMutation = api.setSection.create.useMutation();
   const apiUtils = api.useUtils();

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -23,6 +23,7 @@ import {
 } from "@components/ui/select";
 import { Switch } from "@components/ui/switch";
 import { Textarea } from "@components/ui/textarea";
+import { VStack } from "@components/VStack";
 import { DevTool } from "@hookform/devtools";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { DESKTOP_MEDIA_QUERY_STRING, songKeys } from "@lib/constants";
@@ -44,7 +45,7 @@ import {
   Plus,
 } from "@phosphor-icons/react/dist/ssr";
 import { redirect } from "next/navigation";
-import { type Dispatch, type SetStateAction, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { useMediaQuery } from "usehooks-ts";
@@ -68,12 +69,13 @@ export type AddSongToSetFormFields = Omit<
   notes: NonNullable<z.infer<typeof createSetSectionSongsSchema>["notes"]>;
 };
 
-type ConfigureSongForSetProps = {
+export type ConfigureSongForSetProps = {
   existingSetSections: SetSectionWithSongs[];
   selectedSong: NonNullable<SongSearchResult>;
   setDialogStep: Dispatch<SetStateAction<SongSearchDialogSteps>>;
   onSubmit?: () => void;
   setId: string;
+  prePopulatedSetSectionId?: string | null;
 };
 
 export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
@@ -82,6 +84,7 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   setDialogStep,
   onSubmit,
   setId,
+  prePopulatedSetSectionId,
 }) => {
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
   const textSize = isDesktop ? "text-base" : "text-xs";
@@ -111,6 +114,14 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
     clearErrors,
   } = addSongToSetForm;
   const shouldAddSongBeDisabled = !isDirty || !isValid || isSubmitting;
+
+  useEffect(() => {
+    if (prePopulatedSetSectionId) {
+      setValue("setSectionId", prePopulatedSetSectionId, {
+        shouldDirty: true,
+      });
+    }
+  }, [prePopulatedSetSectionId]);
 
   const addSetSectionSongMutation = api.setSectionSong.create.useMutation();
   const createSetSectionMutation = api.setSection.create.useMutation();
@@ -451,18 +462,18 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                   />
                 )}
                 {sectionsForSetData.length === 0 && (
-                  <div className="mb-4 flex w-full flex-col items-center rounded border border-dashed border-slate-200 py-3">
-                    <Text
-                      style="header-small-semibold"
-                      align="center"
-                      className="text-slate-900"
-                    >
-                      No sections yet
-                    </Text>
-                    <Text align="center" className="">
-                      Add one below to get started.
-                    </Text>
-                  </div>
+                    <div className="mb-4 flex w-full flex-col items-center rounded border border-dashed border-slate-200 py-3">
+                      <Text
+                        style="header-small-semibold"
+                        align="center"
+                        className="text-slate-900"
+                      >
+                        No sections yet
+                      </Text>
+                      <Text align="center" className="">
+                        Add one below to get started.
+                      </Text>
+                    </div>
                 )}
                 {!isAddingSection && (
                   <Button

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -462,6 +462,12 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                   />
                 )}
                 {sectionsForSetData.length === 0 && (
+                  <VStack className="gap-2">
+                    <Text
+                      className={cn("font-normal text-slate-900", textSize)}
+                    >
+                      Which part of the set?
+                    </Text>
                     <div className="mb-4 flex w-full flex-col items-center rounded border border-dashed border-slate-200 py-3">
                       <Text
                         style="header-small-semibold"
@@ -474,6 +480,7 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                         Add one below to get started.
                       </Text>
                     </div>
+                  </VStack>
                 )}
                 {!isAddingSection && (
                   <Button

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -125,11 +125,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
 
   const shouldAddSongBeDisabled = !isDirty || !isValid || isSubmitting;
 
-  console.log("🚀 ~ ConfigureSongForSet.tsx:112 ~ formState:", {
-    isDirty,
-    isSubmitting,
-    isValid,
-  });
   const addSetSectionSongMutation = api.setSectionSong.create.useMutation();
   const createSetSectionMutation = api.setSection.create.useMutation();
   const apiUtils = api.useUtils();


### PR DESCRIPTION
## Background
This PR is to add the action to add a song to a specific set section. To achieve this, the search song dialog has been updated to use URL search params as its state. This also sets up to allow more fields to be pre-populated through the URL search params.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New Features**
  - The song addition interface now uses URL parameters to automatically open and pre-populate song dialogs, creating a smoother experience for assigning songs to a section.
  - Improved button interactions streamline the process of initiating the song search, ensuring the dialog state is updated seamlessly.

- **Style Improvements**
  - Updated layout and messaging provide clearer, more intuitive guidance—especially when no sections are available—enhancing overall usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
### Test Scenario 1: Adding a Song to a Section via Section Card
1. Navigate to a set detail page (`/[organization]/sets/[setId]`)
2. Locate a section card in the set
3. Click the "+ Add Song" button on the section card
4. Verify that the song search dialog opens
5. Verify that the URL now contains search parameters (`?addSongDialogOpen=1&setSectionId=[section-id]`)
6. Search for a song in the dialog
7. Select a song from the search results
8. Verify that the "Configure Song" step automatically shows the correct section pre-selected in the dropdown
9. Complete the song addition by clicking "Add Song"
10. Verify that the song appears in the correct section

### Test Scenario 2: Handling URL Parameters
1. Manually navigate to a set page with URL parameters: `/[organization]/sets/[setId]?addSongDialogOpen=1&setSectionId=[section-id]`
2. Verify that the song search dialog opens automatically
3. Verify that when a song is selected, the correct section is pre-populated in the configuration step

### Test Scenario 3: Dialog State Management
1. Open the song search dialog using the section card button
2. Click outside the dialog or press Escape to close it
3. Verify that the URL parameters (`addSongDialogOpen` and `setSectionId`) are removed from the URL
4. Reopen the dialog and complete adding a song
5. Verify that the URL parameters are removed after successful addition

### Test Scenario 4: Browser Navigation with Dialog State
1. Open the song search dialog using the section card button
2. Use browser back button
3. Verify that the dialog closes
4. Use browser forward button
5. Verify that the dialog reopens with the correct section pre-populated