### PR TITLE
[SWY-88] Add set archived banner

### DIFF
--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -211,7 +211,7 @@ export default function SetListPage({ params }: SetListPageProps) {
   };
 
   return (
-    <PageContentContainer className="gap-8 lg:mb-16">
+    <PageContentContainer className="gap-6 lg:mb-16">
       <VStack className="gap-6">
         <HStack className="items-start justify-between">
           <SetDetails
@@ -279,7 +279,7 @@ export default function SetListPage({ params }: SetListPageProps) {
         />
       )}
       {setData?.sections && setData.sections.length > 0 && (
-        <VStack className="gap-8">
+        <VStack className="gap-6">
           <>
             {setData.sections.map((section) => {
               let sectionStartIndex = 1;

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -27,6 +27,7 @@ import { SetPageLoadingState } from "@modules/sets/components/SetLoadingState";
 import { SetNotes } from "@modules/sets/components/SetNotes";
 import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { ArchivedBanner } from "@modules/shared/components";
 import { type ConfigureSongForSetProps } from "@modules/songs/components/ConfigureSongForSet/ConfigureSongForSet";
 import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
 import { CaretDown, CaretUp } from "@phosphor-icons/react";
@@ -37,8 +38,6 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useMediaQuery } from "usehooks-ts";
 import { validate as uuidValidate } from "uuid";
-
-const amber900 = "#78350f";
 
 type SetListPageProps = {
   params: { organization: string; setId: string };
@@ -51,8 +50,6 @@ export default function SetListPage({ params }: SetListPageProps) {
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
   const textSize = isDesktop ? "text-base" : "text-xs";
 
-  const [isArchivedBannerExpanded, setIsArchivedBannerExpanded] =
-    useState<boolean>(true);
   const [isEditingSetDetails, setIsEditingSetDetails] =
     useState<boolean>(false);
   const [prePopulatedSetSectionId, setPrePopulatedSetSectionId] =
@@ -241,56 +238,7 @@ export default function SetListPage({ params }: SetListPageProps) {
           </HStack>
         </HStack>
         {setData.isArchived && (
-          <Alert className="border-amber-200 bg-amber-50 ">
-            <HStack className="items-start gap-2">
-              <div className="grid size-9 shrink-0 place-items-center">
-                <Archive color={amber900} />
-              </div>
-              <VStack className="w-full">
-                <HStack className="items-center justify-between">
-                  <AlertTitle className="mb-0 text-amber-900">
-                    Set is archived
-                  </AlertTitle>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="hover:bg-amber-100"
-                    onClick={() => {
-                      setIsArchivedBannerExpanded((isExpanded) => !isExpanded);
-                    }}
-                  >
-                    {isArchivedBannerExpanded ? (
-                      <CaretUp color={amber900} />
-                    ) : (
-                      <CaretDown color={amber900} />
-                    )}
-                  </Button>
-                </HStack>
-                {isArchivedBannerExpanded && (
-                  <AlertDescription>
-                    <VStack className="justify-start gap-3">
-                      <VStack className="gap-1">
-                        <Text className="text-amber-700">
-                          This means this set won&apos;t show up on the sets
-                          list page or in searches by default. However, all set
-                          history and data are preserved and you can find it in
-                          the archived section.
-                        </Text>
-                      </VStack>
-                      <Button
-                        variant="link"
-                        size="sm"
-                        className="self-start p-0 text-amber-900"
-                        onClick={unarchiveSet}
-                      >
-                        Unarchive this set
-                      </Button>
-                    </VStack>
-                  </AlertDescription>
-                )}
-              </VStack>
-            </HStack>
-          </Alert>
+          <ArchivedBanner itemType="set" onCtaClick={unarchiveSet} />
         )}
         <SetNotes
           setId={params.setId}

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -220,6 +220,11 @@ export default function SetListPage({ params }: SetListPageProps) {
             setIsEditing={setIsEditingSetDetails}
           />
           <HStack className="gap-2">
+            {setData?.sections && setData.sections.length > 0 && (
+              <Button onClick={openAddSongDialog} className="hidden md:flex">
+                <Plus /> Add a song
+              </Button>
+            )}
             <SetActionsMenu
               setId={params.setId}
               organizationId={userMembership.organizationId}
@@ -228,11 +233,6 @@ export default function SetListPage({ params }: SetListPageProps) {
               setIsEditingSetDetails={setIsEditingSetDetails}
               align="end"
             />
-            {setData?.sections && setData.sections.length > 0 && (
-              <Button onClick={openAddSongDialog} className="hidden md:flex">
-                <Plus /> Add a song
-              </Button>
-            )}
           </HStack>
         </HStack>
         {setData.isArchived && (
@@ -279,7 +279,7 @@ export default function SetListPage({ params }: SetListPageProps) {
         />
       )}
       {setData?.sections && setData.sections.length > 0 && (
-        <VStack className="gap-8 lg:gap-12">
+        <VStack className="gap-8">
           <>
             {setData.sections.map((section) => {
               let sectionStartIndex = 1;

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -213,8 +213,8 @@ export default function SetListPage({ params }: SetListPageProps) {
   };
 
   return (
-    <PageContentContainer className="gap-6 lg:mb-16">
-      <VStack className="gap-6">
+    <PageContentContainer className="gap-8 lg:mb-16">
+      <VStack className="gap-4">
         <HStack className="items-start justify-between">
           <SetDetails
             set={setData}

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -29,6 +29,7 @@ import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
 import { type ConfigureSongForSetProps } from "@modules/songs/components/ConfigureSongForSet/ConfigureSongForSet";
 import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
+import { CaretDown, CaretUp } from "@phosphor-icons/react";
 import { Archive, Plus } from "@phosphor-icons/react/dist/ssr";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { redirect, useSearchParams } from "next/navigation";
@@ -36,6 +37,8 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useMediaQuery } from "usehooks-ts";
 import { validate as uuidValidate } from "uuid";
+
+const amber900 = "#78350f";
 
 type SetListPageProps = {
   params: { organization: string; setId: string };
@@ -48,6 +51,8 @@ export default function SetListPage({ params }: SetListPageProps) {
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
   const textSize = isDesktop ? "text-base" : "text-xs";
 
+  const [isArchivedBannerExpanded, setIsArchivedBannerExpanded] =
+    useState<boolean>(true);
   const [isEditingSetDetails, setIsEditingSetDetails] =
     useState<boolean>(false);
   const [prePopulatedSetSectionId, setPrePopulatedSetSectionId] =
@@ -237,27 +242,54 @@ export default function SetListPage({ params }: SetListPageProps) {
         </HStack>
         {setData.isArchived && (
           <Alert className="border-amber-200 bg-amber-50 ">
-            <Archive color="#78350f" />
-            <AlertTitle className="text-amber-900">Set is archived</AlertTitle>
-            <AlertDescription>
-              <VStack className="justify-start gap-3">
-                <VStack className="gap-1">
-                  <Text className="text-amber-700">
-                    This means this set won&apos;t show up on the sets list page
-                    or in searches by default. However, all set history and data
-                    are preserved and you can find it in the archived section.
-                  </Text>
-                </VStack>
-                <Button
-                  variant="link"
-                  size="sm"
-                  className="self-start p-0 text-amber-900"
-                  onClick={unarchiveSet}
-                >
-                  Unarchive this set
-                </Button>
+            <HStack className="items-start gap-2">
+              <div className="grid size-9 shrink-0 place-items-center">
+                <Archive color={amber900} />
+              </div>
+              <VStack className="w-full">
+                <HStack className="items-center justify-between">
+                  <AlertTitle className="mb-0 text-amber-900">
+                    Set is archived
+                  </AlertTitle>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="hover:bg-amber-100"
+                    onClick={() => {
+                      setIsArchivedBannerExpanded((isExpanded) => !isExpanded);
+                    }}
+                  >
+                    {isArchivedBannerExpanded ? (
+                      <CaretUp color={amber900} />
+                    ) : (
+                      <CaretDown color={amber900} />
+                    )}
+                  </Button>
+                </HStack>
+                {isArchivedBannerExpanded && (
+                  <AlertDescription>
+                    <VStack className="justify-start gap-3">
+                      <VStack className="gap-1">
+                        <Text className="text-amber-700">
+                          This means this set won&apos;t show up on the sets
+                          list page or in searches by default. However, all set
+                          history and data are preserved and you can find it in
+                          the archived section.
+                        </Text>
+                      </VStack>
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="self-start p-0 text-amber-900"
+                        onClick={unarchiveSet}
+                      >
+                        Unarchive this set
+                      </Button>
+                    </VStack>
+                  </AlertDescription>
+                )}
               </VStack>
-            </AlertDescription>
+            </HStack>
           </Alert>
         )}
         <SetNotes

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -2,7 +2,7 @@
 
 import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
-import { Button } from "@components/ui/button";
+import { Button, type buttonVariants } from "@components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,6 +26,7 @@ import {
   Swap,
   Trash,
 } from "@phosphor-icons/react";
+import { type VariantProps } from "class-variance-authority";
 import React, {
   type Dispatch,
   type PropsWithChildren,
@@ -44,6 +45,9 @@ type ActionMenuProps = PropsWithChildren & {
 
   /** The preferred side of the trigger to render against when open. Will be reversed when collisions occur and avoidCollisions is enabled. */
   side?: DropdownMenuContentProps["side"];
+
+  /** Which button variant should be used for the action menu trigger? */
+  buttonVariant?: VariantProps<typeof buttonVariants>["variant"];
 };
 
 export const ActionMenu: React.FC<ActionMenuProps> = ({
@@ -51,12 +55,13 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   setIsOpen,
   align = "end",
   side = "bottom",
+  buttonVariant,
   children,
 }) => {
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger>
-        <Button variant="ghost" size="sm">
+        <Button variant={buttonVariant ?? "outline"} size="sm">
           <DotsThree className="text-slate-900" size={16} />
         </Button>
       </DropdownMenuTrigger>

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -1,3 +1,4 @@
+import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
 
@@ -10,23 +11,29 @@ export type PageTitleProps = {
 
   /** small text under title/subtitle */
   details?: string;
+
+  badge?: React.ReactElement;
 };
 
 export const PageTitle: React.FC<PageTitleProps> = ({
   title,
   subtitle,
   details,
+  badge,
 }) => {
   return (
     <VStack as="header" className="flex flex-col gap-1 pb-2">
-      <Text
-        asElement="h1"
-        style="header-large"
-        className="text-2xl lg:text-4xl"
-      >
-        {/* TODO: format the date to match locale */}
-        {title}
-      </Text>
+      <HStack className="items-center gap-4">
+        <Text
+          asElement="h1"
+          style="header-large"
+          className="text-2xl lg:text-4xl"
+        >
+          {/* TODO: format the date to match locale */}
+          {title}
+        </Text>
+        {!!badge && badge}
+      </HStack>
       {subtitle && (
         <Text
           asElement="h2"

--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -22,7 +22,7 @@ export const PageTitle: React.FC<PageTitleProps> = ({
   badge,
 }) => {
   return (
-    <VStack as="header" className="flex flex-col gap-1 pb-2">
+    <VStack as="header" className="flex flex-col gap-1">
       <HStack className="items-center gap-4">
         <Text
           asElement="h1"

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
   "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
@@ -16,8 +16,8 @@ const alertVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 const Alert = React.forwardRef<
   HTMLDivElement,
@@ -29,8 +29,8 @@ const Alert = React.forwardRef<
     className={cn(alertVariants({ variant }), className)}
     {...props}
   />
-))
-Alert.displayName = "Alert"
+));
+Alert.displayName = "Alert";
 
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -41,8 +41,8 @@ const AlertTitle = React.forwardRef<
     className={cn("mb-1 font-medium leading-none tracking-tight", className)}
     {...props}
   />
-))
-AlertTitle.displayName = "AlertTitle"
+));
+AlertTitle.displayName = "AlertTitle";
 
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -53,7 +53,7 @@ const AlertDescription = React.forwardRef<
     className={cn("text-sm [&_p]:leading-relaxed", className)}
     {...props}
   />
-))
-AlertDescription.displayName = "AlertDescription"
+));
+AlertDescription.displayName = "AlertDescription";
 
-export { Alert, AlertTitle, AlertDescription }
+export { Alert, AlertTitle, AlertDescription };

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+        warn: "text-amber-700 border-amber-200 bg-amber-50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-primary underline-offset-4 underline",
       },
       size: {
         default: "h-10 px-5 py-2",

--- a/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
+++ b/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
@@ -188,7 +188,11 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
 
   return (
     <>
-      <ActionMenu isOpen={isActionMenuOpen} setIsOpen={setIsActionMenuOpen}>
+      <ActionMenu
+        isOpen={isActionMenuOpen}
+        setIsOpen={setIsActionMenuOpen}
+        buttonVariant="ghost"
+      >
         <ActionMenuItem
           icon="Swap"
           label="Change section type"

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -199,6 +199,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
       <ActionMenu
         isOpen={isSongActionMenuOpen}
         setIsOpen={setIsSongActionMenuOpen}
+        buttonVariant="ghost"
       >
         <ActionMenuItem
           icon="Article"

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -161,9 +161,9 @@ export const SongItem: React.FC<SongItemProps> = ({
           className={cn(
             "gap-4 rounded-lg",
             [small && "p-1"],
-            [!small && "px-4 py-3"],
+            [!small && "py-3 pl-2 md:px-4"],
             [isEditingDetails && "border border-slate-200 bg-slate-50 p-6"],
-            [!isEditingDetails && "px-4 py-2 hover:bg-slate-50"],
+            [!isEditingDetails && "py-2 hover:bg-slate-50 md:px-4"],
           )}
         >
           <HStack className="items-baseline justify-between">

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -163,7 +163,7 @@ export const SongItem: React.FC<SongItemProps> = ({
             [small && "p-1"],
             [!small && "px-4 py-3"],
             [isEditingDetails && "border border-slate-200 bg-slate-50 p-6"],
-            [!isEditingDetails && "p-4 hover:bg-slate-50"],
+            [!isEditingDetails && "px-4 py-2 hover:bg-slate-50"],
           )}
         >
           <HStack className="items-baseline justify-between">

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -159,8 +159,11 @@ export const SongItem: React.FC<SongItemProps> = ({
       >
         <VStack
           className={cn(
+            "gap-4 rounded-lg",
             [small && "p-1"],
-            [!small && "rounded-lg px-6 py-3 shadow lg:py-4"],
+            [!small && "px-4 py-3"],
+            [isEditingDetails && "border border-slate-200 bg-slate-50 p-6"],
+            [!isEditingDetails && "p-4 hover:bg-slate-50"],
           )}
         >
           <HStack className="items-baseline justify-between">

--- a/src/modules/sets/components/SetDetails/SetDetails.tsx
+++ b/src/modules/sets/components/SetDetails/SetDetails.tsx
@@ -6,14 +6,16 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@components/ResponsiveDialog";
+import { Badge } from "@components/ui/badge";
 import { formatDate } from "@lib/date/formatDate";
 import { pluralize } from "@lib/string/pluralize";
 import { type SetWithSectionsSongsAndEventType } from "@lib/types";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import {
   EditSetDetailsForm,
   type EditSetDetailsFormProps,
 } from "@modules/sets/components/forms/EditSetDetailsForm";
+import { Archive } from "@phosphor-icons/react";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 
 type SetDetailsProps = {
   set: SetWithSectionsSongsAndEventType;
@@ -36,6 +38,14 @@ export const SetDetails: React.FC<SetDetailsProps> = ({
         title={formatDate(set.date, { month: "long" })}
         subtitle={set.eventType.name}
         details={`${songCount} ${pluralize(songCount, { singular: "song", plural: "songs" })}`}
+        badge={
+          set.isArchived ? (
+            <Badge variant="warn" className="gap-1">
+              <Archive />
+              Archived
+            </Badge>
+          ) : undefined
+        }
       />
       <ResponsiveDialog open={isEditing} onOpenChange={setIsEditing}>
         <ResponsiveDialogContent className="mx-6 gap-2 p-6 lg:gap-6 lg:p-8">

--- a/src/modules/sets/components/SetNotes/SetNotes.tsx
+++ b/src/modules/sets/components/SetNotes/SetNotes.tsx
@@ -55,7 +55,7 @@ export const SetNotes: React.FC<SetNotesProps> = ({
 
   return (
     <VStack className={isEditingNotes ? "gap-4" : "gap-2"}>
-      <Text style="header-small-semibold" className="text-slate-500">
+      <Text style="header-small-semibold" className="text-slate-700">
         Set notes
       </Text>
       {isEditingNotes && (

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -141,17 +141,14 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
     !isDirty || !isValid || isSubmitting;
 
   return (
-    <VStack
-      key={id}
-      className="gap-4 rounded-lg border p-4 shadow lg:gap-8 lg:p-8"
-    >
-      <VStack as="header" className="gap-4 lg:gap-6">
+    <VStack key={id} className="gap-4 rounded-lg border p-4 lg:gap-4 lg:p-6">
+      <VStack as="header" className="gap-4">
         <Form {...updateSetSectionForm}>
           <form
             onSubmit={updateSetSectionForm.handleSubmit(handleUpdateSetSection)}
           >
             {!isEditingSectionType && (
-              <HStack className="flex-wrap items-baseline justify-between gap-4 lg:gap-16">
+              <HStack className="flex-wrap items-baseline justify-between gap-4 pr-4 lg:gap-16">
                 <Text
                   asElement="h3"
                   style="header-medium-semibold"
@@ -162,7 +159,7 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
                 <HStack className="flex items-start gap-2">
                   <Button
                     size="sm"
-                    variant="outline"
+                    variant="ghost"
                     onClick={(clickEvent) => {
                       clickEvent.preventDefault();
                       openAddSongDialogWithPrePopulatedSection();
@@ -256,7 +253,7 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
         </Form>
         <hr className="bg-slate-100" />
       </VStack>
-      <VStack className="gap-y-4">
+      <VStack>
         {songs &&
           songs.length > 0 &&
           section.songs.map((setSectionSong) => (

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -1,6 +1,7 @@
 import { api } from "@/trpc/react";
 import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
+import { Badge } from "@components/ui/badge";
 import { Button } from "@components/ui/button";
 import { type ComboboxOption } from "@components/ui/combobox";
 import {
@@ -13,6 +14,7 @@ import {
 import { VStack } from "@components/VStack";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
+import { pluralize } from "@lib/string";
 import { type SetSectionWithSongs } from "@lib/types";
 import { insertSetSectionSchema } from "@lib/types/zod";
 import { cn } from "@lib/utils";
@@ -21,6 +23,7 @@ import { SetSectionActionMenu } from "@modules/SetListCard/components/SetSection
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
 import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { useUserQuery } from "@modules/users/api/queries";
+import { CaretDown, CaretUp } from "@phosphor-icons/react";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
 import { redirect, useSearchParams } from "next/navigation";
 import { useState, type FC } from "react";
@@ -70,6 +73,7 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
   const textSize = isDesktop ? "text-base" : "text-xs";
 
+  const [isSectionExpanded, setIsSectionExpanded] = useState<boolean>(true);
   const [isEditingSectionType, setIsEditingSectionType] =
     useState<boolean>(false);
 
@@ -149,14 +153,31 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
           >
             {!isEditingSectionType && (
               <HStack className="flex-wrap items-baseline justify-between gap-4 pr-4 lg:gap-16">
-                <Text
-                  asElement="h3"
-                  style="header-medium-semibold"
-                  className="flex-wrap text-xl"
-                >
-                  {type.name}
-                </Text>
+                <HStack className="gap-4">
+                  <Text
+                    asElement="h3"
+                    style="header-medium-semibold"
+                    className="flex-wrap text-xl"
+                  >
+                    {type.name}
+                  </Text>
+                  {!isSectionExpanded ? (
+                    <Badge variant="secondary">
+                      {`${section.songs.length} ${pluralize(section.songs.length, { singular: "song", plural: "songs" })}`}
+                    </Badge>
+                  ) : null}
+                </HStack>
                 <HStack className="flex items-start gap-2">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={(clickEvent) => {
+                      clickEvent.preventDefault();
+                      setIsSectionExpanded((isExpanded) => !isExpanded);
+                    }}
+                  >
+                    {isSectionExpanded ? <CaretUp /> : <CaretDown />}
+                  </Button>
                   <Button
                     size="sm"
                     variant="ghost"
@@ -251,26 +272,30 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
             )}
           </form>
         </Form>
-        <hr className="bg-slate-100" />
       </VStack>
-      <VStack>
-        {songs &&
-          songs.length > 0 &&
-          section.songs.map((setSectionSong) => (
-            <SongItem
-              key={setSectionSong.id}
-              setSectionSong={setSectionSong}
-              index={sectionStartIndex + setSectionSong.position}
-              setId={setId}
-              setSectionType={type.name}
-              isInFirstSection={isFirstSection}
-              isInLastSection={isLastSection}
-              isFirstSong={setSectionSong.position === 0}
-              isLastSong={setSectionSong.position === section.songs.length - 1}
-              withActionsMenu
-            />
-          ))}
-      </VStack>
+      {isSectionExpanded && (
+        <VStack>
+          <hr className="mb-4 bg-slate-100" />
+          {songs &&
+            songs.length > 0 &&
+            section.songs.map((setSectionSong) => (
+              <SongItem
+                key={setSectionSong.id}
+                setSectionSong={setSectionSong}
+                index={sectionStartIndex + setSectionSong.position}
+                setId={setId}
+                setSectionType={type.name}
+                isInFirstSection={isFirstSection}
+                isInLastSection={isLastSection}
+                isFirstSong={setSectionSong.position === 0}
+                isLastSong={
+                  setSectionSong.position === section.songs.length - 1
+                }
+                withActionsMenu
+              />
+            ))}
+        </VStack>
+      )}
     </VStack>
   );
 };

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -145,25 +145,31 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
     !isDirty || !isValid || isSubmitting;
 
   return (
-    <VStack key={id} className="gap-4 rounded-lg border p-4 lg:gap-4 lg:p-6">
+    <VStack key={id} className="gap-4 rounded-lg border p-4 md:gap-4 lg:p-6">
       <VStack as="header" className="gap-4">
         <Form {...updateSetSectionForm}>
           <form
             onSubmit={updateSetSectionForm.handleSubmit(handleUpdateSetSection)}
           >
             {!isEditingSectionType && (
-              <HStack className="flex-wrap items-baseline justify-between gap-4 pr-4 lg:gap-16">
-                <HStack className="gap-4">
+              <HStack className="flex-wrap items-baseline justify-between gap-4 lg:gap-16 lg:pr-4">
+                <HStack className="gap-2 lg:gap-4">
                   <Text
                     asElement="h3"
                     style="header-medium-semibold"
-                    className="flex-wrap text-xl"
+                    className="text-l flex-wrap md:text-xl"
                   >
                     {type.name}
                   </Text>
                   {!isSectionExpanded ? (
                     <Badge variant="secondary">
-                      {`${section.songs.length} ${pluralize(section.songs.length, { singular: "song", plural: "songs" })}`}
+                      <span>{section.songs.length}</span>
+                      <span className="hidden md:ml-1 md:inline-block">
+                        {pluralize(section.songs.length, {
+                          singular: "song",
+                          plural: "songs",
+                        })}
+                      </span>
                     </Badge>
                   ) : null}
                 </HStack>

--- a/src/modules/shared/components/ArchivedBanner.tsx
+++ b/src/modules/shared/components/ArchivedBanner.tsx
@@ -1,0 +1,76 @@
+import { HStack } from "@components/HStack";
+import { Alert, AlertDescription, AlertTitle } from "@components/ui/alert";
+import { Button } from "@components/ui/button";
+import { VStack } from "@components/VStack";
+import { Archive, CaretDown } from "@phosphor-icons/react";
+import { CaretUp } from "@phosphor-icons/react/dist/ssr";
+import { useState } from "react";
+import { Text } from "@components/Text";
+
+// This is needed since setting text-amber-900 on the icons doesn't seem to work
+const AMBER_900 = "#78350f";
+
+type ArchivedBannerProps = {
+  itemType: "set" | "song";
+  onCtaClick?: () => void;
+};
+
+export const ArchivedBanner: React.FC<ArchivedBannerProps> = ({
+  itemType,
+  onCtaClick,
+}) => {
+  const [isExpanded, setIsExpanded] = useState<boolean>(true);
+
+  return (
+    <Alert className="border-amber-200 bg-amber-50 ">
+      <HStack className="items-start gap-2">
+        <div className="grid h-9 w-6 shrink-0 place-items-center">
+          <Archive color={AMBER_900} />
+        </div>
+        <VStack className="w-full">
+          <HStack className="items-center justify-between">
+            <AlertTitle className="mb-0 text-amber-900">
+              <span className="capitalize">{itemType}</span> is archived
+            </AlertTitle>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="hover:bg-amber-100"
+              onClick={() => {
+                setIsExpanded((isExpanded) => !isExpanded);
+              }}
+            >
+              {isExpanded ? (
+                <CaretUp color={AMBER_900} />
+              ) : (
+                <CaretDown color={AMBER_900} />
+              )}
+            </Button>
+          </HStack>
+          {isExpanded && (
+            <AlertDescription>
+              <VStack className="justify-start gap-3">
+                <VStack className="gap-1">
+                  <Text className="text-amber-700">
+                    This means this {itemType} won&apos;t show up in your
+                    library or in your searches by default. However, all set
+                    history and data are preserved and you can find it in the
+                    archived section.
+                  </Text>
+                </VStack>
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="self-start p-0 text-amber-900"
+                  onClick={onCtaClick}
+                >
+                  Unarchive this {itemType}
+                </Button>
+              </VStack>
+            </AlertDescription>
+          )}
+        </VStack>
+      </HStack>
+    </Alert>
+  );
+};

--- a/src/modules/shared/components/ArchivedBanner.tsx
+++ b/src/modules/shared/components/ArchivedBanner.tsx
@@ -22,7 +22,7 @@ export const ArchivedBanner: React.FC<ArchivedBannerProps> = ({
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
 
   return (
-    <Alert className="border-amber-200 bg-amber-50 ">
+    <Alert className="border-amber-200 bg-amber-50 p-2 md:p-4">
       <HStack className="items-start gap-2">
         <div className="grid h-9 w-6 shrink-0 place-items-center">
           <Archive color={AMBER_900} />

--- a/src/modules/shared/components/index.ts
+++ b/src/modules/shared/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./NewItemResponsiveDialog";
+export * from "./ArchivedBanner";


### PR DESCRIPTION
## Background
This PR is to add a badge and banner to the set details page when the set is archived to help explain what archiving means. There are other UI updates as well to support adding those additional UI elements to the page and improve the UI in general

| Before | After |  |
| ------- | ---- | - |
| ![SWY-88__before--set-details-page](https://github.com/user-attachments/assets/8fbe3dca-6db2-4df2-9ff0-cccb0dec2172) | ![SWY-88__after--set-details-page](https://github.com/user-attachments/assets/76a76b58-762b-493c-9a03-cd7f92300cc8) |
| ![SWY-88__before--page-header](https://github.com/user-attachments/assets/2c2c6693-9b94-4679-afca-7e73b891c916) | ![SWY-88__after--page-header-expanded](https://github.com/user-attachments/assets/31b351a4-a7db-4dca-84f2-3f437917d099) | ![SWY-88__after--page-header-collapsed](https://github.com/user-attachments/assets/42d27789-f7ba-40e4-a840-9fd04dc60576) |
| ![SWY-88__before--section-card](https://github.com/user-attachments/assets/aca1c1a5-55f3-401a-ad50-21df10910897) | ![SWY-88__after--section-card-expanded](https://github.com/user-attachments/assets/778ab083-60d6-4acb-9045-9f7a183794db) | ![SWY-88__after--section-card-collapsed](https://github.com/user-attachments/assets/c44fa3f5-0ddf-479f-9ddd-8675b11bd811) |


## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New Features**
	- Introduced interactive unarchiving for sets with immediate feedback via notifications.
	- Enabled enhanced customization in menus and page headers by allowing dynamic button styles and badge additions.
	- Added new alert components to deliver more detailed user notifications.
	- Implemented expandable sections in set details with visual song count indicators.
	- Introduced an `ArchivedBanner` component for better visibility of archived items.

- **Style**
	- Updated button and link styling for a consistent underlined appearance.
	- Refined layout adjustments across components for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
### 1. Testing Archived Set Badge and Banner

1. **Find or Create an Archived Set**:
   - Navigate to a set that has been archived, or archive an existing set via the set's action menu.
   
2. **Verify the Archived Badge**:
   - Confirm that an amber colored "Archived" badge appears next to the set title.
   - Verify the badge contains the archive icon and "Archived" text.

3. **Test the Archived Banner**:
   - Verify an amber-colored banner appears below the set title.
   - Confirm it displays "Set is archived" as the title.
   - Check that the banner includes explanatory text about what archiving means.
   
4. **Test Banner Collapse Functionality**:
   - Click the caret button in the top-right corner of the banner.
   - Verify the banner collapses, hiding the description text.
   - Click again to expand the banner.
   - Verify the full description reappears.

5. **Test Unarchive Functionality**:
   - Click the "Unarchive this set" link in the banner.
   - Verify that a loading toast appears with "Unarchiving set..." message.
   - Confirm that a success toast appears after completion.
   - Verify that both the archived badge and banner disappear from the UI.

### 2. Testing Collapsible Section Cards

1. **Locate a Set with Sections**:
   - Navigate to a set that contains at least one section with songs.

2. **Test Section Collapse**:
   - Locate the caret button in the section card header.
   - Click the button to collapse the section.
   - Verify that song items disappear from view.
   - Confirm a badge appears showing the number of songs in the section.
   - For sections with multiple songs, verify the badge shows the plural text (e.g., "5 songs").
   - For sections with one song, verify the badge shows singular text (e.g., "1 song").

3. **Test Section Expand**:
   - Click the caret button again to expand the section.
   - Verify that all songs reappear.
   - Confirm the song count badge disappears when expanded.

### 3. Testing Visual Appearance

1. **Responsive Design Testing**:
   - Test the archived badge and banner on both desktop and mobile viewports.
   - Verify that the collapsible sections function correctly on all screen sizes.

2. **Color and Styling**:
   - Verify the archived badge and banner use amber-colored styling for visual distinction.
   - Check that hover states on buttons within the banner change appropriately.
   - Ensure the section collapse/expand animation is smooth.

### 4. Edge Cases

1. **Empty Sections**:
   - Test collapsing a section with zero songs.
   - Verify the badge shows "0 songs" correctly.

2. **Multiple Operations**:
   - Archive a set, then immediately unarchive it.
   - Verify the UI updates correctly after both operations.

3. **Network Issues**:
   - Simulate a network failure during unarchive operation (if possible).
   - Verify error toast appears with appropriate message.