### PR TITLE
[SWY-84] Add another section action

### DIFF
--- a/.cursor/rules/sanbi-rules.mdc
+++ b/.cursor/rules/sanbi-rules.mdc
@@ -1,0 +1,63 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+
+    You are an expert full-stack developer proficient in TypeScript, React, Next.js App Router, TRPC, Drizzle ORM, postgres, react-hook-form, Clerk auth, Tailwind CSS, Shadcn UI, and Radix UI. Your task is to produce the most optimized and maintainable Next.js code, following best practices and adhering to the principles of clean code and robust architecture.
+
+    ### Objective
+    - Create a Next.js solution that is not only functional but also adheres to the best practices in performance, security, and maintainability.
+
+    ### Code Style and Structure
+    - Use TypeScript with accurate types for all code. Prefer types over types. Avoid enums, use maps.
+    - Write concise, technical TypeScript code with accurate examples.
+    - Favor arrow functions over function declarition or function expressions, unless a function declaration is necessary
+    - React components should be created with named arrow functions (e.g. const component = () => {}) with separate types for its props
+    - Use functional and declarative programming patterns; avoid classes.
+    - Favor iteration and modularization over code duplication.
+    - Use descriptive variable names with auxiliary verbs (e.g., `isLoading`, `hasError`).
+    - Structure files with exported components, subcomponents, helpers, static content, and types.
+    - Use lowercase with dashes for directory names (e.g., `components/auth-wizard`).
+    - Use named exports for components
+    - Prefer iteration, modularization, and reusable code over duplication.
+
+    ### Optimization and Best Practices
+    - Implement dynamic imports for code splitting and optimization.
+    - Optimize images: use WebP format, include size data, implement lazy loading.
+
+    ### Error Handling and Validation
+    - Prioritize error handling and edge cases:
+      - Use early returns for error conditions.
+      - Implement guard clauses to handle preconditions and invalid states early.
+      - Use custom error types for consistent error handling.
+
+    ### UI and Styling
+    - Use Tailwind CSS and Shadcn UI for styling.
+    - Use responsive design with a mobile-first approach with Tailwind CSS.
+    - Implement consistent design and responsive patterns across platforms.
+
+    ### State Management and Data Fetching
+    - Use modern state management solutions (e.g., Zustand, TanStack React Query) to handle global state and data fetching.
+    - Implement validation using Zod for schema validation.
+
+    ### Security and Performance
+    - Implement proper error handling, user input validation, and secure coding practices.
+    - Follow performance optimization techniques, such as reducing load times and improving rendering efficiency.
+
+    ### Testing and Documentation
+    - Write unit tests for components using Jest and React Testing Library.
+    - Provide clear and concise comments for complex logic.
+    - Use JSDoc comments for functions and components to improve IDE intellisense.
+
+    ### Methodology
+    1. **System 2 Thinking**: Approach the problem with analytical rigor. Break down the requirements into smaller, manageable parts and thoroughly consider each step before implementation.
+    2. **Tree of Thoughts**: Evaluate multiple possible solutions and their consequences. Use a structured approach to explore different paths and select the optimal one.
+    3. **Iterative Refinement**: Before finalizing the code, consider improvements, edge cases, and optimizations. Iterate through potential enhancements to ensure the final solution is robust.
+
+    **Process**:
+    4. **Deep Dive Analysis**: Begin by conducting a thorough analysis of the task at hand, considering the technical requirements and constraints.
+    5. **Planning**: Develop a clear plan that outlines the architectural structure and flow of the solution, using <PLANNING> tags if necessary.
+    6. **Implementation**: Implement the solution step-by-step, ensuring that each part adheres to the specified best practices.
+    7. **Review and Optimize**: Perform a review of the code, looking for areas of potential optimization and improvement.
+    8. **Finalization**: Finalize the code by ensuring it meets all requirements, is secure, and is performant.

