### PR TITLE
[SWY-67] Update set actions menu

### DIFF
--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -30,12 +30,10 @@ import { type ComboboxOption } from "@components/ui/combobox";
 import { toast } from "sonner";
 import {
   ResponsiveDialog,
-  ResponsiveDialogClose,
   ResponsiveDialogContent,
   ResponsiveDialogDescription,
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
-  ResponsiveDialogTrigger,
 } from "@components/ResponsiveDialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 
@@ -56,6 +54,8 @@ export default function SetListPage({ params }: SetListPageProps) {
     useState<boolean>(false);
   const [newSetSectionType, setNewSetSectionType] =
     useState<ComboboxOption | null>(null);
+  const [isAddSectionDialogOpen, setIsAddSectionDialogOpen] =
+    useState<boolean>(false);
 
   const createSetSectionMutation = api.setSection.create.useMutation();
   const apiUtils = api.useUtils();
@@ -139,7 +139,7 @@ export default function SetListPage({ params }: SetListPageProps) {
     window.history.pushState(null, "", `?${queryString}`);
   };
 
-  const handleAddSetSection = async () => {
+  const handleAddSetSection = () => {
     const toastId = toast.loading("Adding section to set...");
 
     if (!newSetSectionType) {
@@ -158,7 +158,7 @@ export default function SetListPage({ params }: SetListPageProps) {
 
     const positionForNewSetSection = setData.sections.length;
 
-    await createSetSectionMutation.mutateAsync(
+    createSetSectionMutation.mutate(
       {
         setId: setData.id,
         organizationId: userMembership.organizationId,
@@ -223,6 +223,7 @@ export default function SetListPage({ params }: SetListPageProps) {
               setId={params.setId}
               organizationId={userMembership.organizationId}
               archived={setData.isArchived ?? false}
+              setIsAddSectionDialogOpen={setIsAddSectionDialogOpen}
             />
           </HStack>
         </VStack>
@@ -261,73 +262,79 @@ export default function SetListPage({ params }: SetListPageProps) {
               );
             })}
           </>
-          {/* TODO: extract to separate AddSectionDialog? */}
-          <ResponsiveDialog
-            onOpenChange={(isOpen) => {
-              if (!isOpen) {
-                setNewSetSectionType(null);
-              }
-            }}
+          <Button
+            variant="outline"
+            onClick={() => setIsAddSectionDialogOpen(true)}
           >
-            <ResponsiveDialogTrigger asChild>
-              <Button variant="outline">
-                <Plus /> Add another section
-              </Button>
-            </ResponsiveDialogTrigger>
-            <ResponsiveDialogContent className="p-6 lg:p-8">
-              <ResponsiveDialogHeader>
-                <ResponsiveDialogTitle asChild>
-                  <VisuallyHidden.Root>Add section to set</VisuallyHidden.Root>
-                </ResponsiveDialogTitle>
-                <ResponsiveDialogDescription asChild>
-                  <VisuallyHidden.Root>
-                    Dialog to add section to set
-                  </VisuallyHidden.Root>
-                </ResponsiveDialogDescription>
-              </ResponsiveDialogHeader>
-              <ResponsiveDialogTitle>
-                <Text
-                  asElement="h3"
-                  style="header-medium-semibold"
-                  className="flex-wrap text-xl"
-                >
-                  Add section to set
-                </Text>
-              </ResponsiveDialogTitle>
-              <VStack className="mt-4 gap-4 lg:mt-0 lg:gap-8">
-                <SetSectionTypeCombobox
-                  placeholder="Select a section type to add"
-                  value={newSetSectionType}
-                  onChange={setNewSetSectionType}
-                  textStyles={cn("text-slate-700", textSize)}
-                  organizationId={userMembership.organizationId}
-                />
-                <div className="mt-2 flex justify-end gap-2">
-                  <ResponsiveDialogClose asChild>
-                    <Button variant="ghost" size="sm" className={cn(textSize)}>
-                      Cancel
-                    </Button>
-                  </ResponsiveDialogClose>
-                  <ResponsiveDialogClose asChild>
-                    <Button
-                      size="sm"
-                      onClick={handleAddSetSection}
-                      disabled={
-                        !newSetSectionType?.id ||
-                        createSetSectionMutation.isPending
-                      }
-                      isLoading={createSetSectionMutation.isPending}
-                      className={cn(textSize)}
-                    >
-                      Add section to set
-                    </Button>
-                  </ResponsiveDialogClose>
-                </div>
-              </VStack>
-            </ResponsiveDialogContent>
-          </ResponsiveDialog>
+            <Plus /> Add another section
+          </Button>
         </VStack>
       )}
+      {/* TODO: extract to separate AddSectionDialog? */}
+      <ResponsiveDialog
+        open={isAddSectionDialogOpen}
+        onOpenChange={(isOpen) => {
+          setIsAddSectionDialogOpen(isOpen);
+          if (!isOpen) {
+            setNewSetSectionType(null);
+          }
+        }}
+      >
+        <ResponsiveDialogContent className="p-6 lg:p-8">
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle asChild>
+              <VisuallyHidden.Root>Add section to set</VisuallyHidden.Root>
+            </ResponsiveDialogTitle>
+            <ResponsiveDialogDescription asChild>
+              <VisuallyHidden.Root>
+                Dialog to add section to set
+              </VisuallyHidden.Root>
+            </ResponsiveDialogDescription>
+          </ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>
+            <Text
+              asElement="h3"
+              style="header-medium-semibold"
+              className="flex-wrap text-xl"
+            >
+              Add section to set
+            </Text>
+          </ResponsiveDialogTitle>
+          <VStack className="mt-4 gap-4 lg:mt-0 lg:gap-8">
+            <SetSectionTypeCombobox
+              placeholder="Select a section type to add"
+              value={newSetSectionType}
+              onChange={setNewSetSectionType}
+              textStyles={cn("text-slate-700", textSize)}
+              organizationId={userMembership.organizationId}
+            />
+            <div className="mt-2 flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(textSize)}
+                onClick={() => setIsAddSectionDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => {
+                  setIsAddSectionDialogOpen(false);
+                  handleAddSetSection();
+                }}
+                disabled={
+                  !newSetSectionType?.id || createSetSectionMutation.isPending
+                }
+                isLoading={createSetSectionMutation.isPending}
+                className={cn(textSize)}
+              >
+                Add section to set
+              </Button>
+            </div>
+          </VStack>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
 
       <SongSearchDialog
         open={isSongSearchDialogOpen}

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -6,6 +6,7 @@ import { Button } from "@components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  type DropdownMenuContentProps,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@components/ui/dropdown-menu";
@@ -37,11 +38,19 @@ type ActionMenuProps = PropsWithChildren & {
 
   /** callback to set open/closed state of the menu */
   setIsOpen: Dispatch<SetStateAction<boolean>>;
+
+  /** The preferred alignment against the trigger. May change when collisions occur. */
+  align?: DropdownMenuContentProps["align"];
+
+  /** The preferred side of the trigger to render against when open. Will be reversed when collisions occur and avoidCollisions is enabled. */
+  side?: DropdownMenuContentProps["side"];
 };
 
 export const ActionMenu: React.FC<ActionMenuProps> = ({
   isOpen,
   setIsOpen,
+  align = "end",
+  side = "bottom",
   children,
 }) => {
   return (
@@ -51,7 +60,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
           <DotsThree className="text-slate-900" size={16} />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent avoidCollisions align="end" side="bottom">
+      <DropdownMenuContent avoidCollisions align={align} side={side}>
         {children}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -11,13 +11,17 @@ import {
 } from "@components/ui/dropdown-menu";
 import { cn } from "@lib/utils";
 import {
+  Archive,
   ArrowDown,
   ArrowLineDown,
   ArrowLineUp,
   ArrowUp,
   Article,
+  BoxArrowUp,
+  Copy,
   DotsThree,
   Pencil,
+  Plus,
   Swap,
   Trash,
 } from "@phosphor-icons/react";
@@ -55,12 +59,16 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
 };
 
 const iconMap = {
+  Archive,
   ArrowDown,
   ArrowLineDown,
   ArrowLineUp,
   ArrowUp,
   Article,
+  BoxArrowUp,
+  Copy,
   Pencil,
+  Plus,
   Swap,
   Trash,
 } as const;

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,27 +1,27 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { Check, ChevronRight, Circle } from "lucide-react"
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
 
-import { cn } from "@lib/utils"
+import { cn } from "@lib/utils";
 
-const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenu = DropdownMenuPrimitive.Root;
 
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 
-const DropdownMenuGroup = DropdownMenuPrimitive.Group
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
 
-const DropdownMenuSub = DropdownMenuPrimitive.Sub
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
@@ -29,16 +29,16 @@ const DropdownMenuSubTrigger = React.forwardRef<
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   >
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
   </DropdownMenuPrimitive.SubTrigger>
-))
+));
 DropdownMenuSubTrigger.displayName =
-  DropdownMenuPrimitive.SubTrigger.displayName
+  DropdownMenuPrimitive.SubTrigger.displayName;
 
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
@@ -48,17 +48,20 @@ const DropdownMenuSubContent = React.forwardRef<
     ref={ref}
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
+      className,
     )}
     {...props}
   />
