### PR TITLE
[SWY-86]  Edit set details action

### DIFF
--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -37,6 +37,7 @@ import {
 } from "@components/ResponsiveDialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { SetNotes } from "@modules/sets/components/SetNotes";
+import { SetDetails } from "@modules/sets/components/SetDetails";
 
 type SetListPageProps = {
   params: { organization: string; setId: string };
@@ -49,6 +50,8 @@ export default function SetListPage({ params }: SetListPageProps) {
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
   const textSize = isDesktop ? "text-base" : "text-xs";
 
+  const [isEditingSetDetails, setIsEditingSetDetails] =
+    useState<boolean>(false);
   const [prePopulatedSetSectionId, setPrePopulatedSetSectionId] =
     useState<ConfigureSongForSetProps["prePopulatedSetSectionId"]>(undefined);
   const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] =
@@ -186,20 +189,14 @@ export default function SetListPage({ params }: SetListPageProps) {
     );
   };
 
-  const songCount =
-    setData?.sections.reduce(
-      (total, section) => total + section.songs.length,
-      0,
-    ) ?? 0;
-
   return (
     <PageContentContainer className="gap-8 lg:mb-16">
       <VStack className="gap-6">
         <HStack className="items-start justify-between">
-          <PageTitle
-            title={formatDate(setData.date, { month: "long" })}
-            subtitle={setData.eventType.name}
-            details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
+          <SetDetails
+            set={setData}
+            isEditing={isEditingSetDetails}
+            setIsEditing={setIsEditingSetDetails}
           />
           <HStack className="gap-2">
             <SetActionsMenu
@@ -207,6 +204,7 @@ export default function SetListPage({ params }: SetListPageProps) {
               organizationId={userMembership.organizationId}
               archived={setData.isArchived ?? false}
               setIsAddSectionDialogOpen={setIsAddSectionDialogOpen}
+              setIsEditingSetDetails={setIsEditingSetDetails}
               align="end"
             />
             {setData?.sections && setData.sections.length > 0 && (

--- a/src/lib/types/db.ts
+++ b/src/lib/types/db.ts
@@ -42,6 +42,10 @@ export type SongTag = typeof songTags.$inferSelect;
 
 export type NewSet = typeof sets.$inferInsert;
 export type SetType = typeof sets.$inferSelect; // have to have the "Type" suffix since Set is a reserved keyword
+export type SetWithSectionsSongsAndEventType = SetType & {
+  eventType: SetSectionTypeType;
+  sections: SetSectionWithSongs[];
+};
 
 export type NewSetSection = typeof setSections.$inferInsert;
 export type SetSection = typeof setSections.$inferSelect;

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -37,17 +37,16 @@ export const insertOrganizationMembershipSchema = createInsertSchema(
  */
 export const getSetSchema = z.object({ setId: z.string().uuid() });
 export const insertSetSchema = createInsertSchema(sets);
-
 const setIdSchema = z.object({
   setId: z.string().uuid(),
 });
-
 export const archiveSetSchema = setIdSchema;
-
 export const unarchiveSetSchema = setIdSchema;
-
 export const deleteSetSchema = setIdSchema;
-
+export const updateSetDetailsSchema = setIdSchema.extend({
+  date: z.string().date(),
+  eventTypeId: z.string().uuid(),
+});
 export const updateSetNotesSchema = setIdSchema.extend({
   notes: z.string().trim(),
 });

--- a/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
+++ b/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
@@ -27,6 +27,7 @@ type SetActionsMenuProps = {
   setIsAddSectionDialogOpen: Dispatch<SetStateAction<boolean>>;
   align?: DropdownMenuContentProps["align"];
   side?: DropdownMenuContentProps["side"];
+  setIsEditingSetDetails: Dispatch<SetStateAction<boolean>>;
 };
 
 export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
@@ -36,6 +37,7 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
   setIsAddSectionDialogOpen,
   align,
   side,
+  setIsEditingSetDetails,
 }) => {
   const router = useRouter();
 
@@ -129,7 +131,14 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
           }}
         />
         <DropdownMenuSeparator />
-        <ActionMenuItem icon="Pencil" label="Edit set details" />
+        <ActionMenuItem
+          icon="Pencil"
+          label="Edit set details"
+          onClick={() => {
+            setIsSetActionsMenuOpen(false);
+            setIsEditingSetDetails(true);
+          }}
+        />
         <ActionMenuItem icon="Copy" label="Duplicate set" />
         {archived ? (
           <ActionMenuItem

--- a/src/modules/sets/components/SetDetails/SetDetails.tsx
+++ b/src/modules/sets/components/SetDetails/SetDetails.tsx
@@ -31,8 +31,13 @@ export const SetDetails: React.FC<SetDetailsProps> = ({
     set.sections.reduce((total, section) => total + section.songs.length, 0) ??
     0;
 
-  if (isEditing) {
-    return (
+  return (
+    <>
+      <PageTitle
+        title={formatDate(set.date, { month: "long" })}
+        subtitle={set.eventType.name}
+        details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
+      />
       <ResponsiveDialog open={isEditing} onOpenChange={setIsEditing}>
         <ResponsiveDialogContent>
           <ResponsiveDialogHeader>
@@ -46,14 +51,6 @@ export const SetDetails: React.FC<SetDetailsProps> = ({
           <EditSetDetailsForm set={set} setIsEditing={setIsEditing} />
         </ResponsiveDialogContent>
       </ResponsiveDialog>
-    );
-  }
-
-  return (
-    <PageTitle
-      title={formatDate(set.date, { month: "long" })}
-      subtitle={set.eventType.name}
-      details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
-    />
+    </>
   );
 };

--- a/src/modules/sets/components/SetDetails/SetDetails.tsx
+++ b/src/modules/sets/components/SetDetails/SetDetails.tsx
@@ -1,0 +1,59 @@
+import { PageTitle } from "@components/PageTitle";
+import { formatDate } from "@lib/date/formatDate";
+import { pluralize } from "@lib/string/pluralize";
+import { type SetWithSectionsSongsAndEventType } from "@lib/types";
+import {
+  EditSetDetailsForm,
+  type EditSetDetailsFormProps,
+} from "../forms/EditSetDetailsForm";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@components/ResponsiveDialog";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
+import { Text } from "@components/Text";
+
+type SetDetailsProps = {
+  set: SetWithSectionsSongsAndEventType;
+  isEditing: boolean;
+  setIsEditing: EditSetDetailsFormProps["setIsEditing"];
+};
+
+export const SetDetails: React.FC<SetDetailsProps> = ({
+  set,
+  isEditing,
+  setIsEditing,
+}) => {
+  const songCount =
+    set.sections.reduce((total, section) => total + section.songs.length, 0) ??
+    0;
+
+  if (isEditing) {
+    return (
+      <ResponsiveDialog open={isEditing} onOpenChange={setIsEditing}>
+        <ResponsiveDialogContent>
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle>Edit set details</ResponsiveDialogTitle>
+            <VisuallyHidden.Root>
+              <ResponsiveDialogDescription>
+                Edit set details
+              </ResponsiveDialogDescription>
+            </VisuallyHidden.Root>
+          </ResponsiveDialogHeader>
+          <EditSetDetailsForm set={set} setIsEditing={setIsEditing} />
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+    );
+  }
+
+  return (
+    <PageTitle
+      title={formatDate(set.date, { month: "long" })}
+      subtitle={set.eventType.name}
+      details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
+    />
+  );
+};

--- a/src/modules/sets/components/SetDetails/index.ts
+++ b/src/modules/sets/components/SetDetails/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetDetails";

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -120,7 +120,6 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
           </HStack>
         </VStack>
       </form>
-      <DevTool control={editSetDetailsForm.control} />
     </FormProvider>
   );
 };

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -41,7 +41,9 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
 
   const isSubmitDisabled = !isDirty || !isValid;
 
-  const handleEditSetDetails = () => {};
+  const handleEditSetDetails = (formValues: EditSetDetailsFields) => {
+    // TODO: update the set db record with the form values
+  };
 
   return (
     <FormProvider {...editSetDetailsForm}>

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -94,7 +94,7 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
   return (
     <FormProvider {...editSetDetailsForm}>
       <form onSubmit={editSetDetailsForm.handleSubmit(handleEditSetDetails)}>
-        <VStack className="mx-6 gap-6">
+        <VStack className="mx-6 gap-6 p-8">
           <SetDatePickerFormField />
           <SetEventTypeSelectFormField />
           <HStack className="justify-end gap-2">

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -1,0 +1,72 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type SetWithSectionsSongsAndEventType } from "@lib/types";
+import { FormProvider, useForm } from "react-hook-form";
+import { type CreateSetFormFields } from "@modules/sets/components/CreateSetForm";
+import { insertSetSchema } from "@lib/types/zod";
+import { SetDatePickerFormField } from "@modules/sets/components/forms/SetDatePickerFormField";
+import { VStack } from "@components/VStack";
+import { HStack } from "@components/HStack";
+import { Button } from "@components/ui/button";
+import { type Dispatch, type SetStateAction } from "react";
+import { SetEventTypeSelectFormField } from "./SetEventTypeSelectFormField";
+import { DevTool } from "@hookform/devtools";
+
+const editSetDetailsFormSchema = insertSetSchema.pick({
+  date: true,
+  eventTypeId: true,
+});
+
+export type EditSetDetailsFields = Omit<CreateSetFormFields, "notes">;
+
+export type EditSetDetailsFormProps = {
+  set: SetWithSectionsSongsAndEventType;
+  setIsEditing: Dispatch<SetStateAction<boolean>>;
+};
+
+export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
+  set,
+  setIsEditing,
+}) => {
+  const editSetDetailsForm = useForm<EditSetDetailsFields>({
+    resolver: zodResolver(editSetDetailsFormSchema),
+    defaultValues: {
+      date: set.date,
+      eventTypeId: set.eventTypeId,
+    },
+  });
+
+  const {
+    formState: { isDirty, isValid },
+  } = editSetDetailsForm;
+
+  const isSubmitDisabled = !isDirty || !isValid;
+
+  const handleEditSetDetails = () => {};
+
+  return (
+    <FormProvider {...editSetDetailsForm}>
+      <form onSubmit={editSetDetailsForm.handleSubmit(handleEditSetDetails)}>
+        <VStack className="gap-6">
+          <SetDatePickerFormField />
+          <SetEventTypeSelectFormField />
+          <HStack className="justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setIsEditing(false);
+                editSetDetailsForm.reset();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={isSubmitDisabled}>
+              Save details
+            </Button>
+          </HStack>
+        </VStack>
+      </form>
+      <DevTool control={editSetDetailsForm.control} />
+    </FormProvider>
+  );
+};

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -59,8 +59,9 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
     formState: { isDirty, isValid },
   } = editSetDetailsForm;
 
+  const isLoading = updateSetDetailsMutation.isPending;
   const isSubmitDisabled =
-    !isDirty || !isValid || userQueryLoading || !isAuthLoaded;
+    !isDirty || !isValid || userQueryLoading || !isAuthLoaded || isLoading;
 
   const handleEditSetDetails = (formValues: EditSetDetailsFields) => {
     const { date, eventTypeId } = formValues;
@@ -108,7 +109,12 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
             >
               Cancel
             </Button>
-            <Button type="submit" size="sm" disabled={isSubmitDisabled}>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={isSubmitDisabled}
+              isLoading={isLoading}
+            >
               Save details
             </Button>
           </HStack>

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -1,23 +1,20 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import { type SetWithSectionsSongsAndEventType } from "@lib/types";
-import { FormProvider, useForm } from "react-hook-form";
-import { type CreateSetFormFields } from "@modules/sets/components/CreateSetForm";
-import { insertSetSchema } from "@lib/types/zod";
-import { SetDatePickerFormField } from "@modules/sets/components/forms/SetDatePickerFormField";
-import { VStack } from "@components/VStack";
+import { api } from "@/trpc/react";
 import { HStack } from "@components/HStack";
 import { Button } from "@components/ui/button";
-import { type Dispatch, type SetStateAction } from "react";
-import { SetEventTypeSelectFormField } from "./SetEventTypeSelectFormField";
+import { VStack } from "@components/VStack";
 import { DevTool } from "@hookform/devtools";
-import { api } from "@/trpc/react";
-import { toast } from "sonner";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type SetWithSectionsSongsAndEventType } from "@lib/types";
+import { updateSetDetailsSchema } from "@lib/types/zod";
+import { type CreateSetFormFields } from "@modules/sets/components/CreateSetForm";
+import { SetDatePickerFormField } from "@modules/sets/components/forms/SetDatePickerFormField";
 import { useUserQuery } from "@modules/users/api/queries";
+import { type Dispatch, type SetStateAction } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { SetEventTypeSelectFormField } from "./SetEventTypeSelectFormField";
 
-const editSetDetailsFormSchema = insertSetSchema.pick({
-  date: true,
-  eventTypeId: true,
-});
+const editSetDetailsFormSchema = updateSetDetailsSchema;
 
 export type EditSetDetailsFields = Omit<CreateSetFormFields, "notes">;
 
@@ -50,6 +47,7 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
   });
 
   if (!!userQueryError || !userData || !userMembership) {
+    // FIXME: show an error here instead?
     return;
   }
 

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -14,7 +14,10 @@ import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { SetEventTypeSelectFormField } from "./SetEventTypeSelectFormField";
 
-const editSetDetailsFormSchema = updateSetDetailsSchema;
+const editSetDetailsFormSchema = updateSetDetailsSchema.pick({
+  date: true,
+  eventTypeId: true,
+});
 
 export type EditSetDetailsFields = Omit<CreateSetFormFields, "notes">;
 
@@ -44,6 +47,7 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
       date: set.date,
       eventTypeId: set.eventTypeId,
     },
+    mode: "onChange",
   });
 
   if (!!userQueryError || !userData || !userMembership) {

--- a/src/modules/sets/components/forms/SetDatePickerFormField.tsx
+++ b/src/modules/sets/components/forms/SetDatePickerFormField.tsx
@@ -29,7 +29,8 @@ export const SetDatePickerFormField: React.FC = () => {
             <DatePicker
               {...field}
               presets={datePresets}
-              initialDate={field.value}
+              initialDate={field.value as Date} // technically, this is a string, but this satisfies TS and works..
+              // also, asserting the type since TS can't tell since we're using form context
             />
           </FormControl>
         </FormItem>

--- a/src/modules/sets/components/forms/SetDatePickerFormField.tsx
+++ b/src/modules/sets/components/forms/SetDatePickerFormField.tsx
@@ -1,0 +1,39 @@
+import { DatePicker, type DatePickerPreset } from "@components/ui/datePicker";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@components/ui/form";
+import { useFormContext } from "react-hook-form";
+
+const datePresets: DatePickerPreset[] = [
+  {
+    value: "0",
+    label: "Today",
+  },
+  { value: "1", label: "Tomorrow" },
+];
+
+export const SetDatePickerFormField: React.FC = () => {
+  const { control } = useFormContext();
+
+  return (
+    <FormField
+      control={control}
+      name="date"
+      render={({ field }) => (
+        <FormItem className="flex flex-col gap-2">
+          <FormLabel>Set date *</FormLabel>
+          <FormControl>
+            <DatePicker
+              {...field}
+              presets={datePresets}
+              initialDate={field.value}
+            />
+          </FormControl>
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/src/modules/sets/components/forms/SetEventTypeSelectFormField.tsx
+++ b/src/modules/sets/components/forms/SetEventTypeSelectFormField.tsx
@@ -57,7 +57,10 @@ export const SetEventTypeSelectFormField: React.FC = () => {
         <FormItem className="flex flex-col gap-2">
           <FormLabel>Event type *</FormLabel>
           <FormControl>
-            <Select value={field.value} onValueChange={field.onChange}>
+            <Select
+              value={field.value as string} // asserting the type since TS can't tell due to the form context
+              onValueChange={field.onChange}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Select event type" />
               </SelectTrigger>

--- a/src/modules/sets/components/forms/SetEventTypeSelectFormField.tsx
+++ b/src/modules/sets/components/forms/SetEventTypeSelectFormField.tsx
@@ -1,0 +1,91 @@
+import { api } from "@/trpc/react";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@components/ui/select";
+import { Skeleton } from "@components/ui/skeleton";
+import { VStack } from "@components/VStack";
+import { useUserQuery } from "@modules/users/api/queries";
+import { skipToken } from "@tanstack/react-query";
+import { useFormContext } from "react-hook-form";
+import { Text } from "@components/Text";
+
+export const SetEventTypeSelectFormField: React.FC = () => {
+  const { control } = useFormContext();
+
+  const {
+    data: userData,
+    error: userQueryError,
+    isLoading: userQueryLoading,
+    isAuthLoaded,
+  } = useUserQuery();
+  const userMembership = userData?.memberships[0];
+
+  const {
+    data: eventTypeData,
+    isError: eventTypeQueryError,
+    isLoading: eventTypeQueryLoading,
+  } = api.eventType.getEventTypes.useQuery(
+    userMembership
+      ? { organizationId: userMembership.organizationId }
+      : skipToken,
+  );
+
+  const isLoading = !isAuthLoaded || userQueryLoading || eventTypeQueryLoading;
+  const isError = !!userQueryError || !!eventTypeQueryError;
+
+  if (isError) {
+    return (
+      <Text>Uh oh. We couldn&apos;t get your team&apos;s event types.</Text>
+    );
+  }
+
+  return (
+    <FormField
+      control={control}
+      name="eventTypeId"
+      render={({ field }) => (
+        <FormItem className="flex flex-col gap-2">
+          <FormLabel>Event type *</FormLabel>
+          <FormControl>
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select event type" />
+              </SelectTrigger>
+              <SelectContent>
+                {isLoading && (
+                  <VStack className="gap-3 py-3">
+                    <div className="pl-8 pr-2">
+                      <Skeleton className="h-4 w-1/2" />
+                    </div>
+                    <div className="pl-8 pr-2">
+                      <Skeleton className="h-4 w-2/5" />
+                    </div>
+                    <div className="pl-8 pr-2">
+                      <Skeleton className="h-4 w-3/5" />
+                    </div>
+                  </VStack>
+                )}
+                {!isLoading &&
+                  eventTypeData?.map((eventType) => (
+                    <SelectItem key={eventType.id} value={eventType.id}>
+                      {eventType.name}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+          </FormControl>
+        </FormItem>
+      )}
+    />
+  );
+};


### PR DESCRIPTION
## Background
This PR is to add the ability for the user to edit the set details (i.e. set date and event type). This introduces an edit set details form that is shown to the user in a responsive dialog to have consistency with the create set form.
![SWY-86__after](https://github.com/user-attachments/assets/a2bc7314-d296-46b5-a0c9-3f306e204ce2)

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New Features**
  - Introduced a refreshed, interactive set details view that streamlines the display of set information and supports direct editing via a responsive dialog.
  - Updated the actions menu to enable seamless toggling into edit mode.
  - Enhanced the set creation and editing forms with modular inputs for date and event type selection, along with improved feedback notifications for a smoother user experience.
  - Added new components for managing set details, including a dedicated form for editing set details and separate fields for date and event type selection.
  - Implemented a new schema for validating set detail updates, ensuring proper data structure during edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
#### 1. Accessing the Edit Set Details Dialog
1. Navigate to any existing set's detail page (`/[organization]/sets/[setId]`)
2. Verify the set details (date and event type) are displayed in the page title
3. Click on the actions menu (three dots icon) in the top right corner
4. Verify that an "Edit Set Details" option is present in the dropdown menu
5. Click on the "Edit Set Details" option
6. Verify that a dialog appears with a form for editing set details

#### 2. Testing the Edit Form Fields
**Date Field:**
1. In the edit dialog, locate the date picker field
2. Click on the date field to open the calendar picker
3. Select a different date from the current set date
4. Verify that the date picker updates with the selected date
5. Test the date presets if available (Today, Tomorrow options)

**Event Type Field:**
1. Locate the event type dropdown in the edit form
2. Click to expand the dropdown
3. Verify that all available event types are displayed
4. Select a different event type from the current one
5. Verify that the dropdown updates with the selected event type

#### 3. Testing Form Submission
1. After making changes to the date and/or event type, click the "Save" button
2. Verify that the dialog closes after submission
3. Verify that the set details in the page title are updated with the new values
4. Refresh the page and confirm that the changes persist

#### 4. Testing Cancellation
1. Open the edit dialog again
2. Make changes to the date and/or event type
3. Click the "Cancel" button
4. Verify that the dialog closes without saving changes
5. Verify that the set details remain unchanged

#### 5. Testing Validation
1. Open the edit dialog
2. Clear the date field if possible
3. Attempt to submit the form
4. Verify that appropriate validation errors are displayed
5. Fill in the date field and submit again
6. Verify that the form submits successfully

#### 6. Edge Cases
1. Test with various event types to ensure all options work correctly
2. Test with dates in different formats (past, present, future)
3. Attempt to submit the form without making any changes
4. Test rapid interactions (opening/closing the dialog quickly)

### Expected Results
- The edit dialog should open and close properly
- Form fields should be pre-populated with the current set details
- Changes should be saved correctly when submitting the form
- Cancellation should not alter the set details
- Validation should prevent submission of invalid data
- UI should remain responsive and user-friendly throughout the interaction