--- a/.cursor/rules/sanbi-rules.mdc
+++ b/.cursor/rules/sanbi-rules.mdc
@@ -1,6 +1,6 @@
 ---
-description: 
-globs: 
+description: Best practices and guidelines for Next.js application development with TypeScript, TRPC, and related technologies.
+globs: ["src/**/*.{ts,tsx}", "app/**/*.{ts,tsx}"]
 alwaysApply: true
 ---
 
@@ -10,9 +10,9 @@ alwaysApply: true
     - Create a Next.js solution that is not only functional but also adheres to the best practices in performance, security, and maintainability.
 
     ### Code Style and Structure
-    - Use TypeScript with accurate types for all code. Prefer types over types. Avoid enums, use maps.
+    - Use TypeScript with accurate types for all code. Prefer types over interfaces. Avoid enums, use maps.
     - Write concise, technical TypeScript code with accurate examples.
-    - Favor arrow functions over function declarition or function expressions, unless a function declaration is necessary
+    - Favor arrow functions over function declaration or function expressions, unless a function declaration is necessary
     - React components should be created with named arrow functions (e.g. const component = () => {}) with separate types for its props
     - Use functional and declarative programming patterns; avoid classes.
     - Favor iteration and modularization over code duplication.
@@ -33,7 +33,10 @@ alwaysApply: true
       - Use custom error types for consistent error handling.
 
     ### UI and Styling
-    - Use Tailwind CSS and Shadcn UI for styling.
+    - Use Tailwind CSS and Shadcn UI for styling:
+      - Customize Shadcn UI components through the global.css file rather than modifying the component source.
+      - Use Shadcn UI's theming capabilities for consistent branding.
+      - Leverage Shadcn UI's form components with react-hook-form for validated inputs.
     - Use responsive design with a mobile-first approach with Tailwind CSS.
     - Implement consistent design and responsive patterns across platforms.
 
@@ -46,7 +49,10 @@ alwaysApply: true
     - Follow performance optimization techniques, such as reducing load times and improving rendering efficiency.
 
     ### Testing and Documentation
-    - Write unit tests for components using Jest and React Testing Library.
+    - Implement a comprehensive testing strategy:
+      - Write unit tests for components and utility functions using Jest and React Testing Library.
+      - Create integration tests for API routes and data fetching workflows.
+      - Set up end-to-end tests with Playwright for critical user journeys.
     - Provide clear and concise comments for complex logic.
     - Use JSDoc comments for functions and components to improve IDE intellisense.
 

--- a/src/app/[organization]/layout.tsx
+++ b/src/app/[organization]/layout.tsx
@@ -1,7 +1,4 @@
-import { type Organization } from "@/lib/types";
-import { getOrganization } from "@/server/queries";
 import { auth } from "@clerk/nextjs/server";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { validate as uuidValidate } from "uuid";
 

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -26,7 +26,6 @@ import { cn } from "@lib/utils";
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
 import { useMediaQuery } from "usehooks-ts";
 import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
-import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { type ComboboxOption } from "@components/ui/combobox";
 import { toast } from "sonner";
 
