### PR TITLE
[SWY-89] Update set date picker and presets

### DIFF
--- a/src/components/ui/datePicker.tsx
+++ b/src/components/ui/datePicker.tsx
@@ -29,11 +29,13 @@ export type DatePickerPreset = {
 type DatePickerProps = ControllerRenderProps<{ date: string }, "date"> & {
   presets?: DatePickerPreset[];
   initialDate?: Date;
+  presetSelectPlaceholder?: string;
 };
 
 export const DatePicker: React.FC<DatePickerProps> = ({
   presets,
   initialDate,
+  presetSelectPlaceholder = "Quick select date",
   ...props
 }) => {
   const [date, setDate] = React.useState<Date | undefined>(initialDate);
@@ -71,12 +73,12 @@ export const DatePicker: React.FC<DatePickerProps> = ({
             onValueChange={(value) => {
               const presetOffset = parseInt(value);
               const selectedDate = addDays(new Date(), presetOffset);
-              setViewMonth(selectedDate);
               onDateChange(selectedDate);
+              setViewMonth(selectedDate);
             }}
           >
             <SelectTrigger>
-              <SelectValue placeholder="Select" />
+              <SelectValue placeholder={presetSelectPlaceholder} />
             </SelectTrigger>
             <SelectContent position="popper">
               {presets?.map((preset) => (

--- a/src/components/ui/datePicker.tsx
+++ b/src/components/ui/datePicker.tsx
@@ -26,13 +26,7 @@ export type DatePickerPreset = {
   label: string;
 };
 
-// TODO: add closeAfterSelect boolean prop
-type DatePickerProps = ControllerRenderProps<
-  {
-    date: string;
-  },
-  "date"
-> & {
+type DatePickerProps = ControllerRenderProps<{ date: string }, "date"> & {
   presets?: DatePickerPreset[];
   initialDate?: Date;
 };
@@ -43,16 +37,22 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   ...props
 }) => {
   const [date, setDate] = React.useState<Date | undefined>(initialDate);
+  const [open, setOpen] = React.useState(false);
+  const [viewMonth, setViewMonth] = React.useState<Date>(
+    initialDate ?? new Date(),
+  );
 
-  const onDateChange = (selectedDate: Date | undefined) => {
+  const onDateChange = (selectedDate: Date | undefined, closePicker = true) => {
     const formattedDate = selectedDate?.toLocaleDateString("en-CA");
     setDate(selectedDate);
     props.onChange?.(formattedDate);
-    // TODO: if closeAfterSelect, close the popover after date is selected
+    if (closePicker) {
+      setOpen(false);
+    }
   };
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
           variant={"outline"}
@@ -69,8 +69,10 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         {!!presets && (
           <Select
             onValueChange={(value) => {
-              const selectedDate = addDays(new Date(), parseInt(value));
-              return onDateChange(selectedDate);
+              const presetOffset = parseInt(value);
+              const selectedDate = addDays(new Date(), presetOffset);
+              setViewMonth(selectedDate);
+              onDateChange(selectedDate);
             }}
           >
             <SelectTrigger>
@@ -86,7 +88,13 @@ export const DatePicker: React.FC<DatePickerProps> = ({
           </Select>
         )}
         <div className="rounded-md border">
-          <Calendar mode="single" selected={date} onSelect={onDateChange} />
+          <Calendar
+            mode="single"
+            selected={date}
+            onSelect={(selectedDate) => onDateChange(selectedDate)}
+            month={viewMonth}
+            onMonthChange={setViewMonth}
+          />
         </div>
       </PopoverContent>
     </Popover>

--- a/src/lib/date/__tests__/getFirstSundayOfNextMonth.test.ts
+++ b/src/lib/date/__tests__/getFirstSundayOfNextMonth.test.ts
@@ -1,0 +1,47 @@
+import { getFirstSundayOfNextMonth } from "@lib/date/getFirstSundayOfNextMonth";
+
+describe("getFirstSundayOfNextMonth", () => {
+  it("returns the first day of next month if it is a Sunday", () => {
+    // Example: Given July 15, 2021, next month is August 2021.
+    // August 1, 2021 was a Sunday.
+    const inputDate = new Date(2021, 6, 15); // Months are 0-indexed: 6 = July
+    const result = getFirstSundayOfNextMonth(inputDate);
+    expect(result.getFullYear()).toBe(2021);
+    expect(result.getMonth()).toBe(7); // 7 = August
+    expect(result.getDate()).toBe(1);
+    expect(result.getDay()).toBe(0); // Sunday
+  });
+
+  it("returns the first Sunday of next month when the first day is not Sunday", () => {
+    // Example: Given September 10, 2021, next month is October 2021.
+    // October 1, 2021 is a Friday (day 5), so (7 - 5) % 7 = 2 days later -> October 3, 2021.
+    const inputDate = new Date(2021, 8, 10); // 8 = September
+    const result = getFirstSundayOfNextMonth(inputDate);
+    expect(result.getFullYear()).toBe(2021);
+    expect(result.getMonth()).toBe(9); // 9 = October
+    expect(result.getDate()).toBe(3);
+    expect(result.getDay()).toBe(0);
+  });
+
+  it("handles end of year transition correctly", () => {
+    // Example: Given December 25, 2021, next month is January 2022.
+    // January 1, 2022 is a Saturday (day 6), so expected Sunday is January 2, 2022.
+    const inputDate = new Date(2021, 11, 25); // 11 = December
+    const result = getFirstSundayOfNextMonth(inputDate);
+    expect(result.getFullYear()).toBe(2022);
+    expect(result.getMonth()).toBe(0); // 0 = January
+    expect(result.getDate()).toBe(2);
+    expect(result.getDay()).toBe(0);
+  });
+
+  it("returns a valid Sunday for default input date (no argument)", () => {
+    // When no argument is provided, the function should return the first Sunday of the next month.
+    // We'll verify that the result is indeed in the next month and is a Sunday.
+    const now = new Date();
+    const result = getFirstSundayOfNextMonth();
+    const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    expect(result.getFullYear()).toBe(nextMonth.getFullYear());
+    expect(result.getMonth()).toBe(nextMonth.getMonth());
+    expect(result.getDay()).toBe(0); // Ensure it's a Sunday.
+  });
+});

--- a/src/lib/date/getFirstSundayOfNextMonth.ts
+++ b/src/lib/date/getFirstSundayOfNextMonth.ts
@@ -1,0 +1,9 @@
+import { addDays, addMonths, getDay, startOfMonth } from "date-fns";
+
+export const getFirstSundayOfNextMonth = (fromDate = new Date()) => {
+  const firstDayOfNextMonth = startOfMonth(addMonths(fromDate, 1));
+  const dayOfWeek = getDay(firstDayOfNextMonth);
+
+  const daysUntilSunday = (7 - dayOfWeek) % 7;
+  return addDays(firstDayOfNextMonth, daysUntilSunday);
+};

--- a/src/modules/sets/components/forms/SetDatePickerFormField.tsx
+++ b/src/modules/sets/components/forms/SetDatePickerFormField.tsx
@@ -9,36 +9,35 @@ import { getFirstSundayOfNextMonth } from "@lib/date/getFirstSundayOfNextMonth";
 import { addWeeks, differenceInCalendarDays, nextSunday } from "date-fns";
 import { useFormContext } from "react-hook-form";
 
-const upcomingSunday = nextSunday(new Date());
-const upcomingSundayInDays = differenceInCalendarDays(
-  upcomingSunday,
-  new Date(),
-);
-const sundayAfterNextInDays = differenceInCalendarDays(
-  addWeeks(upcomingSunday, 1),
-  new Date(),
-);
-
-const firstSundayOfNextMonthInDays = differenceInCalendarDays(
-  getFirstSundayOfNextMonth(),
-  new Date(),
-);
-
-const datePresets: DatePickerPreset[] = [
-  {
-    value: `${upcomingSundayInDays}`,
-    label: "Upcoming Sunday",
-  },
-  { value: `${sundayAfterNextInDays}`, label: "Sunday After Next" },
-  {
-    value: `${firstSundayOfNextMonthInDays}`,
-    label: "First Sunday of Next Month",
-  },
-];
-
 export const SetDatePickerFormField: React.FC = () => {
   const { control } = useFormContext();
 
+  const upcomingSunday = nextSunday(new Date());
+  const upcomingSundayInDays = differenceInCalendarDays(
+    upcomingSunday,
+    new Date(),
+  );
+  const sundayAfterNextInDays = differenceInCalendarDays(
+    addWeeks(upcomingSunday, 1),
+    new Date(),
+  );
+
+  const firstSundayOfNextMonthInDays = differenceInCalendarDays(
+    getFirstSundayOfNextMonth(),
+    new Date(),
+  );
+
+  const datePresets: DatePickerPreset[] = [
+    {
+      value: `${upcomingSundayInDays}`,
+      label: "Upcoming Sunday",
+    },
+    { value: `${sundayAfterNextInDays}`, label: "Sunday After Next" },
+    {
+      value: `${firstSundayOfNextMonthInDays}`,
+      label: "First Sunday of Next Month",
+    },
+  ];
   return (
     <FormField
       control={control}

--- a/src/modules/sets/components/forms/SetDatePickerFormField.tsx
+++ b/src/modules/sets/components/forms/SetDatePickerFormField.tsx
@@ -5,14 +5,35 @@ import {
   FormItem,
   FormLabel,
 } from "@components/ui/form";
+import { getFirstSundayOfNextMonth } from "@lib/date/getFirstSundayOfNextMonth";
+import { addWeeks, differenceInCalendarDays, nextSunday } from "date-fns";
 import { useFormContext } from "react-hook-form";
+
+const upcomingSunday = nextSunday(new Date());
+const upcomingSundayInDays = differenceInCalendarDays(
+  upcomingSunday,
+  new Date(),
+);
+const sundayAfterNextInDays = differenceInCalendarDays(
+  addWeeks(upcomingSunday, 1),
+  new Date(),
+);
+
+const firstSundayOfNextMonthInDays = differenceInCalendarDays(
+  getFirstSundayOfNextMonth(),
+  new Date(),
+);
 
 const datePresets: DatePickerPreset[] = [
   {
-    value: "0",
-    label: "Today",
+    value: `${upcomingSundayInDays}`,
+    label: "Upcoming Sunday",
   },
-  { value: "1", label: "Tomorrow" },
+  { value: `${sundayAfterNextInDays}`, label: "Sunday After Next" },
+  {
+    value: `${firstSundayOfNextMonthInDays}`,
+    label: "First Sunday of Next Month",
+  },
 ];
 
 export const SetDatePickerFormField: React.FC = () => {


### PR DESCRIPTION
## Background 
This PR is to update the `datePicker` component for better UX and use more sensible date presets

| Before | After |
| ------ | ----- |
| ![SWY-89__before](https://github.com/user-attachments/assets/e3235ae0-f561-4e88-beeb-48da47882bcf) | ![SWY-89__after](https://github.com/user-attachments/assets/e93e8ac6-181f-4149-afdf-57406d94038d) |

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the date picker for a smoother, more responsive experience with improved control over calendar visibility.
  - Updated date presets now offer dynamically calculated options—including Upcoming Sunday, Sunday After Next, and First Sunday of Next Month—for more intuitive scheduling.
  - Added a new function to calculate the first Sunday of the next month.
  
- **Bug Fixes**
  - Improved handling of preset date selections to ensure accurate month viewing and date selection behavior. 

- **Tests**
  - Introduced a new test suite to validate the functionality of the new date calculation feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
### 1. Basic Functionality
- [ ] Open any page where the date picker is used
- [ ] Click on the date picker button to open the calendar popover
- [ ] Verify that clicking outside the popover closes it
- [ ] Verify that selecting a date closes the popover automatically

### 2. New Date Presets
- [ ] Open the date picker and click on the preset dropdown
- [ ] Verify the dropdown contains the following options:
  - "Upcoming Sunday"
  - "Sunday After Next" 
  - "First Sunday of Next Month"
- [ ] Test each preset:
  - [ ] Select "Upcoming Sunday" and verify it sets the date to the next Sunday
  - [ ] Select "Sunday After Next" and verify it sets the date to the Sunday after next
  - [ ] Select "First Sunday of Next Month" and verify it sets the date to the first Sunday of the next month
- [ ] Verify that when a preset is selected, the popover closes automatically, but when re-opened calendar view updates to show the relevant month

### 3. Calendar Month View
- [ ] Open the date picker
- [ ] Navigate to a different month using the month navigation controls
- [ ] Select a date from that month
- [ ] Reopen the date picker and verify it opens showing the month of the selected date

### 4. Visual Verification
- [ ] Compare the date picker appearance to the "After" screenshot in the PR description
- [ ] Verify the overall styling is consistent with the design
- [ ] Check that the date display formatting appears correct when a date is selected

### 5. Edge Cases
- [ ] Test selecting dates spanning multiple months to ensure month navigation works correctly
- [ ] Verify the date picker behaves correctly when opened and closed multiple times
