### PR TITLE
[SWY-93] Create card component

### DIFF
--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -15,7 +15,6 @@ import { Alert, AlertDescription, AlertTitle } from "@components/ui/alert";
 import { Button } from "@components/ui/button";
 import { type ComboboxOption } from "@components/ui/combobox";
 import { VStack } from "@components/VStack";
-import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
 import { type SetSectionWithSongs } from "@lib/types";
 import { cn } from "@lib/utils";
 import { useSetQuery } from "@modules/sets/api";
@@ -36,8 +35,8 @@ import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { redirect, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
-import { useMediaQuery } from "usehooks-ts";
 import { validate as uuidValidate } from "uuid";
+import { useResponsive } from "@/hooks/useResponsive";
 
 type SetListPageProps = {
   params: { organization: string; setId: string };
@@ -47,8 +46,7 @@ type SetListPageProps = {
 export default function SetListPage({ params }: SetListPageProps) {
   const searchParams = useSearchParams();
 
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
-  const textSize = isDesktop ? "text-base" : "text-xs";
+  const { textSize } = useResponsive();
 
   const [isEditingSetDetails, setIsEditingSetDetails] =
     useState<boolean>(false);

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,105 @@
+import { HStack } from "@components/HStack";
+import { Text } from "@components/Text";
+import { Button } from "@components/ui/button";
+import { VStack } from "@components/VStack";
+import { CaretDown, CaretUp } from "@phosphor-icons/react";
+import { useState } from "react";
+
+type BaseCardProps = React.PropsWithChildren;
+
+type CardPropsWithHeader = BaseCardProps & {
+  header: React.ReactElement;
+  title?: never;
+  badge?: never;
+  collapsible?: never;
+  externalIsExpanded?: boolean;
+  initialIsExpanded?: never;
+  buttonLabel?: never;
+  buttonOnClick?: never;
+  actionMenu?: never;
+};
+
+type CardPropsWithoutHeader = BaseCardProps & {
+  header?: never;
+  title: string;
+  badge?: React.ReactElement;
+  collapsible?: boolean;
+  externalIsExpanded?: never;
+  initialIsExpanded?: boolean;
+  buttonLabel?: React.ReactElement;
+  buttonOnClick?: () => void;
+  actionMenu?: React.ReactElement;
+};
+
+type CardProps = CardPropsWithHeader | CardPropsWithoutHeader;
+
+export const Card: React.FC<CardProps> = ({
+  header,
+  title,
+  badge,
+  collapsible,
+  externalIsExpanded,
+  initialIsExpanded,
+  buttonLabel,
+  buttonOnClick,
+  actionMenu,
+  children,
+}) => {
+  const [isExpanded, setIsExpanded] = useState<boolean>(
+    initialIsExpanded ?? true,
+  );
+
+  return (
+    <VStack className="gap-4 rounded-lg border p-4 md:gap-4 lg:p-6">
+      <VStack as="header" className="gap-4">
+        {!!header ? (
+          header
+        ) : (
+          <>
+            <HStack className="flex-wrap items-baseline justify-between gap-4 lg:gap-16 lg:pr-4">
+              <Text
+                asElement="h3"
+                style="header-medium-semibold"
+                className="text-l flex-wrap md:text-xl"
+              >
+                {title}
+              </Text>
+              {!!badge && badge}
+            </HStack>
+            <HStack className="flex items-start gap-2">
+              {collapsible && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={(clickEvent) => {
+                    clickEvent.preventDefault();
+                    setIsExpanded((isExpanded) => !isExpanded);
+                  }}
+                >
+                  {isExpanded ? <CaretUp /> : <CaretDown />}
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={(clickEvent) => {
+                  clickEvent.preventDefault();
+                  buttonOnClick?.();
+                }}
+              >
+                {buttonLabel}
+              </Button>
+              {!!actionMenu && actionMenu}
+            </HStack>
+          </>
+        )}
+      </VStack>
+      {((collapsible && isExpanded) ?? externalIsExpanded) && (
+        <VStack>
+          <hr className="mb-4 bg-slate-100" />
+          {children}
+        </VStack>
+      )}
+    </VStack>
+  );
+};

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
 import { Button } from "@components/ui/button";
@@ -26,7 +28,7 @@ type CardPropsWithoutHeader = BaseCardProps & {
   collapsible?: boolean;
   externalIsExpanded?: never;
   initialIsExpanded?: boolean;
-  buttonLabel?: React.ReactElement;
+  buttonLabel?: React.ReactNode;
   buttonOnClick?: () => void;
   actionMenu?: React.ReactElement;
 };
@@ -37,7 +39,7 @@ export const Card: React.FC<CardProps> = ({
   header,
   title,
   badge,
-  collapsible,
+  collapsible: isCollapsible,
   externalIsExpanded,
   initialIsExpanded,
   buttonLabel,
@@ -48,6 +50,10 @@ export const Card: React.FC<CardProps> = ({
   const [isExpanded, setIsExpanded] = useState<boolean>(
     initialIsExpanded ?? true,
   );
+
+  const hasButton = !!buttonLabel && !!buttonOnClick;
+  const shouldShowChildren =
+    (isCollapsible && isExpanded) ?? externalIsExpanded ?? !isCollapsible;
 
   return (
     <VStack className="gap-4 rounded-lg border p-4 md:gap-4 lg:p-6">
@@ -65,36 +71,40 @@ export const Card: React.FC<CardProps> = ({
                 {title}
               </Text>
               {!!badge && badge}
-            </HStack>
-            <HStack className="flex items-start gap-2">
-              {collapsible && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={(clickEvent) => {
-                    clickEvent.preventDefault();
-                    setIsExpanded((isExpanded) => !isExpanded);
-                  }}
-                >
-                  {isExpanded ? <CaretUp /> : <CaretDown />}
-                </Button>
+              {(!!isCollapsible || hasButton) && (
+                <HStack className="flex items-start gap-2">
+                  {isCollapsible && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={(clickEvent) => {
+                        clickEvent.preventDefault();
+                        setIsExpanded((isExpanded) => !isExpanded);
+                      }}
+                    >
+                      {isExpanded ? <CaretUp /> : <CaretDown />}
+                    </Button>
+                  )}
+                  {hasButton && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={(clickEvent) => {
+                        clickEvent.preventDefault();
+                        buttonOnClick?.();
+                      }}
+                    >
+                      {buttonLabel}
+                    </Button>
+                  )}
+                  {!!actionMenu && actionMenu}
+                </HStack>
               )}
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={(clickEvent) => {
-                  clickEvent.preventDefault();
-                  buttonOnClick?.();
-                }}
-              >
-                {buttonLabel}
-              </Button>
-              {!!actionMenu && actionMenu}
             </HStack>
           </>
         )}
       </VStack>
-      {((collapsible && isExpanded) ?? externalIsExpanded) && (
+      {shouldShowChildren && (
         <VStack>
           <hr className="mb-4 bg-slate-100" />
           {children}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -53,7 +53,7 @@ export const Card: React.FC<CardProps> = ({
 
   const hasButton = !!buttonLabel && !!buttonOnClick;
   const shouldShowChildren =
-    (isCollapsible && isExpanded) ?? externalIsExpanded ?? !isCollapsible;
+    externalIsExpanded ?? (isCollapsible ? isExpanded : true);
 
   return (
     <VStack className="gap-4 rounded-lg border p-4 md:gap-4 lg:p-6">

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -58,7 +58,7 @@ export const Card: React.FC<CardProps> = ({
   return (
     <VStack className="gap-4 rounded-lg border p-4 md:gap-4 lg:p-6">
       <VStack as="header" className="gap-4">
-        {!!header ? (
+        {header ? (
           header
         ) : (
           <>

--- a/src/components/ResponsiveDialog/ResponsiveDialog.tsx
+++ b/src/components/ResponsiveDialog/ResponsiveDialog.tsx
@@ -1,5 +1,4 @@
 import type React from "react";
-import { useMediaQuery } from "usehooks-ts";
 import {
   Dialog,
   DialogClose,
@@ -36,7 +35,7 @@ import {
   DrawerTrigger,
   type DrawerTriggerProps,
 } from "@components/ui/drawer";
-import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants/mediaQueries";
+import { useResponsive } from "@/hooks/useResponsive";
 
 type ResponsiveDialogProps = React.PropsWithChildren & {
   open?: boolean;
@@ -51,7 +50,7 @@ export const ResponsiveDialog: React.FC<ResponsiveDialogProps> = ({
   children,
   ...sharedProps
 }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
 
   return isDesktop ? (
     <Dialog {...sharedProps} {...dialogProps}>
@@ -73,7 +72,7 @@ type ResponsiveDialogTriggerProps = React.PropsWithChildren & {
 export const ResponsiveDialogTrigger: React.FC<
   ResponsiveDialogTriggerProps
 > = ({ dialogProps, drawerProps, children, ...sharedProps }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
   return isDesktop ? (
     <DialogTrigger {...sharedProps} {...dialogProps}>
       {children}
@@ -97,7 +96,7 @@ export const ResponsiveDialogClose: React.FC<ResponsiveDialogCloseProps> = ({
   children,
   ...sharedProps
 }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
 
   return isDesktop ? (
     <DialogClose {...sharedProps} {...dialogProps}>
@@ -119,7 +118,7 @@ type ResponsiveDialogContentProps = React.PropsWithChildren & {
 export const ResponsiveDialogContent: React.FC<
   ResponsiveDialogContentProps
 > = ({ dialogProps, drawerProps, children, ...sharedProps }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
 
   return isDesktop ? (
     <DialogContent {...sharedProps} {...dialogProps}>
@@ -142,7 +141,7 @@ export const ResponsiveDialogHeader: React.FC<ResponsiveDialogHeaderProps> = ({
   drawerProps,
   children,
 }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
 
   return isDesktop ? (
     <DialogHeader {...dialogProps}>{children}</DialogHeader>
@@ -162,7 +161,7 @@ export const ResponsiveDialogTitle: React.FC<ResponsiveDialogTitle> = ({
   asChild,
   children,
 }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
 
   return isDesktop ? (
     <DialogTitle asChild={asChild} {...dialogProps}>
@@ -178,17 +177,21 @@ export const ResponsiveDialogTitle: React.FC<ResponsiveDialogTitle> = ({
 type ResponsiveDialogDescriptionProps = React.PropsWithChildren & {
   dialogProps?: DialogDescriptionProps;
   drawerProps?: DrawerDescriptionProps;
-  asChild?: boolean
+  asChild?: boolean;
 };
 export const ResponsiveDialogDescription: React.FC<
   ResponsiveDialogDescriptionProps
 > = ({ dialogProps, drawerProps, asChild, children }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
 
   return isDesktop ? (
-    <DialogDescription asChild={asChild} {...dialogProps}>{children}</DialogDescription>
+    <DialogDescription asChild={asChild} {...dialogProps}>
+      {children}
+    </DialogDescription>
   ) : (
-    <DrawerDescription asChild={asChild} {...drawerProps}>{children}</DrawerDescription>
+    <DrawerDescription asChild={asChild} {...drawerProps}>
+      {children}
+    </DrawerDescription>
   );
 };
 
@@ -201,7 +204,7 @@ export const ResponsiveDialogFooter: React.FC<ResponsiveDialogFooterProps> = ({
   drawerProps,
   children,
 }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
 
   return isDesktop ? (
     <DialogFooter {...dialogProps}>{children}</DialogFooter>

--- a/src/hooks/__tests__/useResponsive.test.tsx
+++ b/src/hooks/__tests__/useResponsive.test.tsx
@@ -9,6 +9,10 @@ jest.mock("usehooks-ts", () => ({
 }));
 
 describe("useResponsive", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should return desktop values when on desktop viewport", () => {
     // Mock the useMediaQuery to return true (desktop viewport)
     (useMediaQuery as jest.Mock).mockReturnValue(true);

--- a/src/hooks/__tests__/useResponsive.test.tsx
+++ b/src/hooks/__tests__/useResponsive.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from "@testing-library/react";
+import { useResponsive } from "../useResponsive";
+import { useMediaQuery } from "usehooks-ts";
+import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants/mediaQueries";
+
+// Mock the usehooks-ts useMediaQuery hook
+jest.mock("usehooks-ts", () => ({
+  useMediaQuery: jest.fn(),
+}));
+
+describe("useResponsive", () => {
+  it("should return desktop values when on desktop viewport", () => {
+    // Mock the useMediaQuery to return true (desktop viewport)
+    (useMediaQuery as jest.Mock).mockReturnValue(true);
+
+    const { result } = renderHook(() => useResponsive());
+
+    expect(result.current.isDesktop).toBe(true);
+    expect(result.current.textSize).toBe("text-base");
+    expect(useMediaQuery).toHaveBeenCalledWith(DESKTOP_MEDIA_QUERY_STRING);
+  });
+
+  it("should return mobile values when on mobile viewport", () => {
+    // Mock the useMediaQuery to return false (mobile viewport)
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+
+    const { result } = renderHook(() => useResponsive());
+
+    expect(result.current.isDesktop).toBe(false);
+    expect(result.current.textSize).toBe("text-xs");
+    expect(useMediaQuery).toHaveBeenCalledWith(DESKTOP_MEDIA_QUERY_STRING);
+  });
+
+  it("should use the correct media query string", () => {
+    (useMediaQuery as jest.Mock).mockReturnValue(true);
+
+    renderHook(() => useResponsive());
+
+    expect(useMediaQuery).toHaveBeenCalledWith("(min-width: 1025px)");
+  });
+});

--- a/src/hooks/__tests__/useResponsive.test.tsx
+++ b/src/hooks/__tests__/useResponsive.test.tsx
@@ -36,6 +36,6 @@ describe("useResponsive", () => {
 
     renderHook(() => useResponsive());
 
-    expect(useMediaQuery).toHaveBeenCalledWith("(min-width: 1025px)");
+    expect(useMediaQuery).toHaveBeenCalledWith(DESKTOP_MEDIA_QUERY_STRING);
   });
 });

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -1,0 +1,29 @@
+import { useMediaQuery } from "usehooks-ts";
+import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants/mediaQueries";
+
+/**
+ * A hook that provides responsive utilities for desktop vs mobile views.
+ * Uses the DESKTOP_MEDIA_QUERY_STRING constant for consistency across the app.
+ *
+ * @returns {Object} An object containing:
+ *   - isDesktop: boolean - True if the viewport matches desktop size
+ *   - textSize: string - The appropriate text size class for the current viewport
+ *
+ * @example
+ * const { isDesktop, textSize } = useResponsive();
+ *
+ * return (
+ *   <div className={textSize}>
+ *     {isDesktop ? <DesktopView /> : <MobileView />}
+ *   </div>
+ * );
+ */
+export const useResponsive = () => {
+  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const textSize = isDesktop ? "text-base" : "text-xs";
+
+  return {
+    isDesktop,
+    textSize,
+  } as const;
+};

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -1,42 +1,9 @@
-import { api } from "@/trpc/react";
-import { HStack } from "@components/HStack";
-import { Text } from "@components/Text";
-import { Badge } from "@components/ui/badge";
-import { Button } from "@components/ui/button";
-import { type ComboboxOption } from "@components/ui/combobox";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-} from "@components/ui/form";
 import { VStack } from "@components/VStack";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
-import { pluralize } from "@lib/string";
 import { type SetSectionWithSongs } from "@lib/types";
-import { insertSetSectionSchema } from "@lib/types/zod";
-import { cn } from "@lib/utils";
 import { SongItem } from "@modules/SetListCard";
-import { SetSectionActionMenu } from "@modules/SetListCard/components/SetSectionActionMenu";
-import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
-import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
-import { useUserQuery } from "@modules/users/api/queries";
-import { CaretDown, CaretUp } from "@phosphor-icons/react";
-import { Plus } from "@phosphor-icons/react/dist/ssr";
-import { redirect, useSearchParams } from "next/navigation";
 import { useState, type FC } from "react";
-import { useForm, type SubmitHandler } from "react-hook-form";
-import { toast } from "sonner";
-import { useMediaQuery } from "usehooks-ts";
-import { type z } from "zod";
-
-const updateSetSectionSchema = insertSetSectionSchema.pick({
-  sectionTypeId: true,
-});
-
-export type UpdateSetSectionFormFields = z.infer<typeof updateSetSectionSchema>;
+import { EditSetSectionTypeForm } from "../forms/EditSetSectionTypeForm";
+import { Card } from "@components/Card/Card";
 
 export type SetSectionCardProps = {
   /** The section data including songs, type, and position */
@@ -64,244 +31,44 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   sectionStartIndex,
   withActionsMenu,
 }) => {
-  const { id, type, songs, setId, position, sectionTypeId } = section;
-  const searchParams = useSearchParams();
+  const { type, songs, setId, position } = section;
 
   const isFirstSection = position === 0;
   const isLastSection = position === setSectionsLength - 1;
 
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
-  const textSize = isDesktop ? "text-base" : "text-xs";
-
   const [isSectionExpanded, setIsSectionExpanded] = useState<boolean>(true);
-  const [isEditingSectionType, setIsEditingSectionType] =
-    useState<boolean>(false);
-
-  const updateSetSectionForm = useForm<UpdateSetSectionFormFields>({
-    resolver: zodResolver(updateSetSectionSchema),
-    defaultValues: {
-      sectionTypeId,
-    },
-  });
-
-  const {
-    formState: { isDirty, isSubmitting, isValid },
-    reset: resetForm,
-  } = updateSetSectionForm;
-
-  const changeSetSectionTypeMutation = api.setSection.changeType.useMutation();
-  const apiUtils = api.useUtils();
-
-  const { data: userData } = useUserQuery();
-
-  const userMembership = userData?.memberships[0];
-
-  if (!userMembership) {
-    redirect("/sign-in");
-  }
-
-  const { options: setSectionTypesOptions } = useSectionTypesOptions(
-    userMembership.organizationId,
-  );
-
-  const handleUpdateSetSection: SubmitHandler<
-    UpdateSetSectionFormFields
-  > = async (formValues: UpdateSetSectionFormFields) => {
-    toast.loading("Updating section...");
-
-    changeSetSectionTypeMutation.mutate(
-      {
-        id: section.id,
-        sectionTypeId: formValues.sectionTypeId,
-        organizationId: userMembership.organizationId,
-      },
-      {
-        async onSuccess() {
-          toast.dismiss();
-          toast.success("Updated section");
-          await apiUtils.set.get.invalidate({
-            setId: section.setId,
-            organizationId: userMembership.organizationId,
-          });
-          setIsEditingSectionType(false);
-        },
-
-        async onError(updateError) {
-          toast.dismiss();
-          toast.error(`Could not update section: ${updateError.message}`);
-        },
-      },
-    );
-  };
-
-  const openAddSongDialogWithPrePopulatedSection = () => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("addSongDialogOpen", "1");
-    params.set("setSectionId", section.id);
-    window.history.pushState(null, "", `?${params.toString()}`);
-  };
-
-  const shouldUpdateSectionButtonBeDisabled =
-    !isDirty || !isValid || isSubmitting;
 
   return (
-    <VStack key={id} className="gap-4 rounded-lg border p-4 md:gap-4 lg:p-6">
-      <VStack as="header" className="gap-4">
-        <Form {...updateSetSectionForm}>
-          <form
-            onSubmit={updateSetSectionForm.handleSubmit(handleUpdateSetSection)}
-          >
-            {!isEditingSectionType && (
-              <HStack className="flex-wrap items-baseline justify-between gap-4 lg:gap-16 lg:pr-4">
-                <HStack className="gap-2 lg:gap-4">
-                  <Text
-                    asElement="h3"
-                    style="header-medium-semibold"
-                    className="text-l flex-wrap md:text-xl"
-                  >
-                    {type.name}
-                  </Text>
-                  {!isSectionExpanded ? (
-                    <Badge variant="secondary">
-                      <span>{section.songs.length}</span>
-                      <span className="hidden md:ml-1 md:inline-block">
-                        {pluralize(section.songs.length, {
-                          singular: "song",
-                          plural: "songs",
-                        })}
-                      </span>
-                    </Badge>
-                  ) : null}
-                </HStack>
-                <HStack className="flex items-start gap-2">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={(clickEvent) => {
-                      clickEvent.preventDefault();
-                      setIsSectionExpanded((isExpanded) => !isExpanded);
-                    }}
-                  >
-                    {isSectionExpanded ? <CaretUp /> : <CaretDown />}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={(clickEvent) => {
-                      clickEvent.preventDefault();
-                      openAddSongDialogWithPrePopulatedSection();
-                    }}
-                  >
-                    <Plus className="text-slate-900" size={16} />
-                    <span className="hidden sm:inline">Add song</span>
-                  </Button>
-                  {withActionsMenu && (
-                    <SetSectionActionMenu
-                      setSection={section}
-                      setSectionsLength={setSectionsLength}
-                      isInFirstSection={isFirstSection}
-                      isInLastSection={isLastSection}
-                      setIsEditingSectionType={setIsEditingSectionType}
-                    />
-                  )}
-                </HStack>
-              </HStack>
-            )}
-            {isEditingSectionType && (
-              <VStack className="gap-4">
-                <FormField
-                  control={updateSetSectionForm.control}
-                  name="sectionTypeId"
-                  render={({ field }) => {
-                    const matchingSetSectionType = setSectionTypesOptions.find(
-                      (setSectionType) => setSectionType.id === field.value,
-                    );
-
-                    const value: ComboboxOption = {
-                      id: matchingSetSectionType?.id ?? "",
-                      label: matchingSetSectionType?.label ?? "",
-                    };
-
-                    return (
-                      <FormItem>
-                        <VStack className="gap-2">
-                          <FormLabel>
-                            <Text
-                              asElement="h3"
-                              style="header-medium-semibold"
-                              className="flex-wrap"
-                            >
-                              Section type
-                            </Text>
-                          </FormLabel>
-                          <FormControl>
-                            <SetSectionTypeCombobox
-                              value={value}
-                              onChange={(selectedValue) => {
-                                field.onChange(selectedValue?.id);
-                              }}
-                              textStyles={cn("text-slate-700", textSize)}
-                              organizationId={userMembership.organizationId}
-                              onCreateSuccess={(newSectionType) =>
-                                field.onChange(newSectionType.id)
-                              }
-                            />
-                          </FormControl>
-                        </VStack>
-                      </FormItem>
-                    );
-                  }}
-                />
-                <HStack className="flex items-start gap-2 self-end">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      resetForm({
-                        sectionTypeId,
-                      });
-                      setIsEditingSectionType(false);
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    size="sm"
-                    type="submit"
-                    disabled={shouldUpdateSectionButtonBeDisabled}
-                    isLoading={isSubmitting}
-                  >
-                    Update section
-                  </Button>
-                </HStack>
-              </VStack>
-            )}
-          </form>
-        </Form>
-      </VStack>
-      {isSectionExpanded && (
-        <VStack>
-          <hr className="mb-4 bg-slate-100" />
-          {songs &&
-            songs.length > 0 &&
-            section.songs.map((setSectionSong) => (
-              <SongItem
-                key={setSectionSong.id}
-                setSectionSong={setSectionSong}
-                index={sectionStartIndex + setSectionSong.position}
-                setId={setId}
-                setSectionType={type.name}
-                isInFirstSection={isFirstSection}
-                isInLastSection={isLastSection}
-                isFirstSong={setSectionSong.position === 0}
-                isLastSong={
-                  setSectionSong.position === section.songs.length - 1
-                }
-                withActionsMenu
-              />
-            ))}
-        </VStack>
-      )}
-    </VStack>
+    <Card
+      externalIsExpanded={isSectionExpanded}
+      header={
+        <EditSetSectionTypeForm
+          section={section}
+          setSectionsLength={setSectionsLength}
+          isExpanded={isSectionExpanded}
+          setIsExpanded={setIsSectionExpanded}
+          withActionsMenu={withActionsMenu}
+          isFirstSection={isFirstSection}
+          isLastSection={isLastSection}
+        />
+      }
+    >
+      {songs &&
+        songs.length > 0 &&
+        section.songs.map((setSectionSong) => (
+          <SongItem
+            key={setSectionSong.id}
+            setSectionSong={setSectionSong}
+            index={sectionStartIndex + setSectionSong.position}
+            setId={setId}
+            setSectionType={type.name}
+            isInFirstSection={isFirstSection}
+            isInLastSection={isLastSection}
+            isFirstSong={setSectionSong.position === 0}
+            isLastSong={setSectionSong.position === section.songs.length - 1}
+            withActionsMenu
+          />
+        ))}
+    </Card>
   );
 };

--- a/src/modules/sets/components/forms/DuplicateSetForm.tsx
+++ b/src/modules/sets/components/forms/DuplicateSetForm.tsx
@@ -22,10 +22,9 @@ import { CaretDown, CaretUp } from "@phosphor-icons/react/dist/ssr";
 import { useSetQuery } from "@modules/sets/api";
 import { type SetSectionWithSongs } from "@lib/types";
 import { SetSectionList } from "../SetSectionList/SetSectionList";
-import { useMediaQuery } from "usehooks-ts";
-import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
 import { sanitizeInput } from "@lib/string";
 import { useRouter } from "next/navigation";
+import { useResponsive } from "@/hooks/useResponsive";
 
 const duplicateSetFormSchema = insertSetSchema.pick({
   date: true,
@@ -44,7 +43,7 @@ export const DuplicateSetForm: React.FC<DuplicateSetFormProps> = ({
   setToDuplicateId,
   setIsDuplicateSetDialogOpen,
 }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const { isDesktop } = useResponsive();
   const [isSectionsAndSongsOpen, setIsSectionsAndSongsOpen] =
     useState<boolean>(isDesktop);
 

--- a/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
+++ b/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
@@ -1,0 +1,265 @@
+import { api } from "@/trpc/react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { insertSetSectionSchema } from "@lib/types/zod";
+import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
+import { useUserQuery } from "@modules/users/api/queries";
+import { redirect, useSearchParams } from "next/navigation";
+import React, { useState, type Dispatch, type SetStateAction } from "react";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { type z } from "zod";
+import { type SetSectionCardProps } from "../SetSectionCard";
+import { useMediaQuery } from "usehooks-ts";
+import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
+import { VStack } from "@components/VStack";
+import { HStack } from "@components/HStack";
+import { pluralize } from "@lib/string";
+import { Text } from "@components/Text";
+import { CaretDown, CaretUp, Plus } from "@phosphor-icons/react";
+import { type ComboboxOption } from "@components/ui/combobox";
+import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { Button } from "@components/ui/button";
+import { Badge } from "@components/ui/badge";
+import { cn } from "@lib/utils";
+import { SetSectionActionMenu } from "@modules/SetListCard/components/SetSectionActionMenu";
+
+const updateSetSectionSchema = insertSetSectionSchema.pick({
+  sectionTypeId: true,
+});
+
+export type UpdateSetSectionFormFields = z.infer<typeof updateSetSectionSchema>;
+
+type EditSetSectionTypeFormProps = Pick<
+  SetSectionCardProps,
+  "section" | "setSectionsLength" | "withActionsMenu"
+> & {
+  isExpanded: boolean;
+  setIsExpanded: Dispatch<SetStateAction<boolean>>;
+  isFirstSection: boolean;
+  isLastSection: boolean;
+};
+
+export const EditSetSectionTypeForm: React.FC<EditSetSectionTypeFormProps> = ({
+  section,
+  setSectionsLength,
+  isExpanded,
+  setIsExpanded,
+  withActionsMenu,
+  isFirstSection,
+  isLastSection,
+}) => {
+  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
+  const textSize = isDesktop ? "text-base" : "text-xs";
+
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+
+  const searchParams = useSearchParams();
+
+  const changeSetSectionTypeMutation = api.setSection.changeType.useMutation();
+  const apiUtils = api.useUtils();
+
+  const updateSetSectionForm = useForm<UpdateSetSectionFormFields>({
+    resolver: zodResolver(updateSetSectionSchema),
+    defaultValues: {
+      sectionTypeId: section.sectionTypeId,
+    },
+  });
+
+  const {
+    formState: { isDirty, isSubmitting, isValid },
+    reset: resetForm,
+  } = updateSetSectionForm;
+
+  const { data: userData } = useUserQuery();
+
+  const userMembership = userData?.memberships[0];
+
+  if (!userMembership) {
+    redirect("/sign-in");
+  }
+
+  const { options: setSectionTypesOptions } = useSectionTypesOptions(
+    userMembership.organizationId,
+  );
+
+  const openAddSongDialogWithPrePopulatedSection = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("addSongDialogOpen", "1");
+    params.set("setSectionId", section.id);
+    window.history.pushState(null, "", `?${params.toString()}`);
+  };
+
+  const shouldUpdateSectionButtonBeDisabled =
+    !isDirty || !isValid || isSubmitting;
+
+  const handleUpdateSetSection: SubmitHandler<
+    UpdateSetSectionFormFields
+  > = async (formValues: UpdateSetSectionFormFields) => {
+    toast.loading("Updating section...");
+
+    changeSetSectionTypeMutation.mutate(
+      {
+        id: section.id,
+        sectionTypeId: formValues.sectionTypeId,
+        organizationId: userMembership.organizationId,
+      },
+      {
+        async onSuccess() {
+          toast.dismiss();
+          toast.success("Updated section");
+          await apiUtils.set.get.invalidate({
+            setId: section.setId,
+            organizationId: userMembership.organizationId,
+          });
+          setIsEditing(false);
+        },
+
+        async onError(updateError) {
+          toast.dismiss();
+          toast.error(`Could not update section: ${updateError.message}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <Form {...updateSetSectionForm}>
+      <form
+        onSubmit={updateSetSectionForm.handleSubmit(handleUpdateSetSection)}
+      >
+        {!isEditing && (
+          <HStack className="flex-wrap items-baseline justify-between gap-4 lg:gap-16 lg:pr-4">
+            <HStack className="gap-2 lg:gap-4">
+              <Text
+                asElement="h3"
+                style="header-medium-semibold"
+                className="text-l flex-wrap md:text-xl"
+              >
+                {section.type.name}
+              </Text>
+              {!isExpanded ? (
+                <Badge variant="secondary">
+                  <span>{section.songs.length}</span>
+                  <span className="hidden md:ml-1 md:inline-block">
+                    {pluralize(section.songs.length, {
+                      singular: "song",
+                      plural: "songs",
+                    })}
+                  </span>
+                </Badge>
+              ) : null}
+            </HStack>
+            <HStack className="flex items-start gap-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={(clickEvent) => {
+                  clickEvent.preventDefault();
+                  setIsExpanded((isExpanded) => !isExpanded);
+                }}
+              >
+                {isExpanded ? <CaretUp /> : <CaretDown />}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={(clickEvent) => {
+                  clickEvent.preventDefault();
+                  openAddSongDialogWithPrePopulatedSection();
+                }}
+              >
+                <Plus className="text-slate-900" size={16} />
+                <span className="hidden sm:inline">Add song</span>
+              </Button>
+              {withActionsMenu && (
+                <SetSectionActionMenu
+                  setSection={section}
+                  setSectionsLength={setSectionsLength}
+                  isInFirstSection={isFirstSection}
+                  isInLastSection={isLastSection}
+                  setIsEditingSectionType={setIsEditing}
+                />
+              )}
+            </HStack>
+          </HStack>
+        )}
+        {isEditing && (
+          <VStack className="gap-4">
+            <FormField
+              control={updateSetSectionForm.control}
+              name="sectionTypeId"
+              render={({ field }) => {
+                const matchingSetSectionType = setSectionTypesOptions.find(
+                  (setSectionType) => setSectionType.id === field.value,
+                );
+
+                const value: ComboboxOption = {
+                  id: matchingSetSectionType?.id ?? "",
+                  label: matchingSetSectionType?.label ?? "",
+                };
+
+                return (
+                  <FormItem>
+                    <VStack className="gap-2">
+                      <FormLabel>
+                        <Text
+                          asElement="h3"
+                          style="header-medium-semibold"
+                          className="flex-wrap"
+                        >
+                          Section type
+                        </Text>
+                      </FormLabel>
+                      <FormControl>
+                        <SetSectionTypeCombobox
+                          value={value}
+                          onChange={(selectedValue) => {
+                            field.onChange(selectedValue?.id);
+                          }}
+                          textStyles={cn("text-slate-700", textSize)}
+                          organizationId={userMembership.organizationId}
+                          onCreateSuccess={(newSectionType) =>
+                            field.onChange(newSectionType.id)
+                          }
+                        />
+                      </FormControl>
+                    </VStack>
+                  </FormItem>
+                );
+              }}
+            />
+            <HStack className="flex items-start gap-2 self-end">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  resetForm({
+                    sectionTypeId: section.sectionTypeId,
+                  });
+                  setIsEditing(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                type="submit"
+                disabled={shouldUpdateSectionButtonBeDisabled}
+                isLoading={isSubmitting}
+              >
+                Update section
+              </Button>
+            </HStack>
+          </VStack>
+        )}
+      </form>
+    </Form>
+  );
+};

--- a/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
+++ b/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
@@ -1,4 +1,10 @@
+import { useResponsive } from "@/hooks/useResponsive";
 import { api } from "@/trpc/react";
+import { HStack } from "@components/HStack";
+import { Text } from "@components/Text";
+import { Badge } from "@components/ui/badge";
+import { Button } from "@components/ui/button";
+import { type ComboboxOption } from "@components/ui/combobox";
 import {
   Form,
   FormControl,
@@ -6,30 +12,22 @@ import {
   FormItem,
   FormLabel,
 } from "@components/ui/form";
+import { VStack } from "@components/VStack";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { pluralize } from "@lib/string";
 import { insertSetSectionSchema } from "@lib/types/zod";
+import { cn } from "@lib/utils";
+import { SetSectionActionMenu } from "@modules/SetListCard/components/SetSectionActionMenu";
+import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
 import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { useUserQuery } from "@modules/users/api/queries";
+import { CaretDown, CaretUp, Plus } from "@phosphor-icons/react";
 import { redirect, useSearchParams } from "next/navigation";
 import React, { useState, type Dispatch, type SetStateAction } from "react";
-import { type SubmitHandler, useForm } from "react-hook-form";
+import { useForm, type SubmitHandler } from "react-hook-form";
 import { toast } from "sonner";
 import { type z } from "zod";
 import { type SetSectionCardProps } from "../SetSectionCard";
-import { useMediaQuery } from "usehooks-ts";
-import { DESKTOP_MEDIA_QUERY_STRING } from "@lib/constants";
-import { VStack } from "@components/VStack";
-import { HStack } from "@components/HStack";
-import { pluralize } from "@lib/string";
-import { Text } from "@components/Text";
-import { CaretDown, CaretUp, Plus } from "@phosphor-icons/react";
-import { type ComboboxOption } from "@components/ui/combobox";
-import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
-import { Button } from "@components/ui/button";
-import { Badge } from "@components/ui/badge";
-import { cn } from "@lib/utils";
-import { SetSectionActionMenu } from "@modules/SetListCard/components/SetSectionActionMenu";
-import { useResponsive } from "@/hooks/useResponsive";
 
 const updateSetSectionSchema = insertSetSectionSchema.pick({
   sectionTypeId: true,

--- a/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
+++ b/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
@@ -29,6 +29,7 @@ import { Button } from "@components/ui/button";
 import { Badge } from "@components/ui/badge";
 import { cn } from "@lib/utils";
 import { SetSectionActionMenu } from "@modules/SetListCard/components/SetSectionActionMenu";
+import { useResponsive } from "@/hooks/useResponsive";
 
 const updateSetSectionSchema = insertSetSectionSchema.pick({
   sectionTypeId: true,
@@ -55,8 +56,7 @@ export const EditSetSectionTypeForm: React.FC<EditSetSectionTypeFormProps> = ({
   isFirstSection,
   isLastSection,
 }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
-  const textSize = isDesktop ? "text-base" : "text-xs";
+  const { textSize } = useResponsive();
 
   const [isEditing, setIsEditing] = useState<boolean>(false);
 

--- a/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
+++ b/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
@@ -22,7 +22,7 @@ import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeC
 import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { useUserQuery } from "@modules/users/api/queries";
 import { CaretDown, CaretUp, Plus } from "@phosphor-icons/react";
-import { redirect, useSearchParams } from "next/navigation";
+import { redirect, useRouter, useSearchParams } from "next/navigation";
 import React, { useState, type Dispatch, type SetStateAction } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { toast } from "sonner";
@@ -58,6 +58,7 @@ export const EditSetSectionTypeForm: React.FC<EditSetSectionTypeFormProps> = ({
 
   const [isEditing, setIsEditing] = useState<boolean>(false);
 
+  const router = useRouter();
   const searchParams = useSearchParams();
 
   const changeSetSectionTypeMutation = api.setSection.changeType.useMutation();
@@ -91,7 +92,8 @@ export const EditSetSectionTypeForm: React.FC<EditSetSectionTypeFormProps> = ({
     const params = new URLSearchParams(searchParams.toString());
     params.set("addSongDialogOpen", "1");
     params.set("setSectionId", section.id);
-    window.history.pushState(null, "", `?${params.toString()}`);
+
+    router.push(`?${params.toString()}`);
   };
 
   const shouldUpdateSectionButtonBeDisabled =

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -26,7 +26,7 @@ import { Textarea } from "@components/ui/textarea";
 import { VStack } from "@components/VStack";
 import { DevTool } from "@hookform/devtools";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { DESKTOP_MEDIA_QUERY_STRING, songKeys } from "@lib/constants";
+import { songKeys } from "@lib/constants";
 import { formatSongKey } from "@lib/string/formatSongKey";
 import { type SetSectionWithSongs } from "@lib/types";
 import { insertSetSectionSongSchema } from "@lib/types/zod";
@@ -47,8 +47,8 @@ import { redirect } from "next/navigation";
 import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { useMediaQuery } from "usehooks-ts";
 import { z } from "zod";
+import { useResponsive } from "@/hooks/useResponsive";
 
 const createSetSectionSongsSchema = insertSetSectionSongSchema
   .pick({
@@ -85,8 +85,7 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   setId,
   prePopulatedSetSectionId,
 }) => {
-  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY_STRING);
-  const textSize = isDesktop ? "text-base" : "text-xs";
+  const { textSize, isDesktop } = useResponsive();
 
   const [newSetSectionType, setNewSetSectionType] =
     useState<ComboboxOption | null>(null);


### PR DESCRIPTION
## Background
This PR is to help set up the updates to the song details page by creating a reusable `Card` component based on the card that the set details page uses. This will help keep things consistent between the set details page and the song details page.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a versatile card component offering both header and title presentations with collapsible content and interactive options.
	- Added an enhanced editing form for set sections that delivers a user-friendly interface with real-time feedback.

- **Refactor**
	- Streamlined the section display by integrating the new editing form and simplifying the update workflow.
	- Updated responsiveness handling across multiple components by implementing a custom hook for consistent text size management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test
[In progress...]