@@ -48,8 +47,6 @@ export default function SetListPage({ params }: SetListPageProps) {
   const [isAddingSection, setIsAddingSection] = useState<boolean>(false);
   const [newSetSectionType, setNewSetSectionType] =
     useState<ComboboxOption | null>(null);
-  const [isAddSectionComboboxOpen, setIsAddSectionComboboxOpen] =
-    useState<boolean>(false);
 
   const createSetSectionMutation = api.setSection.create.useMutation();
   const apiUtils = api.useUtils();
@@ -108,11 +105,6 @@ export default function SetListPage({ params }: SetListPageProps) {
     error: userQueryError,
   } = api.user.getUser.useQuery({ userId: userId! }, { enabled: !!userId }); // we use a non-null assertion here since the query will be disabled if userId is falsy
   const userMembership = userData?.memberships[0];
-
-  const {
-    options: setSectionTypesOptions,
-    isLoading: isSetSectionTypesQueryLoading,
-  } = useSectionTypesOptions(userMembership?.organizationId);
 
   validateParams();
 
@@ -270,13 +262,8 @@ export default function SetListPage({ params }: SetListPageProps) {
               </Text>
               <SetSectionTypeCombobox
                 placeholder="Select a section type to add"
-                options={setSectionTypesOptions}
                 value={newSetSectionType}
                 onChange={setNewSetSectionType}
-                open={isAddSectionComboboxOpen}
-                setOpen={setIsAddSectionComboboxOpen}
-                loading={isSetSectionTypesQueryLoading}
-                disabled={isSetSectionTypesQueryLoading}
                 textStyles={cn("text-slate-700", textSize)}
                 organizationId={userMembership.organizationId}
               />

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -192,8 +192,8 @@ export default function SetListPage({ params }: SetListPageProps) {
     ) ?? 0;
 
   return (
-    <PageContentContainer className="gap-8">
-      <VStack className="gap6">
+    <PageContentContainer className="gap-8 lg:mb-16">
+      <VStack className="gap-6">
         <PageTitle
           title={formatDate(setData.date, { month: "long" })}
           subtitle={setData.eventType.name}

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -142,7 +142,7 @@ export default function SetListPage({ params }: SetListPageProps) {
     const toastId = toast.loading("Adding section to set...");
 
     if (!newSetSectionType) {
-      // TODO: this case shouldn't happen, but how would we properly handle it just in case?
+      toast.error("Please select a section type", { id: toastId });
       return;
     }
 

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -28,6 +28,16 @@ import { useMediaQuery } from "usehooks-ts";
 import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
 import { type ComboboxOption } from "@components/ui/combobox";
 import { toast } from "sonner";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogTrigger,
+} from "@components/ResponsiveDialog";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 
 type SetListPageProps = {
   params: { organization: string; setId: string };
@@ -44,7 +54,6 @@ export default function SetListPage({ params }: SetListPageProps) {
     useState<ConfigureSongForSetProps["prePopulatedSetSectionId"]>(undefined);
   const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] =
     useState<boolean>(false);
-  const [isAddingSection, setIsAddingSection] = useState<boolean>(false);
   const [newSetSectionType, setNewSetSectionType] =
     useState<ComboboxOption | null>(null);
 
@@ -157,7 +166,6 @@ export default function SetListPage({ params }: SetListPageProps) {
           async onSuccess() {
             toast.success(`Section added to set!`, { id: toastId });
 
-            setIsAddingSection(false);
             setNewSetSectionType(null);
 
             await apiUtils.setSection.getSectionsForSet.refetch({
@@ -251,60 +259,73 @@ export default function SetListPage({ params }: SetListPageProps) {
               );
             })}
           </>
-          {isAddingSection ? (
-            <VStack className="gap-4 rounded-lg border p-4 shadow lg:gap-8 lg:p-8">
-              <Text
-                asElement="h3"
-                style="header-medium-semibold"
-                className="flex-wrap text-xl"
-              >
-                Add a new section
-              </Text>
-              <SetSectionTypeCombobox
-                placeholder="Select a section type to add"
-                value={newSetSectionType}
-                onChange={setNewSetSectionType}
-                textStyles={cn("text-slate-700", textSize)}
-                organizationId={userMembership.organizationId}
-              />
-              <div className="mt-2 flex justify-end gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    setIsAddingSection(false);
-                    setNewSetSectionType(null);
-                  }}
-                  className={cn(textSize)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleAddSetSection}
-                  disabled={
-                    !newSetSectionType ||
-                    newSetSectionType.id === "" ||
-                    createSetSectionMutation.isPending
-                  }
-                  isLoading={createSetSectionMutation.isPending}
-                  className={cn(textSize)}
+          <ResponsiveDialog
+            onOpenChange={(isOpen) => {
+              if (!isOpen) {
+                setNewSetSectionType(null);
+              }
+            }}
+          >
+            <ResponsiveDialogTrigger asChild>
+              <Button variant="outline">
+                <Plus /> Add another section
+              </Button>
+            </ResponsiveDialogTrigger>
+            <ResponsiveDialogContent className="p-6 lg:p-8">
+              <ResponsiveDialogHeader>
+                <VisuallyHidden.Root>
+                  <>
+                    <ResponsiveDialogTitle>
+                      Add section to set
+                    </ResponsiveDialogTitle>
+                    <ResponsiveDialogDescription>
+                      Dialog to add section to set
+                    </ResponsiveDialogDescription>
+                  </>
+                </VisuallyHidden.Root>
+              </ResponsiveDialogHeader>
+              <ResponsiveDialogTitle>
+                <Text
+                  asElement="h3"
+                  style="header-medium-semibold"
+                  className="flex-wrap text-xl"
                 >
                   Add section to set
-                </Button>
-              </div>
-            </VStack>
-          ) : (
-            <Button
-              variant="outline"
-              onClick={() => {
-                setIsAddingSection(true);
-              }}
-            >
-              <Plus /> Add another section
-            </Button>
-          )}
+                </Text>
+              </ResponsiveDialogTitle>
+              <VStack className="mt-4 gap-4 lg:mt-0 lg:gap-8">
+                <SetSectionTypeCombobox
+                  placeholder="Select a section type to add"
+                  value={newSetSectionType}
+                  onChange={setNewSetSectionType}
+                  textStyles={cn("text-slate-700", textSize)}
+                  organizationId={userMembership.organizationId}
+                />
+                <div className="mt-2 flex justify-end gap-2">
+                  <ResponsiveDialogClose asChild>
+                    <Button variant="ghost" size="sm" className={cn(textSize)}>
+                      Cancel
+                    </Button>
+                  </ResponsiveDialogClose>
+                  <ResponsiveDialogClose asChild>
+                    <Button
+                      size="sm"
+                      onClick={handleAddSetSection}
+                      disabled={
+                        !newSetSectionType ||
+                        newSetSectionType.id === "" ||
+                        createSetSectionMutation.isPending
+                      }
+                      isLoading={createSetSectionMutation.isPending}
+                      className={cn(textSize)}
+                    >
+                      Add section to set
+                    </Button>
+                  </ResponsiveDialogClose>
+                </div>
+              </VStack>
+            </ResponsiveDialogContent>
+          </ResponsiveDialog>
         </VStack>
       )}
 

--- a/src/components/ResponsiveDialog/ResponsiveDialog.tsx
+++ b/src/components/ResponsiveDialog/ResponsiveDialog.tsx
@@ -154,34 +154,41 @@ export const ResponsiveDialogHeader: React.FC<ResponsiveDialogHeaderProps> = ({
 type ResponsiveDialogTitle = React.PropsWithChildren & {
   dialogProps?: DialogTitleProps;
   drawerProps?: DrawerTitleProps;
+  asChild?: boolean;
 };
 export const ResponsiveDialogTitle: React.FC<ResponsiveDialogTitle> = ({
   dialogProps,
   drawerProps,
+  asChild,
   children,
 }) => {
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
 
   return isDesktop ? (
-    <DialogTitle {...dialogProps}>{children}</DialogTitle>
+    <DialogTitle asChild={asChild} {...dialogProps}>
+      {children}
+    </DialogTitle>
   ) : (
-    <DrawerTitle {...drawerProps}>{children}</DrawerTitle>
+    <DrawerTitle asChild={asChild} {...drawerProps}>
+      {children}
+    </DrawerTitle>
   );
 };
 
 type ResponsiveDialogDescriptionProps = React.PropsWithChildren & {
   dialogProps?: DialogDescriptionProps;
   drawerProps?: DrawerDescriptionProps;
+  asChild?: boolean
 };
 export const ResponsiveDialogDescription: React.FC<
   ResponsiveDialogDescriptionProps
-> = ({ dialogProps, drawerProps, children }) => {
+> = ({ dialogProps, drawerProps, asChild, children }) => {
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
 
   return isDesktop ? (
-    <DialogDescription {...dialogProps}>{children}</DialogDescription>
+    <DialogDescription asChild={asChild} {...dialogProps}>{children}</DialogDescription>
   ) : (
-    <DrawerDescription {...drawerProps}>{children}</DrawerDescription>
+    <DrawerDescription asChild={asChild} {...drawerProps}>{children}</DrawerDescription>
   );
 };
 

--- a/src/modules/sets/components/SetEmptyState/SetEmptyState.tsx
+++ b/src/modules/sets/components/SetEmptyState/SetEmptyState.tsx
@@ -13,9 +13,8 @@ export const SetEmptyState: React.FC<SetEmptyStateProps> = ({
     <div className="flex grow flex-col items-center justify-center gap-4 min-[1025px]:mt-32 min-[1025px]:grow-0">
       <Text style="header-medium-semibold">No songs... yet</Text>
       <Text style="body-small" className="text-slate-700">
-        Add a song or section to start putting your set together
+        Add a song to start building your set
       </Text>
-      {/* TODO: wire up button with onClick handler */}
       <Button
         leftIcon={<MusicNoteSimple size={14} className="text-slate-100" />}
         onClick={onActionClick}

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -72,8 +72,6 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
 
   const [isEditingSectionType, setIsEditingSectionType] =
     useState<boolean>(false);
-  const [isAddSectionComboboxOpen, setIsAddSectionComboboxOpen] =
-    useState<boolean>(false);
 
   const updateSetSectionForm = useForm<UpdateSetSectionFormFields>({
     resolver: zodResolver(updateSetSectionSchema),
@@ -90,7 +88,7 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   const changeSetSectionTypeMutation = api.setSection.changeType.useMutation();
   const apiUtils = api.useUtils();
 
-  const { data: userData, isLoading: isUserQueryLoading } = useUserQuery();
+  const { data: userData } = useUserQuery();
 
   const userMembership = userData?.memberships[0];
 
@@ -98,10 +96,9 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
     redirect("/sign-in");
   }
 
-  const {
-    options: setSectionTypesOptions,
-    isLoading: isSetSectionTypesQueryLoading,
-  } = useSectionTypesOptions(userMembership.organizationId);
+  const { options: setSectionTypesOptions } = useSectionTypesOptions(
+    userMembership.organizationId,
+  );
 
   const handleUpdateSetSection: SubmitHandler<
     UpdateSetSectionFormFields
@@ -142,8 +139,6 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
 
   const shouldUpdateSectionButtonBeDisabled =
     !isDirty || !isValid || isSubmitting;
-  const isSetSectionTypesListLoading =
-    isUserQueryLoading || isSetSectionTypesQueryLoading;
 
   return (
     <VStack
@@ -217,15 +212,10 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
                           </FormLabel>
                           <FormControl>
                             <SetSectionTypeCombobox
-                              options={setSectionTypesOptions}
                               value={value}
                               onChange={(selectedValue) => {
                                 field.onChange(selectedValue?.id);
                               }}
-                              open={isAddSectionComboboxOpen}
-                              setOpen={setIsAddSectionComboboxOpen}
-                              loading={isSetSectionTypesListLoading}
-                              disabled={isSetSectionTypesQueryLoading}
                               textStyles={cn("text-slate-700", textSize)}
                               organizationId={userMembership.organizationId}
                               onCreateSuccess={(newSectionType) =>

--- a/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
+++ b/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
-import {
-  Combobox,
-  type ComboboxProps,
-  type ComboboxOption,
-} from "@components/ui/combobox";
+import { Combobox, type ComboboxOption } from "@components/ui/combobox";
 import { Input } from "@components/ui/input";
 import { Button } from "@components/ui/button";
 import { CommandGroup } from "@components/ui/command";
@@ -11,22 +7,17 @@ import { Plus } from "@phosphor-icons/react/dist/ssr";
 import { cn } from "@lib/utils";
 import { api } from "@/trpc/react";
 import { toast } from "sonner";
+import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 
 export type SetSectionTypeComboboxProps = {
   /** Available set section type options */
-  options: ComboboxOption[];
+  options?: ComboboxOption[];
 
   /** Currently selected value */
   value: ComboboxOption | null;
 
   /** Callback when value changes */
   onChange: (value: ComboboxOption | null) => void;
-
-  /** Whether the combobox is open */
-  open: boolean;
-
-  /** Callback to set open state */
-  setOpen: React.Dispatch<React.SetStateAction<ComboboxProps["open"]>>;
 
   /** Whether the combobox is loading */
   loading?: boolean;
@@ -51,8 +42,6 @@ export const SetSectionTypeCombobox: React.FC<SetSectionTypeComboboxProps> = ({
   options,
   value,
   onChange,
-  open,
-  setOpen,
   loading = false,
   disabled = false,
   organizationId,
@@ -60,11 +49,18 @@ export const SetSectionTypeCombobox: React.FC<SetSectionTypeComboboxProps> = ({
   placeholder = "Add a set section",
   onCreateSuccess,
 }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const [newSetSectionInputValue, setNewSetSectionInputValue] =
     useState<string>("");
 
   const createSetSectionTypeMutation = api.setSectionType.create.useMutation();
   const apiUtils = api.useUtils();
+
+  const {
+    options: setSectionTypesOptions,
+    isLoading: isSetSectionTypesQueryLoading,
+    error: setSectionTypesQueryError,
+  } = useSectionTypesOptions(organizationId);
 
   const handleCreateNewSetSectionType = async () => {
     const trimmedInput = newSetSectionInputValue.trim();
@@ -99,20 +95,20 @@ export const SetSectionTypeCombobox: React.FC<SetSectionTypeComboboxProps> = ({
       },
     );
 
-    setOpen(false);
+    setIsOpen(false);
     setNewSetSectionInputValue("");
   };
 
   return (
     <Combobox
       placeholder={placeholder}
-      options={options}
+      options={options ?? setSectionTypesOptions}
       value={value}
       onChange={onChange}
-      open={open}
-      setOpen={setOpen}
-      loading={loading}
-      disabled={disabled}
+      open={isOpen}
+      setOpen={setIsOpen}
+      loading={loading ?? isSetSectionTypesQueryLoading}
+      disabled={disabled ?? setSectionTypesQueryError}
       textStyles={cn(textStyles)}
     >
       <CommandGroup heading="Create new section type">

--- a/src/modules/sets/hooks/useSetSectionTypes.ts
+++ b/src/modules/sets/hooks/useSetSectionTypes.ts
@@ -2,11 +2,11 @@ import { api } from "@/trpc/react";
 import { type ComboboxOption } from "@components/ui/combobox";
 import { useEffect, useState } from "react";
 
-export function useSectionTypesOptions(organizationId: string) {
+export function useSectionTypesOptions(organizationId?: string) {
   const [options, setOptions] = useState<ComboboxOption[]>([]);
 
   const { data, error, isLoading } = api.setSectionType.getTypes.useQuery(
-    { organizationId },
+    { organizationId: organizationId! }, // we use a type assertion here since the query will be disabled if organizationId is falsy
     { enabled: !!organizationId },
   );
 

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -32,7 +32,6 @@ import { type SetSectionWithSongs } from "@lib/types";
 import { insertSetSectionSongSchema } from "@lib/types/zod";
 import { cn } from "@lib/utils";
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
-import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { SongListItem } from "@modules/songs/components/SongListItem";
 import { type SongSearchResult } from "@modules/songs/components/SongSearch";
 import { type SongSearchDialogSteps } from "@modules/songs/components/SongSearchDialog";
@@ -92,9 +91,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   const [newSetSectionType, setNewSetSectionType] =
     useState<ComboboxOption | null>(null);
 
-  const [isAddSectionComboboxOpen, setIsAddSectionComboboxOpen] =
-    useState<boolean>(false);
-
   const addSongToSetForm = useForm<AddSongToSetFormFields>({
     // mode: "onBlur",
     resolver: zodResolver(createSetSectionSongsSchema),
@@ -140,11 +136,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   if (!userMembership) {
     redirect("/sign-in");
   }
-
-  const {
-    options: setSectionTypesOptions,
-    isLoading: isSetSectionTypesQueryLoading,
-  } = useSectionTypesOptions(userMembership.organizationId);
 
   const { data: lastPlayInstance, isLoading: isLastPlayInstanceQueryLoading } =
     api.song.getLastPlayInstance.useQuery({
@@ -501,13 +492,8 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                   <>
                     <SetSectionTypeCombobox
                       placeholder="Add a set section"
-                      options={setSectionTypesOptions}
                       value={newSetSectionType}
                       onChange={setNewSetSectionType}
-                      open={isAddSectionComboboxOpen}
-                      setOpen={setIsAddSectionComboboxOpen}
-                      loading={isSetSectionTypesQueryLoading}
-                      disabled={isSetSectionTypesQueryLoading}
                       textStyles={cn("text-slate-700", textSize)}
                       organizationId={userMembership.organizationId}
                     />


### PR DESCRIPTION
## Background
This PR is to add UI that allows a user to add a new, empty section to the set without having to add a song, as long as the set doesn't already have a section of that type already. 

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New Features**
  - Enabled dynamic management of set sections, allowing users to add new sections with real-time feedback and validation.
  - Introduced an interactive dialog to streamline song additions.
  - Integrated a user-friendly selection control for choosing section types when customizing a set.

- **Style**
  - Updated the empty-state message to provide clearer, more focused guidance on starting a set.

- **Documentation**
  - Introduced a new configuration file outlining best practices and guidelines for Next.js application development.

- **Bug Fixes**
  - Simplified component state management by removing unnecessary loading indicators and state variables, enhancing performance and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
#### 1. Basic Functionality
1. Navigate to a set page that has at least one existing section
2. Verify the "Add another section" button appears at the bottom of the set
3. Click the "Add another section" button
4. Verify a dialog opens with:
   - A section type selector (combobox)
   - Cancel and "Add section to set" buttons
5. Select an available section type that doesn't already exist in the set
6. Click "Add section to set"
7. Verify:
   - Toast notification shows "Section added to set!"
   - The new empty section appears in the set
   - The dialog closes automatically

#### 2. Validation Testing
1. Navigate to a set page with existing sections
2. Click "Add another section"
3. **Test missing selection**:
   - When you don't have a section type selected, verify that the "Add section to set" button is disabled
4. **Test duplicate section**:
   - Select a section type that already exists in the set
   - Click "Add section to set"
   - Verify toast notification shows "Section type already exists on this set"

#### 3. Creating New Section Types
1. Click "Add another section"
2. In the section type combobox, type a new section type name
3. Click "Create" or press Enter
4. Verify:
   - New section type is created
   - Toast shows success message
   - The new section type is automatically selected
5. Click "Add section to set"
6. Verify the new section appears in the set

#### 4. UI/UX Testing
1. **Desktop view**:
   - Verify the dialog appears centered on screen
   - Verify the dialog has appropriate padding and styling
2. **Mobile view** (use responsive mode in browser dev tools):
   - Verify the dialog appears as a drawer from the bottom
   - Verify it's usable on small screens
3. **Cancel functionality**:
   - Open the dialog and click Cancel
   - Verify the dialog closes without creating a section
   - Verify any selected section type is cleared when reopening the dialog

#### 5. Empty Set Testing
1. Navigate to an empty set
2. Verify the empty state message reads "Add a song to start building your set" (not "Add a song or section...")
3. Add a song to the set
4. Verify the "Add another section" button appears after the set is no longer empty