-))
+));
 DropdownMenuSubContent.displayName =
-  DropdownMenuPrimitive.SubContent.displayName
+  DropdownMenuPrimitive.SubContent.displayName;
 
+export type DropdownMenuContentProps = React.ComponentPropsWithoutRef<
+  typeof DropdownMenuPrimitive.Content
+>;
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+  DropdownMenuContentProps
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
@@ -66,18 +69,18 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
+        className,
       )}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>
-))
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
@@ -85,12 +88,12 @@ const DropdownMenuItem = React.forwardRef<
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   />
-))
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
@@ -100,7 +103,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     checked={checked}
     {...props}
@@ -112,9 +115,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.CheckboxItem>
-))
+));
 DropdownMenuCheckboxItem.displayName =
-  DropdownMenuPrimitive.CheckboxItem.displayName
+  DropdownMenuPrimitive.CheckboxItem.displayName;
 
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
@@ -124,7 +127,7 @@ const DropdownMenuRadioItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     {...props}
   >
@@ -135,13 +138,13 @@ const DropdownMenuRadioItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.RadioItem>
-))
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
@@ -149,12 +152,12 @@ const DropdownMenuLabel = React.forwardRef<
     className={cn(
       "px-2 py-1.5 text-sm font-semibold",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   />
-))
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
@@ -165,8 +168,8 @@ const DropdownMenuSeparator = React.forwardRef<
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}
   />
