### PR TITLE
[SWY-103] Add update song preferred key action

### DIFF
--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -6,8 +6,16 @@ import { HStack } from "@components/HStack";
 import { SongKey } from "@components/SongKey";
 import { Text } from "@components/Text";
 import { Button } from "@components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@components/ui/select";
 import { Skeleton } from "@components/ui/skeleton";
 import { VStack } from "@components/VStack";
+import { songKeys } from "@lib/constants";
+import { formatSongKey } from "@lib/string/formatSongKey";
 import { PlayHistoryItem, ResourceCard } from "@modules/SetListCard";
 import { ArchivedBanner } from "@modules/shared/components";
 import {
@@ -15,6 +23,7 @@ import {
   SongDetailsPageLoading,
 } from "@modules/songs/components";
 import { SongDetailsItem } from "@modules/songs/components/SongDetailsItem/SongDetailsItem";
+import { SongKeySelect } from "@modules/songs/components/SongKeySelect/SongKeySelect";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
 import { formatDistanceToNow } from "date-fns";
 import { redirect } from "next/navigation";
@@ -72,7 +81,7 @@ export default async function SetListPage({
         <VStack as="dl" className="gap-4 md:gap-6">
           <SongDetailsItem icon="MusicNoteSimple" label="Preferred Key">
             <dd>
-              <SongKey songKey={song.preferredKey} size="large" />
+              <SongKeySelect preferredKey={song.preferredKey} />
             </dd>
           </SongDetailsItem>
           <SongDetailsItem icon="ClockCounterClockwise" label="Last Played">

--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -81,7 +81,11 @@ export default async function SetListPage({
         <VStack as="dl" className="gap-4 md:gap-6">
           <SongDetailsItem icon="MusicNoteSimple" label="Preferred Key">
             <dd>
-              <SongKeySelect preferredKey={song.preferredKey} />
+              <SongKeySelect
+                songId={song.id}
+                preferredKey={song.preferredKey}
+                userMembership={userMembership}
+              />
             </dd>
           </SongDetailsItem>
           <SongDetailsItem icon="ClockCounterClockwise" label="Last Played">

--- a/src/components/SongKey/SongKey.tsx
+++ b/src/components/SongKey/SongKey.tsx
@@ -1,6 +1,6 @@
 import { type Song } from "@/lib/types";
-import { cn } from "@lib/utils";
 import { Text } from "@components/Text";
+import { cn } from "@lib/utils";
 
 export type SongKeyProps = SongKeyGeneralProps &
   (SongKeyFlatProps | SongKeySharpProps);

--- a/src/lib/types/db.ts
+++ b/src/lib/types/db.ts
@@ -20,9 +20,15 @@ export type NewOrganizationMembership =
   typeof organizationMemberships.$inferInsert;
 export type OrganizationMembership =
   typeof organizationMemberships.$inferSelect;
+export type OrganizationMembershipWithOrganization = OrganizationMembership & {
+  organization: Organization;
+};
 
 export type NewUser = typeof users.$inferInsert;
 export type User = typeof users.$inferSelect;
+export type UserWithMembership = User & {
+  membership: OrganizationMembershipWithOrganization;
+};
 export type UserWithMemberships = RouterOutputs["user"]["getUser"];
 
 export type NewEventType = typeof eventTypes.$inferInsert;

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -1,3 +1,4 @@
+import { songKeys } from "@lib/constants";
 import { songNameRegex } from "@lib/constants/regex";
 import {
   organizationMemberships,
@@ -98,6 +99,9 @@ export const songGetLastPlayInstanceSchema = songIdSchema;
 export const songGetPlayHistorySchema = songIdSchema;
 export const songUpdateNameSchema = songIdSchema.extend({
   name: songNameSchema,
+});
+export const songUpdatePreferredKeySchema = songIdSchema.extend({
+  preferredKey: z.enum(songKeys),
 });
 
 /**

--- a/src/modules/songs/components/SongKeySelect/SongKeySelect.tsx
+++ b/src/modules/songs/components/SongKeySelect/SongKeySelect.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { SongKey } from "@components/SongKey";
+import { Button } from "@components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@components/ui/select";
+import { type SongKey as SongKeyType, songKeys } from "@lib/constants";
+import { formatSongKey } from "@lib/string/formatSongKey";
+import { type Song } from "@lib/types";
+import { useState } from "react";
+
+type SongKeySelectProps = {
+  preferredKey: Song["preferredKey"];
+};
+
+export const SongKeySelect: React.FC<SongKeySelectProps> = ({
+  preferredKey,
+}) => {
+  const [songKey, setSongKey] = useState<Song["preferredKey"]>(preferredKey);
+
+  return (
+    <Select
+      onValueChange={(newKey: SongKeyType) => setSongKey(newKey)}
+      defaultValue={songKey as string}
+    >
+      <SelectTrigger className="w-auto gap-2 border-none p-0">
+        <Button variant="ghost" className="p-0">
+          <SongKey songKey={songKey} size="large" />
+        </Button>
+      </SelectTrigger>
+      <SelectContent>
+        {songKeys.map((key) => {
+          return (
+            <SelectItem key={key} value={key}>
+              {formatSongKey(key)}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+};

--- a/src/modules/songs/components/SongKeySelect/SongKeySelect.tsx
+++ b/src/modules/songs/components/SongKeySelect/SongKeySelect.tsx
@@ -31,7 +31,9 @@ export const SongKeySelect: React.FC<SongKeySelectProps> = ({
   const updateSongPreferredKeyMutation =
     api.song.updatePreferredKey.useMutation();
   const router = useRouter();
-  const [songKey, setSongKey] = useState<Song["preferredKey"]>(preferredKey);
+  const [songKey, setSongKey] = useState<Song["preferredKey"]>(
+    preferredKey ?? null,
+  );
 
   const updateSongPreferredKey = (newKey: SongKeyType) => {
     if (!newKey) {
@@ -64,6 +66,7 @@ export const SongKeySelect: React.FC<SongKeySelectProps> = ({
 
   const handleKeySelect = (newKey: SongKeyType) => {
     setSongKey(newKey);
+    // TODO: possibly worth looking into if a debounced update might be worth adding here
     updateSongPreferredKey(newKey);
   };
 

--- a/src/modules/songs/components/SongKeySelect/SongKeySelect.tsx
+++ b/src/modules/songs/components/SongKeySelect/SongKeySelect.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { api } from "@/trpc/react";
 import { SongKey } from "@components/SongKey";
 import { Button } from "@components/ui/button";
 import {
@@ -11,22 +12,63 @@ import {
 import { type SongKey as SongKeyType, songKeys } from "@lib/constants";
 import { formatSongKey } from "@lib/string/formatSongKey";
 import { type Song } from "@lib/types";
+import { type UserData } from "@lib/types/api";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { toast } from "sonner";
 
 type SongKeySelectProps = {
+  songId: string;
   preferredKey: Song["preferredKey"];
+  userMembership: NonNullable<UserData>["memberships"][number];
 };
 
 export const SongKeySelect: React.FC<SongKeySelectProps> = ({
+  songId,
   preferredKey,
+  userMembership,
 }) => {
+  const updateSongPreferredKeyMutation =
+    api.song.updatePreferredKey.useMutation();
+  const router = useRouter();
   const [songKey, setSongKey] = useState<Song["preferredKey"]>(preferredKey);
 
+  const updateSongPreferredKey = (newKey: SongKeyType) => {
+    if (!newKey) {
+      toast.error("Please select a key to update the preferred key to");
+      return;
+    }
+    const toastId = toast.loading("Updating preferred key");
+
+    updateSongPreferredKeyMutation.mutate(
+      {
+        organizationId: userMembership.organizationId,
+        songId,
+        preferredKey: newKey,
+      },
+      {
+        onSuccess() {
+          toast.success("Preferred key updated", { id: toastId });
+          router.refresh();
+        },
+        onError(updateError) {
+          toast.error(
+            `Could not update preferred key: ${updateError.message}`,
+            { id: toastId },
+          );
+          setSongKey(preferredKey);
+        },
+      },
+    );
+  };
+
+  const handleKeySelect = (newKey: SongKeyType) => {
+    setSongKey(newKey);
+    updateSongPreferredKey(newKey);
+  };
+
   return (
-    <Select
-      onValueChange={(newKey: SongKeyType) => setSongKey(newKey)}
-      defaultValue={songKey as string}
-    >
+    <Select onValueChange={handleKeySelect} defaultValue={songKey as string}>
       <SelectTrigger className="w-auto gap-2 border-none p-0">
         <Button variant="ghost" className="p-0">
           <SongKey songKey={songKey} size="large" />

--- a/src/server/api/routers/song.ts
+++ b/src/server/api/routers/song.ts
@@ -471,7 +471,7 @@ export const songRouter = createTRPCRouter({
 
         if (!songToUpdate) {
           console.error(
-            `🤖 - [song/updateName] - could not find song ${input.songId}`,
+            `🤖 - [song/updatePreferredKey] - could not find song ${input.songId}`,
           );
           throw new TRPCError({
             code: "NOT_FOUND",
@@ -483,7 +483,7 @@ export const songRouter = createTRPCRouter({
           songToUpdate.organizationId !== ctx.user.membership.organizationId
         ) {
           console.error(
-            `🤖 - [song/updateName] - user ${ctx.user.id} is not authorized to update song ${input.songId}`,
+            `🤖 - [song/updatePreferredKey] - user ${ctx.user.id} is not authorized to update song ${input.songId}`,
           );
           throw new TRPCError({
             code: "FORBIDDEN",

--- a/src/server/api/routers/song.ts
+++ b/src/server/api/routers/song.ts
@@ -8,6 +8,7 @@ import {
   songGetLastPlayInstanceSchema,
   songGetPlayHistorySchema,
   songUpdateNameSchema,
+  songUpdatePreferredKeySchema,
   unarchiveSongSchema,
 } from "@lib/types/zod";
 import {
@@ -444,6 +445,55 @@ export const songRouter = createTRPCRouter({
         const [updatedSong] = await updateTransaction
           .update(songs)
           .set({ name: trimmedName })
+          .where(eq(songs.id, input.songId))
+          .returning();
+
+        return {
+          success: true,
+          updatedSong,
+          mutationInput: { ...input },
+        };
+      });
+    }),
+
+  updatePreferredKey: organizationProcedure
+    .input(songUpdatePreferredKeySchema)
+    .mutation(async ({ ctx, input }) => {
+      console.log(
+        `🤖 - [song/updatePreferredKey] - attempting to update preferred key for ${input.songId}:`,
+        { mutationInput: { ...input } },
+      );
+
+      return await ctx.db.transaction(async (updateTransaction) => {
+        const songToUpdate = await updateTransaction.query.songs.findFirst({
+          where: eq(songs.id, input.songId),
+        });
+
+        if (!songToUpdate) {
+          console.error(
+            `🤖 - [song/updateName] - could not find song ${input.songId}`,
+          );
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Could not find song",
+          });
+        }
+
+        if (
+          songToUpdate.organizationId !== ctx.user.membership.organizationId
+        ) {
+          console.error(
+            `🤖 - [song/updateName] - user ${ctx.user.id} is not authorized to update song ${input.songId}`,
+          );
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "User is not authorized to update song",
+          });
+        }
+
+        const [updatedSong] = await updateTransaction
+          .update(songs)
+          .set({ preferredKey: input.preferredKey })
           .where(eq(songs.id, input.songId))
           .returning();
 


### PR DESCRIPTION
## Background
This PR is to add the functionality that allows the user to update a song's preferred key on the song details page.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **New Features**
	- Introduced an interactive song key selector on song pages, replacing the previous static display.
	- Users can now update a song’s preferred key directly, with immediate on-screen feedback confirming their changes.
	- Enhanced data structure by linking user memberships with organization details for improved context.
  
- **Bug Fixes**
	- Improved error handling for preferred key updates, ensuring users receive appropriate feedback on selection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## How to test