### PR TITLE
[SWY-97] Adds resource table to db schema

### DIFF
--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -1,2 +1,2 @@
-export * from "./strings";
 export * from "./mediaQueries";
+export * from "./strings";

--- a/src/lib/constants/strings.ts
+++ b/src/lib/constants/strings.ts
@@ -19,3 +19,7 @@ export const songKeys = [
 ] as const;
 
 export type SongKey = (typeof songKeys)[number];
+
+export const resourceStatuses = ["queued", "ready", "failed"] as const;
+
+export type ResourceStatus = (typeof resourceStatuses)[number];

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -116,7 +116,7 @@ export const tags = createTable(
   },
   (tagsTable) => ({
     tagOrganizationUniqueIndex: uniqueIndex(
-      "tags_organization_tag_unique_index",
+      "tags_organization_tag_unique_idx",
     ).on(tagsTable.organizationId, tagsTable.tag),
   }),
 );
@@ -204,7 +204,7 @@ export const sets = createTable(
     updatedAt,
   },
   (setsTable) => ({
-    eventTypeDateIndex: index("sets_event_type_date_index").on(
+    eventTypeDateIndex: index("sets_event_type_date_idx").on(
       setsTable.eventTypeId,
       setsTable.date,
     ),
@@ -294,10 +294,10 @@ export const resources = createTable(
   },
   (resourcesTable) => [
     check("resources_url_scheme_check", sql`"url" ~* '^https?://'`),
-    index("resource_song_id_index").on(resourcesTable.songId),
-    index("resources_url_index").on(resourcesTable.url),
-    index("resource_organization_id_index").on(resourcesTable.organizationId),
-    uniqueIndex("resource_song_id_url_unique_index").on(
+    index("resources_song_id_idx").on(resourcesTable.songId),
+    index("resources_url_idx").on(resourcesTable.url),
+    index("resources_organization_id_idx").on(resourcesTable.organizationId),
+    uniqueIndex("resources_song_id_url_unique_idx").on(
       resourcesTable.songId,
       resourcesTable.url,
     ),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -294,7 +294,6 @@ export const resources = createTable(
   },
   (resourcesTable) => [
     check("resources_url_scheme_check", sql`"url" ~* '^https?://'`),
-    index("resources_song_id_idx").on(resourcesTable.songId),
     index("resources_url_idx").on(resourcesTable.url),
     index("resources_organization_id_idx").on(resourcesTable.organizationId),
     uniqueIndex("resources_song_id_url_unique_idx").on(

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -4,6 +4,7 @@
 import { relations, sql } from "drizzle-orm";
 import {
   boolean,
+  check,
   date,
   index,
   integer,
@@ -278,7 +279,7 @@ export const resources = createTable(
     organizationId: uuid("organization_id")
       .references(() => organizations.id)
       .notNull(),
-    url: varchar("url").notNull(),
+    url: text("url").notNull(),
     title: varchar("title", { length: 255 }).notNull(),
     status: resourceStatusEnum("status").default("queued").notNull(),
     metaTitle: varchar("meta_title", { length: 300 }),
@@ -292,6 +293,7 @@ export const resources = createTable(
     updatedAt,
   },
   (resourcesTable) => [
+    check("resources_url_scheme_check", sql`"url" ~* '^https?://'`),
     index("resource_song_id_index").on(resourcesTable.songId),
     index("resources_url_index").on(resourcesTable.url),
     index("resource_organization_id_index").on(resourcesTable.organizationId),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -295,6 +295,10 @@ export const resources = createTable(
     index("resource_song_id_index").on(resourcesTable.songId),
     index("resources_url_index").on(resourcesTable.url),
     index("resource_organization_id_index").on(resourcesTable.organizationId),
+    uniqueIndex("resource_song_id_url_unique_index").on(
+      resourcesTable.songId,
+      resourcesTable.url,
+    ),
   ],
 );
 
@@ -306,6 +310,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   setSectionSongs: many(setSectionSongs),
   eventTypes: many(eventTypes),
   tags: many(tags),
+  resources: many(resources),
 }));
 
 export const organizationMembersRelations = relations(


### PR DESCRIPTION
## Background
[SWY-97]
This PR is to update the database schema with the resources table that will be used for the song resources feature.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resources support linked to songs and organizations (URL, title, metadata, favicon, image, last-fetched time).
  * Introduced resource status tracking with states: queued, ready, failed.

* **Chores**
  * Added database schema, relations and indexes to support resources and improve lookup performance.
  * Exposed resource status values in public constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->