-))
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 const DropdownMenuShortcut = ({
   className,
@@ -177,9 +180,9 @@ const DropdownMenuShortcut = ({
       className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
       {...props}
     />
-  )
-}
-DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+  );
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   DropdownMenu,
@@ -197,4 +200,4 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuRadioGroup,
-}
+};

--- a/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
+++ b/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
@@ -1,19 +1,6 @@
 "use client";
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@components/ui/dropdown-menu";
-import {
-  Archive,
-  BoxArrowUp,
-  DotsThree,
-  Trash,
-} from "@phosphor-icons/react/dist/ssr";
-import { Text } from "@components/Text";
+import { DropdownMenuSeparator } from "@components/ui/dropdown-menu";
 import { api } from "@/trpc/react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
@@ -26,19 +13,22 @@ import {
   AlertDialogTitle,
 } from "@components/ui/alert-dialog";
 import { AlertDialogDescription } from "@radix-ui/react-alert-dialog";
-import { useState } from "react";
+import { type SetStateAction, type Dispatch, useState } from "react";
 import { Button } from "@components/ui/button";
+import { ActionMenu, ActionMenuItem } from "@components/ActionMenu";
 
 type SetActionsMenuProps = {
   setId: string;
   organizationId: string;
   archived: boolean;
+  setIsAddSectionDialogOpen: Dispatch<SetStateAction<boolean>>;
 };
 
 export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
   setId,
   organizationId,
   archived,
+  setIsAddSectionDialogOpen,
 }) => {
   const router = useRouter();
 
@@ -47,54 +37,69 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] =
     useState<boolean>(false);
 
-  // TODO: move to mutations
   const deleteSetMutation = api.set.delete.useMutation();
