### PR TITLE
[SWY-100] Adds update song resource BE action

### DIFF
--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -298,6 +298,13 @@ export const insertResourceSchema = createInsertSchema(resources).pick({
   title: true,
 });
 
+export const updateResourceSchema = z.object({
+  resourceId: z.uuid(),
+  organizationId: z.uuid(),
+  url: z.optional(z.url()),
+  title: z.optional(z.string()),
+});
+
 export const deleteResourceSchema = z.object({
   resourceId: z.uuid(),
   organizationId: z.uuid(),

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -291,18 +291,25 @@ export const deleteSongTagSchema = z.object({
  */
 export const getResourceSchema = createSelectSchema(resources);
 
-export const insertResourceSchema = createInsertSchema(resources).pick({
-  organizationId: true,
-  songId: true,
-  url: true,
-  title: true,
+export const insertResourceSchema = z.object({
+  ...createInsertSchema(resources).pick({
+    organizationId: true,
+    songId: true,
+    url: true,
+  }).shape,
+  title: z.string().transform((title) => sanitizeInput(title)),
 });
 
 export const updateResourceSchema = z.object({
+  ...createSelectSchema(resources).pick({
+    organizationId: true,
+  }).shape,
   resourceId: z.uuid(),
-  organizationId: z.uuid(),
-  url: z.optional(z.url()),
-  title: z.optional(z.string()),
+  url: z.url().optional(),
+  title: z
+    .string()
+    .transform((title) => sanitizeInput(title))
+    .optional(),
 });
 
 export const deleteResourceSchema = z.object({

--- a/src/server/orpc/routers/resource.ts
+++ b/src/server/orpc/routers/resource.ts
@@ -2,11 +2,13 @@ import { ORPCError } from "@orpc/server";
 import { and, eq } from "drizzle-orm";
 
 import { getRouteLogger } from "@lib/loggers/logger";
-import { type NewResource } from "@lib/types";
+import { sanitizeInput } from "@lib/string";
+import { type NewResource, type Resource } from "@lib/types";
 import {
   deleteResourceSchema,
   getResourceSchema,
   insertResourceSchema,
+  updateResourceSchema,
 } from "@lib/types/zod";
 import { resources, songs } from "@server/db/schema";
 import { organizationProcedure } from "@server/orpc/base";
@@ -91,6 +93,92 @@ export const createResource = organizationProcedure
     return createdResource;
   });
 
+export const updateResource = organizationProcedure
+  .route({
+    method: "PATCH",
+    path: "/resource/update",
+    summary: "Updates a song resource",
+  })
+  .input(updateResourceSchema)
+  .output(getResourceSchema)
+  .handler(async ({ context, input }) => {
+    const { user } = context;
+
+    const logger = getRouteLogger(context, "resource/update", {
+      input,
+      user,
+    });
+
+    logger?.info("Attempting to update resource");
+
+    const { resourceId, organizationId, url, title } = input;
+
+    if (organizationId !== context.user.membership.organizationId) {
+      logger?.warn(
+        "User is not authorized to update resources for this organization",
+      );
+
+      throw new ORPCError("FORBIDDEN", {
+        message:
+          "User is not authorized to update resources for this organization",
+      });
+    }
+
+    const resourceToUpdate = await context.db.query.resources.findFirst({
+      where: eq(resources.id, resourceId),
+    });
+
+    if (!resourceToUpdate) {
+      logger?.warn("Could not find song resource");
+
+      throw new ORPCError("NOT_FOUND", {
+        message: "Could not find target song resource",
+      });
+    }
+
+    if (resourceToUpdate.organizationId !== organizationId) {
+      logger?.warn("Song resource is not associated with organization");
+
+      throw new ORPCError("FORBIDDEN", {
+        message: "Song resource is not associated with this organization",
+      });
+    }
+
+    const sanitizedTitle = title ? sanitizeInput(title) : undefined;
+    const validatedUrl = url ? validateUrl(url) : undefined;
+
+    if (
+      (!title && !url) ||
+      (sanitizedTitle === resourceToUpdate.title &&
+        validatedUrl === resourceToUpdate.url)
+    ) {
+      logger?.info("No updates needed");
+
+      return resourceToUpdate;
+    }
+
+    const [updatedResource] = await context.db
+      .update(resources)
+      .set({
+        title: sanitizedTitle,
+        url: validatedUrl,
+      })
+      .where(eq(resources.id, resourceId))
+      .returning();
+
+    if (!updatedResource) {
+      logger?.warn("Could not update resource");
+
+      throw new ORPCError("CONFLICT", {
+        message: "A resource with this URL already exists for this song",
+      });
+    }
+
+    logger?.info("Song resource has been updated!");
+
+    return updatedResource;
+  });
+
 export const deleteResource = organizationProcedure
   .route({
     method: "DELETE",
@@ -154,5 +242,6 @@ export const deleteResource = organizationProcedure
 
 export const resourceRouter = {
   create: createResource,
+  update: updateResource,
   delete: deleteResource,
 };

--- a/src/server/orpc/routers/resource.ts
+++ b/src/server/orpc/routers/resource.ts
@@ -2,7 +2,6 @@ import { ORPCError } from "@orpc/server";
 import { and, eq } from "drizzle-orm";
 
 import { getRouteLogger } from "@lib/loggers/logger";
-import { sanitizeInput } from "@lib/string";
 import { type NewResource, type Resource } from "@lib/types";
 import {
   deleteResourceSchema,


### PR DESCRIPTION
## Background
This PR is to create the oRPC route for updating a song resource

## What's changed

* **New Features**
  * Added a resource update endpoint to edit resource title and URL with org-level authorization, conflict prevention, and no-op return when unchanged.

* **Bug Fixes / Data Quality**
  * Titles are now sanitized/normalized on both create and update to ensure consistent validation and storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

## How to test
As this is a back-end update with no corresponding UI yet, the easiest way to test this is by using a tool like Insomnia/Postman, etc. Send a `PATCH` request with a `body` like the following to `http://localhost:3000/api/rpc/resource/update`:
```json
{
	"json": {
		"resourceId": "<resource_id>",
		"organizationId": "<organization_id>",
		 // optional params
		"url": "<url>",
		"title": "<title>"
	},
	"meta": []
}
```

You should receive a `200` response along with the resource that was updated:
```json
{
	"json": {
		"id": "1680dd4c-a63d-4e33-a5ad-7fb277971796",
		"songId": "b0f2aac3-3736-4398-b6af-f52423bab919",
		"organizationId": "4f89f472-29b5-4a6b-9d8b-e418b6bdf9a1",
		"url": "https://frail-peninsula.org/",
		"title": "repurpose leading-edge users",
		"status": "queued",
		"metaTitle": null,
		"metaDescription": null,
		"faviconUrl": null,
		"imageUrl": null,
		"lastFetchedAt": null,
		"createdAt": "2025-12-14T20:02:13.138Z",
		"updatedAt": "2025-12-14T20:18:50.372Z"
	},
	"meta": [
		[
			1,
			"createdAt"
		],
		[
			1,
			"updatedAt"
		]
	]
}
```