### PR TITLE
[SWY-87] Add duplicate set action

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@phosphor-icons/react": "^2.1.5",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.2",
+    "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-label": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1448,6 +1451,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collapsible@1.1.3':
+    resolution: {integrity: sha512-jFSerheto1X03MUC0g6R7LedNW9EEGWdg9W1+MlpkMLwGkgkbUXLPBH/KIuWKXUoeYRVY11llqbTBDzuLg7qrw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.0':
     resolution: {integrity: sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==}
     peerDependencies:
@@ -1881,6 +1897,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-radio-group@1.2.2':
     resolution: {integrity: sha512-E0MLLGfOP0l8P/NxgVzfXJ8w3Ch8cdO6UDzJfDChu4EJDy+/WdO5LqpdY8PYnCErkmZH3gZhDL1K7kQ41fAHuQ==}
     peerDependencies:
@@ -1953,6 +1982,15 @@ packages:
 
   '@radix-ui/react-slot@1.1.1':
     resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -7079,6 +7117,22 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-collapsible@1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-collection@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
@@ -7501,6 +7555,15 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-radio-group@1.2.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -7598,6 +7661,13 @@ snapshots:
       '@types/react': 18.3.3
 
   '@radix-ui/react-slot@1.1.1(@types/react@18.3.3)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
+
+  '@radix-ui/react-slot@1.1.2(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,33 +1,8 @@
 "use client";
-import { pluralize } from "@lib/string";
-import { PageTitle } from "@components/PageTitle";
-import { Text } from "@components/Text";
-import { Archive, Plus } from "@phosphor-icons/react/dist/ssr";
-import { redirect, useSearchParams } from "next/navigation";
-import { SetActionsMenu } from "@modules/sets/components/SetActionsMenu";
-import { SetEmptyState } from "@modules/sets/components/SetEmptyState";
-import { Button } from "@components/ui/button";
-import { formatDate } from "@lib/date";
-import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
-import { useState, useCallback, useEffect } from "react";
 import { api } from "@/trpc/react";
-import { validate as uuidValidate } from "uuid";
 import { useAuth } from "@clerk/nextjs";
-import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
-import { type SetSectionWithSongs } from "@lib/types";
-import { useSetQuery } from "@modules/sets/api";
-import { SetPageLoadingState } from "@modules/sets/components/SetLoadingState";
-import { SetPageErrorState } from "@modules/sets/components/SetErrorState";
 import { HStack } from "@components/HStack";
-import { VStack } from "@components/VStack";
 import { PageContentContainer } from "@components/PageContentContainer";
-import { type ConfigureSongForSetProps } from "@modules/songs/components/ConfigureSongForSet/ConfigureSongForSet";
-import { cn } from "@lib/utils";
-import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
-import { useMediaQuery } from "usehooks-ts";
-import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
-import { type ComboboxOption } from "@components/ui/combobox";
-import { toast } from "sonner";
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -35,9 +10,31 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@components/ResponsiveDialog";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
-import { SetNotes } from "@modules/sets/components/SetNotes";
+import { Text } from "@components/Text";
+import { Button } from "@components/ui/button";
+import { type ComboboxOption } from "@components/ui/combobox";
+import { VStack } from "@components/VStack";
+import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
+import { type SetSectionWithSongs } from "@lib/types";
+import { cn } from "@lib/utils";
+import { useSetQuery } from "@modules/sets/api";
+import { SetActionsMenu } from "@modules/sets/components/SetActionsMenu";
 import { SetDetails } from "@modules/sets/components/SetDetails";
+import { SetEmptyState } from "@modules/sets/components/SetEmptyState";
+import { SetPageErrorState } from "@modules/sets/components/SetErrorState";
+import { SetPageLoadingState } from "@modules/sets/components/SetLoadingState";
+import { SetNotes } from "@modules/sets/components/SetNotes";
+import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
+import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { type ConfigureSongForSetProps } from "@modules/songs/components/ConfigureSongForSet/ConfigureSongForSet";
+import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
+import { Archive, Plus } from "@phosphor-icons/react/dist/ssr";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
+import { redirect, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { useMediaQuery } from "usehooks-ts";
+import { validate as uuidValidate } from "uuid";
 
 type SetListPageProps = {
   params: { organization: string; setId: string };

--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -1,3 +1,4 @@
+import { SongActionsMenu } from "@/modules/songs/components/SongActionsMenu";
 import { db } from "@/server/db";
 import {
   eventTypes,
@@ -7,10 +8,15 @@ import {
   sets,
   songs,
 } from "@/server/db/schema";
+import { api } from "@/trpc/server";
+import { auth } from "@clerk/nextjs/server";
 import { Badge } from "@components/Badge";
+import { HStack } from "@components/HStack";
+import { PageContentContainer } from "@components/PageContentContainer";
 import { PageTitle } from "@components/PageTitle";
 import { SongKey } from "@components/SongKey";
 import { Text } from "@components/Text";
+import { VStack } from "@components/VStack";
 import { PlayHistoryItem, ResourceCard } from "@modules/SetListCard";
 import {
   Archive,
@@ -22,15 +28,10 @@ import {
   MusicNotesSimple,
   TagSimple,
 } from "@phosphor-icons/react/dist/ssr";
-import { asc, desc, eq } from "drizzle-orm";
 import { formatDistanceToNow, isPast } from "date-fns";
-import { SongActionsMenu } from "@/modules/songs/components/SongActionsMenu";
-import { auth } from "@clerk/nextjs/server";
+import { asc, desc, eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
-import { api } from "@/trpc/server";
-import { VStack } from "@components/VStack";
-import { HStack } from "@components/HStack";
-import { PageContentContainer } from "@components/PageContentContainer";
+import unescapeHTML from "validator/es/lib/unescape";
 
 export default async function SetListPage({
   params,
@@ -195,7 +196,7 @@ export default async function SetListPage({
           <Text asElement="h3" style="header-small-semibold">
             Notes
           </Text>
-          <Text style="body-small">{songData.notes}</Text>
+          <Text style="body-small">{unescapeHTML(songData.notes)}</Text>
         </VStack>
       )}
       <HStack as="section" className="justify-between gap-2">

--- a/src/components/TextareaFormField/TextareaFormField.tsx
+++ b/src/components/TextareaFormField/TextareaFormField.tsx
@@ -24,7 +24,7 @@ export const TextareaFormField: React.FC<TextareaFormFieldProps> = ({
       control={control}
       name={name}
       render={({ field }) => (
-        <FormItem className="">
+        <FormItem>
           <FormLabel>{label}</FormLabel>
           <FormControl>
             <Textarea

--- a/src/components/TextareaFormField/TextareaFormField.tsx
+++ b/src/components/TextareaFormField/TextareaFormField.tsx
@@ -1,0 +1,35 @@
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@components/ui/form";
+import { Textarea } from "@components/ui/textarea";
+import { useFormContext } from "react-hook-form";
+
+type TextareaFormFieldProps = {
+  name: string;
+  label: string;
+};
+
+export const TextareaFormField: React.FC<TextareaFormFieldProps> = ({
+  name,
+  label,
+}) => {
+  const { control } = useFormContext();
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="">
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <Textarea {...field} />
+          </FormControl>
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/src/components/TextareaFormField/TextareaFormField.tsx
+++ b/src/components/TextareaFormField/TextareaFormField.tsx
@@ -6,6 +6,7 @@ import {
 } from "@components/ui/form";
 import { Textarea } from "@components/ui/textarea";
 import { useFormContext } from "react-hook-form";
+import unescapeHTML from "validator/es/lib/unescape";
 
 type TextareaFormFieldProps = {
   name: string;
@@ -26,7 +27,7 @@ export const TextareaFormField: React.FC<TextareaFormFieldProps> = ({
         <FormItem className="">
           <FormLabel>{label}</FormLabel>
           <FormControl>
-            <Textarea {...field} />
+            <Textarea {...field} value={unescapeHTML(field.value as string)} />
           </FormControl>
         </FormItem>
       )}

--- a/src/components/TextareaFormField/TextareaFormField.tsx
+++ b/src/components/TextareaFormField/TextareaFormField.tsx
@@ -27,7 +27,10 @@ export const TextareaFormField: React.FC<TextareaFormFieldProps> = ({
         <FormItem className="">
           <FormLabel>{label}</FormLabel>
           <FormControl>
-            <Textarea {...field} value={unescapeHTML(field.value as string)} />
+            <Textarea
+              {...field}
+              value={unescapeHTML((field.value as string) ?? "")}
+            />
           </FormControl>
         </FormItem>
       )}

--- a/src/components/TextareaFormField/index.ts
+++ b/src/components/TextareaFormField/index.ts
@@ -1,0 +1,1 @@
+export * from "./TextareaFormField";

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -52,7 +52,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg sm:rounded-lg lg:p-8",
         {
           "duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]":
             animated,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 overflow-y-auto bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -52,7 +52,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full  translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg sm:rounded-lg",
         {
           "duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]":
             animated,

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -53,13 +53,15 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[100%] flex-col rounded-t-[10px] border bg-background",
         className,
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
-      {children}
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+        {children}
+      </div>
     </DrawerPrimitive.Content>
   </DrawerPortal>
 ));

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -58,7 +58,7 @@ const DrawerContent = React.forwardRef<
       )}
       {...props}
     >
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
         {children}
       </div>

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -50,6 +50,15 @@ export const updateSetDetailsSchema = setIdSchema.extend({
 export const updateSetNotesSchema = setIdSchema.extend({
   notes: z.string().trim(),
 });
+export const duplicateSetSchema = insertSetSchema
+  .pick({
+    date: true,
+    eventTypeId: true,
+    notes: true,
+  })
+  .extend({
+    setToDuplicateId: z.string().uuid(),
+  });
 
 /**
  * Song schemas

--- a/src/modules/SetListCard/components/SongContent/SongContent.tsx
+++ b/src/modules/SetListCard/components/SongContent/SongContent.tsx
@@ -1,10 +1,6 @@
 import { HStack } from "@components/HStack";
 import { SongKey } from "@components/SongKey";
 import { Text } from "@components/Text";
-import { VStack } from "@components/VStack";
-import { type SetSectionSongWithSongData } from "@lib/types";
-import { type UseFormReturn } from "react-hook-form";
-import { type UpdateSetSectionSongFormFields } from "../SongItem";
 import {
   FormControl,
   FormField,
@@ -18,10 +14,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@components/ui/select";
+import { Textarea } from "@components/ui/textarea";
+import { VStack } from "@components/VStack";
 import { songKeys } from "@lib/constants";
 import { formatSongKey } from "@lib/string/formatSongKey";
+import { type SetSectionSongWithSongData } from "@lib/types";
 import { cn } from "@lib/utils";
-import { Textarea } from "@components/ui/textarea";
+import { type UseFormReturn } from "react-hook-form";
+import unescapeHTML from "validator/es/lib/unescape";
+import { type UpdateSetSectionSongFormFields } from "../SongItem";
 
 export type SongContentProps = {
   /** The set section song object containing song details and metadata */
@@ -102,7 +103,11 @@ export const SongContent: React.FC<SongContentProps> = ({
                     Song notes
                   </FormLabel>
                   <FormControl>
-                    <Textarea {...field} className="font-normal" />
+                    <Textarea
+                      {...field}
+                      value={unescapeHTML(field.value)}
+                      className="font-normal"
+                    />
                   </FormControl>
                 </FormItem>
               )}
@@ -131,7 +136,7 @@ export const SongContent: React.FC<SongContentProps> = ({
         </HStack>
         {setSectionSong.notes ? (
           <Text style="small" color="slate-700">
-            {setSectionSong.notes}
+            {unescapeHTML(setSectionSong.notes)}
           </Text>
         ) : null}
       </VStack>

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -16,6 +16,7 @@ import { Form } from "@components/ui/form";
 import { api } from "@/trpc/react";
 import { toast } from "sonner";
 import { useUserQuery } from "@modules/users/api/queries";
+import { cn } from "@lib/utils";
 
 type BaseSongItemProps = {
   /** set section song object */
@@ -32,6 +33,9 @@ type BaseSongItemProps = {
 
   /** should the song item show the action menu? */
   withActionsMenu?: boolean;
+
+  /** should this be displayed more compact? */
+  small?: boolean;
 };
 
 export type SongItemWithActionsMenuProps = BaseSongItemProps & {
@@ -75,6 +79,7 @@ export const SongItem: React.FC<SongItemProps> = ({
   setId,
   index,
   setSectionType,
+  small,
   ...props
 }) => {
   const [isEditingDetails, setIsEditingDetails] = useState<boolean>(false);
@@ -152,7 +157,12 @@ export const SongItem: React.FC<SongItemProps> = ({
           handleUpdateSetSectionSong,
         )}
       >
-        <VStack className="gap-4 rounded-lg px-6 py-3 shadow lg:py-4">
+        <VStack
+          className={cn(
+            [small && "p-1"],
+            [!small && "rounded-lg px-6 py-3 shadow lg:py-4"],
+          )}
+        >
           <HStack className="items-baseline justify-between">
             <SongContent
               setSectionSong={setSectionSong}

--- a/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
+++ b/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
@@ -27,6 +27,7 @@ import { toast } from "sonner";
 import { type z } from "zod";
 import { SetDatePickerFormField } from "../forms/SetDatePickerFormField";
 import { SetEventTypeSelectFormField } from "../forms/SetEventTypeSelectFormField";
+import { TextareaFormField } from "@components/TextareaFormField";
 
 const createSetFormSchema = insertSetSchema.pick({
   date: true,
@@ -132,18 +133,7 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
       >
         <SetDatePickerFormField />
         <SetEventTypeSelectFormField />
-        <FormField
-          control={createSetForm.control}
-          name="notes"
-          render={({ field }) => (
-            <FormItem className="">
-              <FormLabel>Set notes</FormLabel>
-              <FormControl>
-                <Textarea {...field} />
-              </FormControl>
-            </FormItem>
-          )}
-        />
+        <TextareaFormField name="notes" label="Set notes" />
         {/* TODO: this was for proof of concept, but we should figure out if we want to implement it */}
         {/* <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between">

--- a/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
+++ b/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
@@ -28,6 +28,7 @@ import { type z } from "zod";
 import { SetDatePickerFormField } from "../forms/SetDatePickerFormField";
 import { SetEventTypeSelectFormField } from "../forms/SetEventTypeSelectFormField";
 import { TextareaFormField } from "@components/TextareaFormField";
+import { sanitizeInput } from "@lib/string";
 
 const createSetFormSchema = insertSetSchema.pick({
   date: true,
@@ -93,7 +94,7 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({ onSubmit }) => {
         {
           date,
           eventTypeId,
-          notes: notes || null,
+          notes: sanitizeInput(notes) || null,
           organizationId: organizationMembership.organizationId,
           isArchived: false,
         },

--- a/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
+++ b/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
@@ -25,6 +25,7 @@ import { useAuth } from "@clerk/nextjs";
 import { api } from "@/trpc/react";
 import { toast } from "sonner";
 import { formatSongKey } from "@/lib/string/formatSongKey";
+import { sanitizeInput } from "@lib/string";
 
 const createSongFormSchema = insertSongSchema
   .pick({
@@ -71,6 +72,7 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
     });
 
   const handleCreateSongSubmit = async (formValues: CreateSongFormFields) => {
+    const toastId = toast.loading("Creating song...");
     const { name, preferredKey, notes } = formValues;
 
     // attempt to create song
@@ -84,7 +86,7 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
         {
           name,
           preferredKey,
-          notes,
+          notes: sanitizeInput(notes ?? "") || null,
           organizationId: organizationMembership.organizationId,
           createdBy: userData.id,
           isArchived: false,
@@ -94,14 +96,16 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
             console.log("🤖 [createSongMutation/onSuccess] ~ data:", data);
             const [newSong] = data;
 
-            toast.success("Song was created");
+            toast.success("Song was created", { id: toastId });
             router.push(
               `/${organizationMembership.organizationId}/songs/${newSong?.id}`,
             );
           },
           onError(error) {
             console.log("🤖 [createSongMutation/onError] ~ error:", error);
-            toast.error(`Could not create song: ${error.message}`);
+            toast.error(`Could not create song: ${error.message}`, {
+              id: toastId,
+            });
           },
         },
       );

--- a/src/modules/sets/components/DuplicateSetDialog/DuplicateSetDialog.tsx
+++ b/src/modules/sets/components/DuplicateSetDialog/DuplicateSetDialog.tsx
@@ -1,0 +1,55 @@
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@components/ResponsiveDialog";
+import { DuplicateSetForm } from "@modules/sets/components/forms/DuplicateSetForm";
+import { useUserQuery } from "@modules/users/api/queries";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
+import { type Dispatch, type SetStateAction } from "react";
+import { type SetActionsMenuProps } from "../SetActionsMenu";
+
+type DuplicateSetDialogProps = {
+  setId: SetActionsMenuProps["setId"];
+  isOpen: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+export const DuplicateSetDialog: React.FC<DuplicateSetDialogProps> = ({
+  setId,
+  isOpen,
+  setIsOpen,
+}) => {
+  const {
+    data: userData,
+    error: userQueryError,
+    isLoading: userQueryLoading,
+    isAuthLoaded,
+  } = useUserQuery();
+  const userMembership = userData?.memberships[0];
+
+  if (!isAuthLoaded || !!userQueryError || !userData || !userMembership) {
+    return null;
+  }
+
+  return (
+    <ResponsiveDialog open={isOpen} onOpenChange={setIsOpen}>
+      <ResponsiveDialogContent className="mx-6 gap-2 p-6 lg:gap-6 lg:p-8">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Duplicate set</ResponsiveDialogTitle>
+          <VisuallyHidden.Root>
+            <ResponsiveDialogDescription>
+              Duplicate set
+            </ResponsiveDialogDescription>
+          </VisuallyHidden.Root>
+        </ResponsiveDialogHeader>
+        <DuplicateSetForm
+          setToDuplicateId={setId}
+          setIsDuplicateSetDialogOpen={setIsOpen}
+        />
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+};

--- a/src/modules/sets/components/DuplicateSetDialog/DuplicateSetDialog.tsx
+++ b/src/modules/sets/components/DuplicateSetDialog/DuplicateSetDialog.tsx
@@ -36,7 +36,7 @@ export const DuplicateSetDialog: React.FC<DuplicateSetDialogProps> = ({
 
   return (
     <ResponsiveDialog open={isOpen} onOpenChange={setIsOpen}>
-      <ResponsiveDialogContent className="mx-6 max-h-[90%] gap-2 p-6 lg:max-h-[80%] lg:gap-6 lg:p-8">
+      <ResponsiveDialogContent className="mx-6 max-h-[90%] gap-2 lg:max-h-[80%] lg:gap-6">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Duplicate set</ResponsiveDialogTitle>
           <VisuallyHidden.Root>

--- a/src/modules/sets/components/DuplicateSetDialog/DuplicateSetDialog.tsx
+++ b/src/modules/sets/components/DuplicateSetDialog/DuplicateSetDialog.tsx
@@ -1,3 +1,4 @@
+import { HStack } from "@components/HStack";
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -5,6 +6,9 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@components/ResponsiveDialog";
+import { Text } from "@components/Text";
+import { Button } from "@components/ui/button";
+import { VStack } from "@components/VStack";
 import { DuplicateSetForm } from "@modules/sets/components/forms/DuplicateSetForm";
 import { useUserQuery } from "@modules/users/api/queries";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
@@ -31,7 +35,35 @@ export const DuplicateSetDialog: React.FC<DuplicateSetDialogProps> = ({
   const userMembership = userData?.memberships[0];
 
   if (!isAuthLoaded || !!userQueryError || !userData || !userMembership) {
-    return null;
+    return (
+      <ResponsiveDialog open={isOpen} onOpenChange={setIsOpen}>
+        <ResponsiveDialogContent className="mx-6 max-h-[90%] gap-2 lg:max-h-[80%] lg:gap-6">
+          <ResponsiveDialogHeader>
+            <ResponsiveDialogTitle>Duplicate set</ResponsiveDialogTitle>
+            <VisuallyHidden.Root>
+              <ResponsiveDialogDescription>
+                Duplicate set
+              </ResponsiveDialogDescription>
+            </VisuallyHidden.Root>
+          </ResponsiveDialogHeader>
+          <VStack className="gap-8">
+            <Text>Unable to load user data. Please try again later.</Text>
+            <HStack className="flex-1">
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={() => {
+                  setIsOpen(false);
+                }}
+              >
+                Close
+              </Button>
+            </HStack>
+          </VStack>
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+    );
   }
 
   return (

--- a/src/modules/sets/components/DuplicateSetDialog/DuplicateSetDialog.tsx
+++ b/src/modules/sets/components/DuplicateSetDialog/DuplicateSetDialog.tsx
@@ -36,7 +36,7 @@ export const DuplicateSetDialog: React.FC<DuplicateSetDialogProps> = ({
 
   return (
     <ResponsiveDialog open={isOpen} onOpenChange={setIsOpen}>
-      <ResponsiveDialogContent className="mx-6 gap-2 p-6 lg:gap-6 lg:p-8">
+      <ResponsiveDialogContent className="mx-6 max-h-[90%] gap-2 p-6 lg:max-h-[80%] lg:gap-6 lg:p-8">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Duplicate set</ResponsiveDialogTitle>
           <VisuallyHidden.Root>

--- a/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
+++ b/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
@@ -19,8 +19,9 @@ import { AlertDialogDescription } from "@radix-ui/react-alert-dialog";
 import { type SetStateAction, type Dispatch, useState } from "react";
 import { Button } from "@components/ui/button";
 import { ActionMenu, ActionMenuItem } from "@components/ActionMenu";
+import { DuplicateSetDialog } from "../DuplicateSetDialog/DuplicateSetDialog";
 
-type SetActionsMenuProps = {
+export type SetActionsMenuProps = {
   setId: string;
   organizationId: string;
   archived: boolean;
@@ -45,6 +46,7 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
     useState<boolean>(false);
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] =
     useState<boolean>(false);
+  const [isDuplicatingSet, setIsDuplicatingSet] = useState<boolean>(false);
 
   const deleteSetMutation = api.set.delete.useMutation();
   const archiveSetMutation = api.set.archive.useMutation();
@@ -139,7 +141,14 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
             setIsEditingSetDetails(true);
           }}
         />
-        <ActionMenuItem icon="Copy" label="Duplicate set" />
+        <ActionMenuItem
+          icon="Copy"
+          label="Duplicate set"
+          onClick={() => {
+            setIsSetActionsMenuOpen(false);
+            setIsDuplicatingSet(true);
+          }}
+        />
         {archived ? (
           <ActionMenuItem
             icon="BoxArrowUp"
@@ -190,6 +199,11 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      <DuplicateSetDialog
+        setId={setId}
+        isOpen={isDuplicatingSet}
+        setIsOpen={setIsDuplicatingSet}
+      />
     </>
   );
 };

--- a/src/modules/sets/components/SetDetails/SetDetails.tsx
+++ b/src/modules/sets/components/SetDetails/SetDetails.tsx
@@ -39,7 +39,7 @@ export const SetDetails: React.FC<SetDetailsProps> = ({
         details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
       />
       <ResponsiveDialog open={isEditing} onOpenChange={setIsEditing}>
-        <ResponsiveDialogContent>
+        <ResponsiveDialogContent className="mx-6 gap-2 p-6 lg:gap-6 lg:p-8">
           <ResponsiveDialogHeader>
             <ResponsiveDialogTitle>Edit set details</ResponsiveDialogTitle>
             <VisuallyHidden.Root>

--- a/src/modules/sets/components/SetDetails/SetDetails.tsx
+++ b/src/modules/sets/components/SetDetails/SetDetails.tsx
@@ -1,11 +1,4 @@
 import { PageTitle } from "@components/PageTitle";
-import { formatDate } from "@lib/date/formatDate";
-import { pluralize } from "@lib/string/pluralize";
-import { type SetWithSectionsSongsAndEventType } from "@lib/types";
-import {
-  EditSetDetailsForm,
-  type EditSetDetailsFormProps,
-} from "../forms/EditSetDetailsForm";
 import {
   ResponsiveDialog,
   ResponsiveDialogContent,
@@ -13,8 +6,14 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@components/ResponsiveDialog";
+import { formatDate } from "@lib/date/formatDate";
+import { pluralize } from "@lib/string/pluralize";
+import { type SetWithSectionsSongsAndEventType } from "@lib/types";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
-import { Text } from "@components/Text";
+import {
+  EditSetDetailsForm,
+  type EditSetDetailsFormProps,
+} from "@modules/sets/components/forms/EditSetDetailsForm";
 
 type SetDetailsProps = {
   set: SetWithSectionsSongsAndEventType;

--- a/src/modules/sets/components/SetSectionList/SetSectionList.tsx
+++ b/src/modules/sets/components/SetSectionList/SetSectionList.tsx
@@ -1,0 +1,38 @@
+import { Text } from "@components/Text";
+import { VStack } from "@components/VStack";
+import { type SetSectionWithSongs } from "@lib/types";
+import { SongItem } from "@modules/SetListCard";
+
+type SetSectionListProps = {
+  /** The section data including songs, type, and position */
+  section: SetSectionWithSongs;
+
+  /** The 1-based index where this section's songs start in the overall set */
+  sectionStartIndex: number;
+};
+
+export const SetSectionList: React.FC<SetSectionListProps> = ({
+  section,
+  sectionStartIndex,
+}) => {
+  const { type, songs, setId } = section;
+  return (
+    <VStack className="gap-y-2">
+      <div className="mb-1 border-b border-slate-100 pb-1">
+        <Text>{type.name}</Text>
+      </div>
+      {songs &&
+        songs.length > 0 &&
+        section.songs.map((setSectionSong) => (
+          <SongItem
+            key={setSectionSong.id}
+            setSectionSong={setSectionSong}
+            index={sectionStartIndex + setSectionSong.position}
+            setId={setId}
+            setSectionType={type.name}
+            small
+          />
+        ))}
+    </VStack>
+  );
+};

--- a/src/modules/sets/components/SetSectionList/index.ts
+++ b/src/modules/sets/components/SetSectionList/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetSectionList";

--- a/src/modules/sets/components/forms/DuplicateSetForm.tsx
+++ b/src/modules/sets/components/forms/DuplicateSetForm.tsx
@@ -45,9 +45,8 @@ export const DuplicateSetForm: React.FC<DuplicateSetFormProps> = ({
   setIsDuplicateSetDialogOpen,
 }) => {
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
-  const [isSectionsAndSongsOpen, setIsSectionsAndSongsOpen] = useState<boolean>(
-    isDesktop ?? false,
-  );
+  const [isSectionsAndSongsOpen, setIsSectionsAndSongsOpen] =
+    useState<boolean>(isDesktop);
 
   const router = useRouter();
 

--- a/src/modules/sets/components/forms/DuplicateSetForm.tsx
+++ b/src/modules/sets/components/forms/DuplicateSetForm.tsx
@@ -1,0 +1,166 @@
+import { api } from "@/trpc/react";
+import { HStack } from "@components/HStack";
+import { Button } from "@components/ui/button";
+import { VStack } from "@components/VStack";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { insertSetSchema } from "@lib/types/zod";
+import { type CreateSetFormFields } from "@modules/sets/components/CreateSetForm";
+import { SetDatePickerFormField } from "@modules/sets/components/forms/SetDatePickerFormField";
+import { useUserQuery } from "@modules/users/api/queries";
+import { useState, type Dispatch, type SetStateAction } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { SetEventTypeSelectFormField } from "./SetEventTypeSelectFormField";
+import { TextareaFormField } from "@components/TextareaFormField";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@components/ui/collapsible";
+import { Text } from "@components/Text";
+import { CaretDown, CaretUp } from "@phosphor-icons/react/dist/ssr";
+import { useSetQuery } from "@modules/sets/api";
+import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
+import { type SetSectionWithSongs } from "@lib/types";
+import { SetSectionList } from "../SetSectionList/SetSectionList";
+
+const duplicateSetFormSchema = insertSetSchema.pick({
+  date: true,
+  eventTypeId: true,
+  notes: true,
+});
+
+export type DuplicateSetFields = CreateSetFormFields;
+
+export type DuplicateSetFormProps = {
+  setToDuplicateId: string;
+  setIsDuplicateSetDialogOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+export const DuplicateSetForm: React.FC<DuplicateSetFormProps> = ({
+  setToDuplicateId,
+  setIsDuplicateSetDialogOpen,
+}) => {
+  const [isSectionsAndSongsOpen, setIsSectionsAndSongsOpen] =
+    useState<boolean>(true);
+
+  const updateSetDetailsMutation = api.set.updateDetails.useMutation();
+  const apiUtils = api.useUtils();
+
+  const {
+    data: userData,
+    error: userQueryError,
+    isLoading: userQueryLoading,
+    isAuthLoaded,
+  } = useUserQuery();
+  const userMembership = userData?.memberships[0];
+
+  const {
+    data: setData,
+    isLoading: setQueryLoading,
+    error: setQueryError,
+  } = useSetQuery({
+    setId: setToDuplicateId,
+    organizationId: userMembership?.organizationId ?? "",
+    userId: userData?.id ?? "", // we use a non-null assertion here since the redirect would have already fired if userId is falsy
+  });
+
+  const editSetDetailsForm = useForm<DuplicateSetFields>({
+    resolver: zodResolver(duplicateSetFormSchema),
+    defaultValues: {
+      date: undefined,
+      eventTypeId: undefined,
+    },
+    mode: "onChange",
+  });
+
+  if (!!userQueryError || !userData || !userMembership) {
+    // FIXME: show an error here instead?
+    return;
+  }
+
+  const {
+    formState: { isDirty, isValid },
+  } = editSetDetailsForm;
+
+  const isLoading = updateSetDetailsMutation.isPending;
+  const isSubmitDisabled =
+    !isDirty || !isValid || userQueryLoading || !isAuthLoaded || isLoading;
+
+  const handleDuplicateSet = (formValues: DuplicateSetFields) => {
+    const { date, eventTypeId, notes } = formValues;
+    const toastId = toast.loading("Duplicating set...");
+  };
+
+  return (
+    <FormProvider {...editSetDetailsForm}>
+      <form onSubmit={editSetDetailsForm.handleSubmit(handleDuplicateSet)}>
+        <VStack className="gap-6">
+          <SetDatePickerFormField />
+          <SetEventTypeSelectFormField />
+          <TextareaFormField name="name" label="Set notes" />
+          {setData && setData.sections.length > 0 && (
+            <Collapsible
+              open={isSectionsAndSongsOpen}
+              onOpenChange={setIsSectionsAndSongsOpen}
+            >
+              <CollapsibleTrigger>
+                <HStack className="gap-4">
+                  <Text className="text-sm font-medium leading-none">
+                    Songs
+                  </Text>
+                  {isSectionsAndSongsOpen ? <CaretUp /> : <CaretDown />}
+                </HStack>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                {setQueryLoading && <Text>Loading...</Text>}
+                {!setQueryLoading && setData && (
+                  <VStack className="mt-2 gap-6 lg:gap-8">
+                    {setData.sections.map((section) => {
+                      let sectionStartIndex = 1;
+                      for (
+                        let sectionPosition = 0;
+                        sectionPosition < section.position;
+                        sectionPosition++
+                      ) {
+                        sectionStartIndex +=
+                          setData.sections[sectionPosition]!.songs.length;
+                      }
+                      return (
+                        <SetSectionList
+                          key={section.id}
+                          section={section as SetSectionWithSongs}
+                          sectionStartIndex={sectionStartIndex}
+                        />
+                      );
+                    })}
+                  </VStack>
+                )}
+              </CollapsibleContent>
+            </Collapsible>
+          )}
+          <HStack className="justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setIsDuplicateSetDialogOpen(false);
+                editSetDetailsForm.reset();
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={isSubmitDisabled}
+              isLoading={isLoading}
+            >
+              Duplicate set
+            </Button>
+          </HStack>
+        </VStack>
+      </form>
+    </FormProvider>
+  );
+};

--- a/src/modules/sets/components/forms/DuplicateSetForm.tsx
+++ b/src/modules/sets/components/forms/DuplicateSetForm.tsx
@@ -23,6 +23,8 @@ import { useSetQuery } from "@modules/sets/api";
 import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
 import { type SetSectionWithSongs } from "@lib/types";
 import { SetSectionList } from "../SetSectionList/SetSectionList";
+import { useMediaQuery } from "usehooks-ts";
+import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
 
 const duplicateSetFormSchema = insertSetSchema.pick({
   date: true,
@@ -41,8 +43,10 @@ export const DuplicateSetForm: React.FC<DuplicateSetFormProps> = ({
   setToDuplicateId,
   setIsDuplicateSetDialogOpen,
 }) => {
-  const [isSectionsAndSongsOpen, setIsSectionsAndSongsOpen] =
-    useState<boolean>(true);
+  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const [isSectionsAndSongsOpen, setIsSectionsAndSongsOpen] = useState<boolean>(
+    isDesktop ?? false,
+  );
 
   const updateSetDetailsMutation = api.set.updateDetails.useMutation();
   const apiUtils = api.useUtils();

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -95,7 +95,7 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
   return (
     <FormProvider {...editSetDetailsForm}>
       <form onSubmit={editSetDetailsForm.handleSubmit(handleEditSetDetails)}>
-        <VStack className="mx-6 gap-6 p-8">
+        <VStack className="gap-6">
           <SetDatePickerFormField />
           <SetEventTypeSelectFormField />
           <HStack className="justify-end gap-2">

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -2,7 +2,6 @@ import { api } from "@/trpc/react";
 import { HStack } from "@components/HStack";
 import { Button } from "@components/ui/button";
 import { VStack } from "@components/VStack";
-import { DevTool } from "@hookform/devtools";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type SetWithSectionsSongsAndEventType } from "@lib/types";
 import { updateSetDetailsSchema } from "@lib/types/zod";
@@ -65,7 +64,7 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
 
   const handleEditSetDetails = (formValues: EditSetDetailsFields) => {
     const { date, eventTypeId } = formValues;
-    const toastId = toast("Updating set details...");
+    const toastId = toast.loading("Updating set details...");
 
     updateSetDetailsMutation.mutate(
       {

--- a/src/modules/shared/components/NewItemResponsiveDialog.tsx
+++ b/src/modules/shared/components/NewItemResponsiveDialog.tsx
@@ -16,7 +16,7 @@ import { CreateSetForm } from "@modules/sets/components/CreateSetForm";
 import { MusicNoteSimple, Playlist } from "@phosphor-icons/react/dist/ssr";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 
-// TODO: add prop to configure which tab is default, with "net set" as fallback (SWY-40)
+// TODO: add prop to configure which tab is default, with "new set" as fallback (SWY-40)
 export const NewItemResponsiveDialog: React.FC = ({}) => {
   const {
     isCreateItemDialogOpen,

--- a/src/modules/users/api/queries.ts
+++ b/src/modules/users/api/queries.ts
@@ -5,12 +5,14 @@ import { validate as uuidValidate } from "uuid";
 export const useUserQuery = () => {
   const { userId, isLoaded: isAuthLoaded } = useAuth();
 
+  const isQueryEnabled = isAuthLoaded && !!userId && uuidValidate(userId);
+
   const user = api.user.getUser.useQuery(
     {
       userId: userId!, // using non-null assertion as the query will not be enabled if the userId is null
     },
     {
-      enabled: isAuthLoaded && !!userId && uuidValidate(userId),
+      enabled: isQueryEnabled,
     },
   );
 

--- a/src/server/api/routers/set.ts
+++ b/src/server/api/routers/set.ts
@@ -342,6 +342,32 @@ export const setRouter = createTRPCRouter({
           });
         }
 
+        const eventType = await duplicateTransaction.query.eventTypes.findFirst(
+          { where: eq(eventTypes.id, input.eventTypeId) },
+        );
+
+        if (!eventType) {
+          console.error(
+            `🤖 - [set/duplicate] - could not find event type ${input.eventTypeId}`,
+          );
+
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Could not find event type",
+          });
+        }
+
+        if (eventType.organizationId !== ctx.user.membership.organizationId) {
+          console.error(
+            `🤖 - [set/duplicate] - User ${ctx.user.id} not authorized to use event type ${input.eventTypeId}`,
+          );
+
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "User not authorized to use event type",
+          });
+        }
+
         const newSetValues: NewSet = {
           date: input.date,
           eventTypeId: input.eventTypeId,

--- a/src/server/api/routers/set.ts
+++ b/src/server/api/routers/set.ts
@@ -3,12 +3,18 @@ import {
   createTRPCRouter,
   organizationProcedure,
 } from "@server/api/trpc";
-import { eventTypes, sets } from "@server/db/schema";
+import {
+  eventTypes,
+  sets,
+  setSections,
+  setSectionSongs,
+} from "@server/db/schema";
 import { type NewSet } from "@lib/types";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import {
   archiveSetSchema,
   deleteSetSchema,
+  duplicateSetSchema,
   getSetSchema,
   insertSetSchema,
   unarchiveSetSchema,
@@ -172,7 +178,7 @@ export const setRouter = createTRPCRouter({
         { ...input },
       );
 
-      const { setId, date, eventTypeId, organizationId } = input;
+      const { setId, date, eventTypeId } = input;
 
       return await ctx.db.transaction(async (updateTransaction) => {
         const setToUpdate = await updateTransaction.query.sets.findFirst({
@@ -297,5 +303,222 @@ export const setRouter = createTRPCRouter({
         `🤖 - [set/updateNotes] - set notes updated for ${input.setId}`,
         { notes: input.notes },
       );
+    }),
+
+  duplicate: organizationProcedure
+    .input(duplicateSetSchema)
+    .mutation(async ({ ctx, input }) => {
+      console.log(
+        `🤖 - [set/duplicate] - attempting to duplicate set ${input.setToDuplicateId}`,
+        { ...input },
+      );
+
+      return await ctx.db.transaction(async (duplicateTransaction) => {
+        const setToDuplicate = await duplicateTransaction.query.sets.findFirst({
+          where: eq(sets.id, input.setToDuplicateId),
+        });
+
+        if (!setToDuplicate) {
+          console.error(
+            `🤖 - [set/duplicate] - could not find target set ${input.setToDuplicateId}`,
+          );
+
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Could not find set to duplicate",
+          });
+        }
+
+        if (
+          setToDuplicate.organizationId !== ctx.user.membership.organizationId
+        ) {
+          console.error(
+            `🤖 - [set/duplicate] - User ${ctx.user.id} not authorized to duplicate set ${input.setToDuplicateId}`,
+          );
+
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "User not authorized to duplicate set",
+          });
+        }
+
+        const newSetValues: NewSet = {
+          date: input.date,
+          eventTypeId: input.eventTypeId,
+          organizationId: setToDuplicate.organizationId,
+          notes: input.notes,
+          isArchived: false,
+        };
+
+        const [newSet] = await duplicateTransaction
+          .insert(sets)
+          .values(newSetValues)
+          .returning();
+
+        if (!newSet) {
+          console.error(
+            `🤖 - [set/duplicate] - Could not create new set with inputs:`,
+            { ...input },
+          );
+
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Could not create new set",
+          });
+        }
+
+        const originalSetSections =
+          await duplicateTransaction.query.setSections.findMany({
+            where: eq(setSections.setId, setToDuplicate.id),
+          });
+
+        if (!originalSetSections || originalSetSections.length === 0) {
+          return {
+            success: true,
+            newSet,
+          };
+        }
+
+        const duplicatedSectionValues = originalSetSections.map((section) => ({
+          setId: newSet.id,
+          position: section.position,
+          sectionTypeId: section.sectionTypeId,
+          organizationId: section.organizationId,
+        }));
+
+        const newSetSections = await duplicateTransaction
+          .insert(setSections)
+          .values(duplicatedSectionValues)
+          .returning();
+
+        if (!newSetSections) {
+          console.error(
+            `🤖 - [set/duplicate] - Could not duplicate set sections from set ${input.setToDuplicateId}:`,
+            { ...duplicatedSectionValues },
+          );
+
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Could not duplicate the set sections from the target set",
+          });
+        }
+
+        if (newSetSections.length !== originalSetSections.length) {
+          console.error(
+            `🤖 - [set/duplicate] - Mismatch between original and new set sections count:`,
+            {
+              originalSetSectionsCount: originalSetSections.length,
+              newSetSectionsCount: newSetSections.length,
+              originalSetSections,
+              newSetSections,
+            },
+          );
+
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message:
+              "Could not duplicate all the set sections from the target set",
+          });
+        }
+
+        /**
+         * Build a mapping from original section id to new section id to know which set section to add the
+         * duplicated set section songs to in the next step.
+         */
+        const sectionIdMapping = new Map<string, string>();
+        for (let i = 0; i < originalSetSections.length; i++) {
+          const originalSection = originalSetSections[i];
+          const newSection = newSetSections[i];
+          if (!originalSection || !newSection) {
+            throw new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: `Undefined section encountered at index ${i}.`,
+            });
+          }
+          sectionIdMapping.set(originalSection.id, newSection.id);
+        }
+
+        const originalSetSectionIds = originalSetSections.map(
+          (section) => section.id,
+        );
+        const originalSetSectionSongs =
+          await duplicateTransaction.query.setSectionSongs.findMany({
+            where: inArray(setSectionSongs.setSectionId, originalSetSectionIds),
+          });
+
+        if (!originalSetSectionSongs) {
+          console.error(
+            `🤖 - [set/duplicate] - Could not duplicate set section songs from set ${input.setToDuplicateId}:`,
+            { originalSetSectionIds },
+          );
+
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message:
+              "Could not duplicate the set section songs from the target set",
+          });
+        }
+
+        const duplicatedSetSectionSongsValues = originalSetSectionSongs.map(
+          (song) => ({
+            songId: song.songId,
+            key: song.key,
+            position: song.position,
+            notes: song.notes,
+            setSectionId: sectionIdMapping.get(song.setSectionId)!,
+            organizationId: song.organizationId,
+          }),
+        );
+
+        if (
+          !duplicatedSetSectionSongsValues ||
+          duplicatedSetSectionSongsValues.length === 0
+        ) {
+          return {
+            success: true,
+            newSet,
+            newSetSections,
+          };
+        }
+
+        const newSetSectionSongs = await duplicateTransaction
+          .insert(setSectionSongs)
+          .values(duplicatedSetSectionSongsValues)
+          .returning();
+
+        if (newSetSectionSongs.length !== originalSetSectionSongs.length) {
+          console.error(
+            `🤖 - [set/duplicate] - Mismatch between original and new set section songs count:`,
+            {
+              originalSetSectionSongsCount: originalSetSectionSongs.length,
+              newSetSectionSongsCount: newSetSectionSongs.length,
+              originalSetSectionSongs,
+              newSetSectionSongs,
+            },
+          );
+
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message:
+              "Could not duplicate all the set section songs from the target set",
+          });
+        }
+
+        console.info(
+          `🤖 - [set/duplicate] - Successfully duplicated set ${input.setToDuplicateId}:`,
+          {
+            newSet,
+            newSetSections,
+            newSetSectionSongs,
+          },
+        );
+
+        return {
+          success: true,
+          newSet,
+          newSetSections,
+          newSetSectionSongs,
+        };
+      });
     }),
 });


### PR DESCRIPTION
## Background
This PR is to add the UI and back-end action to allow a user to duplicate an existing set.

| Desktop | Mobile | 
| -------- | ------- |
| ![SWY-87__after--desktop](https://github.com/user-attachments/assets/d4f91205-25da-4733-8020-80c0607dca4f) | ![SWY-87__after--mobile](https://github.com/user-attachments/assets/120a116e-56cd-44e0-8205-83fca8f41bfc) |

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a versatile textarea input for note-taking in set forms.
  - Added a collapsible component that allows sections of content to expand or collapse.
  - Enabled a duplication workflow for sets, featuring an interactive dialog and form.
  - Provided a compact display option for song items and organized song sections for improved list presentation.
  - Added a new component for duplicating sets, enhancing user interaction.
  - Introduced a new component for displaying sections of songs within sets.
  - Implemented a new schema for duplicating sets with specific attributes.

- **Style**
  - Refined spacing and layout in dialogs and forms to enhance overall visual consistency.
  - Updated dialog and drawer components to support vertical scrolling for better content management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
### Basic Flow Test
1. **Access an existing set**
   - Navigate to a set details page

2. **Initiate duplication**
   - Click on the actions menu (three dots) in the set details view
   - Verify that a "Duplicate set" option is available in the dropdown menu
   - Click on the "Duplicate set" option
   - Verify that a dialog opens with the title related to duplicating the set

3. **Modify set details in the form**
   - Check that the form contains fields for date, event type, and notes
   - Select a date for the new set
   - Select an event type (if multiple event types are available)
   - Add notes in the notes field
   - Verify the form validates properly (all required fields should be marked)

4. **Review set contents**
   - Check if the collapsible section showing songs is present
   - Expand it to verify that all sections and songs from the original set are listed

5. **Complete duplication**
   - Click the submit/duplicate button
   - Verify that a loading toast appears
   - Upon successful duplication, verify you are redirected to the new set's page

6. **Verify duplicated content**
   - Confirm the new set has the date, event type, and notes you specified
   - Verify all sections from the original set were duplicated
   - Verify all songs within each section were duplicated with correct order and content
   - Compare a few songs between original and duplicated set to ensure content like notes and other metadata was copied correctly

### Edge Cases to Test
1. **Form validation**
   - Try submitting the form without required fields
   - Verify appropriate validation messages appear (if applicable)

2. **Duplicate a set with no sections/songs**
   - Test duplicating an empty set
   - Verify a new empty set is created with the specified details

3. **Cancel operation**
   - Open the duplicate dialog and click cancel or close
   - Verify the dialog closes without creating a duplicate

4. **Long content**
   - Test duplicating a set with many sections or very long notes
   - Verify all content is duplicated correctly

5. **Special characters**
   - Test with notes containing special characters or HTML entities
   - Verify the content displays correctly in the duplicated set