-  const deleteSet = (organizationId: string, setId: string) => {
+  const archiveSetMutation = api.set.archive.useMutation();
+  const unarchiveSetMutation = api.set.unarchive.useMutation();
+  const apiUtils = api.useUtils();
+
+  // TODO: move to mutations
+  const deleteSet = () => {
     setIsConfirmationDialogOpen(false);
+    const toastId = toast.loading("Deleting set...");
 
     deleteSetMutation.mutate(
       { organizationId, setId },
       {
         onSuccess() {
-          toast.success("Set deleted");
+          toast.success("Set deleted", { id: toastId });
           router.push(`/${organizationId}`);
         },
         onError(error) {
-          toast.error(`Set could not be deleted: ${error.message}`);
+          toast.error(`Set could not be deleted: ${error.message}`, {
+            id: toastId,
+          });
         },
       },
     );
   };
 
   // TODO: move to mutations
-  const archiveSetMutation = api.set.archive.useMutation();
-  const archiveSet = (organizationId: string, setId: string) => {
+  const archiveSet = () => {
+    setIsSetActionsMenuOpen(false);
+    const toastId = toast.loading("Archiving set...");
+
     archiveSetMutation.mutate(
       { organizationId, setId },
       {
-        onSuccess() {
-          toast.success("Set has been archived");
-          router.refresh();
+        async onSuccess() {
+          toast.success("Set has been archived", { id: toastId });
+          await apiUtils.set.get.invalidate({ setId, organizationId });
         },
         onError(error) {
-          toast.error(`Set could not be archived: ${error.message}`);
+          toast.error(`Set could not be archived: ${error.message}`, {
+            id: toastId,
+          });
         },
       },
     );
   };
 
   // TODO: move to mutations
-  const unarchiveSetMutation = api.set.unarchive.useMutation();
-  const unarchiveSet = (organizationId: string, setId: string) => {
+  const unarchiveSet = () => {
+    setIsSetActionsMenuOpen(false);
+    const toastId = toast.loading("Unarchiving set...");
+
     unarchiveSetMutation.mutate(
       { organizationId, setId },
       {
-        onSuccess() {
-          toast.success("Set has been unarchived");
-          router.refresh();
+        async onSuccess() {
+          toast.success("Set has been unarchived", { id: toastId });
+          await apiUtils.set.get.invalidate({ setId, organizationId });
         },
         onError(error) {
-          toast.error(`Set could not be unarchived: ${error.message}`);
+          toast.error(`Set could not be unarchived: ${error.message}`, {
+            id: toastId,
+          });
         },
       },
     );
@@ -102,40 +107,45 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
 
   return (
     <>
-      <DropdownMenu
-        open={isSetActionsMenuOpen}
-        onOpenChange={setIsSetActionsMenuOpen}
+      <ActionMenu
+        isOpen={isSetActionsMenuOpen}
+        setIsOpen={setIsSetActionsMenuOpen}
       >
-        <DropdownMenuTrigger>
-          <Button variant="outline" size="sm">
-            <DotsThree className="text-slate-900" size={12} />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuItem
-            className="gap-1"
-            onSelect={() =>
-              archived
-                ? unarchiveSet(organizationId, setId)
-                : archiveSet(organizationId, setId)
-            }
-          >
-            {archived ? <BoxArrowUp /> : <Archive />}
-            <Text>{archived ? "Unarchive" : "Archive"} set</Text>
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            className="gap-1 text-slate-400 hover:bg-red-100 hover:text-red-800 active:bg-red-200 active:text-red-900"
-            onSelect={() => {
-              setIsSetActionsMenuOpen(false);
-              setIsConfirmationDialogOpen(true);
-            }}
-          >
-            <Trash />
-            <Text>Delete set</Text>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        <ActionMenuItem
+          icon="Plus"
+          label="Add set section"
+          onClick={() => {
+            setIsSetActionsMenuOpen(false);
+            setIsAddSectionDialogOpen(true);
+          }}
+        />
+        <DropdownMenuSeparator />
+        <ActionMenuItem icon="Pencil" label="Edit set details" />
+        <ActionMenuItem icon="Copy" label="Duplicate set" />
+        {archived ? (
+          <ActionMenuItem
+            icon="BoxArrowUp"
+            label="Unarchive set"
+            onClick={unarchiveSet}
+          />
+        ) : (
+          <ActionMenuItem
+            icon="Archive"
+            label="Archive set"
+            onClick={archiveSet}
+          />
+        )}
+        <DropdownMenuSeparator />
+        <ActionMenuItem
+          icon="Trash"
+          label="Delete set"
+          destructive
+          onClick={() => {
+            setIsSetActionsMenuOpen(false);
+            setIsConfirmationDialogOpen(true);
+          }}
+        />
+      </ActionMenu>
       <AlertDialog
         open={isConfirmationDialogOpen}
         onOpenChange={setIsConfirmationDialogOpen}
@@ -156,10 +166,7 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
             >
               Cancel
             </AlertDialogCancel>
-            <Button
-              variant="destructive"
-              onClick={() => deleteSet(organizationId, setId)}
-            >
+            <Button variant="destructive" onClick={() => deleteSet()}>
               Delete set
             </Button>
           </AlertDialogFooter>

--- a/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
+++ b/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { DropdownMenuSeparator } from "@components/ui/dropdown-menu";
+import {
+  type DropdownMenuContentProps,
+  DropdownMenuSeparator,
+} from "@components/ui/dropdown-menu";
 import { api } from "@/trpc/react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
@@ -22,6 +25,8 @@ type SetActionsMenuProps = {
   organizationId: string;
   archived: boolean;
   setIsAddSectionDialogOpen: Dispatch<SetStateAction<boolean>>;
+  align?: DropdownMenuContentProps["align"];
+  side?: DropdownMenuContentProps["side"];
 };
 
 export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
@@ -110,6 +115,7 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
       <ActionMenu
         isOpen={isSetActionsMenuOpen}
         setIsOpen={setIsSetActionsMenuOpen}
+        align="center"
       >
         <ActionMenuItem
           icon="Plus"


### PR DESCRIPTION
## Background
This PR is to update the set actions manually from the current implementation to match the other action menus (set section, set section song) and to match the design with additional actions.
The actions that were already implemented are added to the updated menu so the functionality will stay the same. The remaining actions will be implemented in separate future PRs.

| Before | After |
| ------- | ---- |
| ![SWY-67__before](https://github.com/user-attachments/assets/02c9a2a7-8fff-41f4-8d40-7063ddfd9743) | ![SWY-67__after](https://github.com/user-attachments/assets/40526e2c-51cb-483b-8072-8293df876199) |


## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved the workflow for adding sections to a set with a dedicated button that opens a responsive dialog for section selection.
	- Revamped set actions with a streamlined menu offering options like adding sections, editing details, duplicating, archiving, unarchiving, and deleting sets.
	- Enhanced menu visuals with new icons for clearer action identification.
- **Bug Fixes**
	- Adjusted handling of confirmation dialogs and loading states for actions within the set actions menu.
- **Style**
	- Improved code consistency with formatting updates across various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
### 1. Visual Verification
- Open a set by navigating to `/[organization]/sets/[setId]`
- Look for the three-dots menu button in the set header
- Verify the set actions menu has the following options in the correct order:
  - "Add set section" (with Plus icon)
  - [separator]
  - "Edit set details" (with Pencil icon)
  - "Duplicate set" (with Copy icon)
  - "Archive set" or "Unarchive set" depending on set status (with Archive/BoxArrowUp icon)
  - [separator]
  - "Delete set" (with Trash icon in red)
- Confirm the styling is consistent with other action menus in the application

### 2. Functional Testing - Add Set Section
- Click on the three-dots menu to open the actions menu
- Click on "Add set section"
- Verify that the menu closes and a section selection dialog opens
- Select a section type and add it to the set
- Verify that the section is added successfully to the set

### 3. Archive/Unarchive Functionality
- For an unarchived set:
  - Open the set actions menu and click "Archive set"
  - Verify the loading state appears
  - Confirm a success toast is shown when the operation completes
  - Verify the set is now marked as archived in the UI ("SET IS ARCHIVED")
  - Open the menu again and confirm "Archive set" has changed to "Unarchive set"
- For an archived set:
  - Open the set actions menu and click "Unarchive set"
  - Verify the loading state appears
  - Confirm a success toast is shown when the operation completes
  - Verify the set no longer shows "SET IS ARCHIVED"
  - Open the menu again and confirm "Unarchive set" has changed to "Archive set"

### 4. Delete Set Functionality
- Open the set actions menu and click "Delete set"
- Verify a confirmation dialog appears with:
  - Warning text about permanent deletion
  - Suggestion to archive instead if unsure
  - Cancel and Delete set buttons
- Test cancellation by clicking "Cancel" and verify the dialog closes without action
- Test deletion by reopening the menu, clicking "Delete set", then confirming deletion
- Verify the user is redirected to the organization page after successful deletion
- Verify that the associated set sections and set section songs have also been deleted

### 5. Edge Cases
- Test the menu on both desktop and mobile to ensure responsive behavior
- If there are no sections in a set, verify the "Add set section" functionality still works
- Test with very long set names to ensure the menu displays properly