### PR TITLE
[SWY-113] Get song resources by song query

### DIFF
--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -291,6 +291,10 @@ export const deleteSongTagSchema = z.object({
  */
 export const getResourceSchema = createSelectSchema(resources);
 
+export const getResourcesBySongIdSchema = z.object({
+  songId: z.uuid(),
+});
+
 export const insertResourceSchema = z.object({
   ...createInsertSchema(resources).pick({
     organizationId: true,

--- a/src/lib/types/zod.ts
+++ b/src/lib/types/zod.ts
@@ -293,6 +293,8 @@ export const getResourceSchema = createSelectSchema(resources);
 
 export const getResourcesBySongIdSchema = z.object({
   songId: z.uuid(),
+  // TODO: remove organization ID from inputs and rely on user context instead
+  organizationId: z.uuid(),
 });
 
 export const insertResourceSchema = z.object({

--- a/src/server/orpc/base.ts
+++ b/src/server/orpc/base.ts
@@ -1,8 +1,8 @@
 import { auth } from "@clerk/nextjs/server";
 import { type LoggerContext } from "@orpc/experimental-pino";
-import { ORPCError, os } from "@orpc/server";
+import { onError, ORPCError, os, ValidationError } from "@orpc/server";
+import { error } from "console";
 import { and, eq } from "drizzle-orm";
-import { validate as uuidValidate } from "uuid";
 import type * as z from "zod";
 
 import {
@@ -78,14 +78,6 @@ const requireOrganizationMembership = o
   .middleware(async ({ context, next }, input: unknown) => {
     const organizationInput = input as z.infer<typeof organizationInputSchema>;
     const { organizationId } = organizationInput;
-
-    const isOrganizationIdValid = uuidValidate(organizationId);
-
-    if (!organizationId || !isOrganizationIdValid) {
-      throw new ORPCError("FORBIDDEN", {
-        message: "Invalid Organization ID",
-      });
-    }
 
     const user = await context.db.query.users.findFirst({
       where: eq(users.id, context.auth.userId),

--- a/src/server/orpc/base.ts
+++ b/src/server/orpc/base.ts
@@ -1,7 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { type LoggerContext } from "@orpc/experimental-pino";
-import { onError, ORPCError, os, ValidationError } from "@orpc/server";
-import { error } from "console";
+import { ORPCError, os } from "@orpc/server";
 import { and, eq } from "drizzle-orm";
 import type * as z from "zod";
 

--- a/src/server/orpc/routers/resource.ts
+++ b/src/server/orpc/routers/resource.ts
@@ -27,7 +27,7 @@ export const getResourcesBySongId = organizationProcedure
   .handler(async ({ context, input }) => {
     const { user } = context;
 
-    const logger = getRouteLogger(context, `${ROUTER_PREFIX}/song/{songId}`, {
+    const logger = getRouteLogger(context, `${ROUTER_PREFIX}/song`, {
       input,
       user,
     });


### PR DESCRIPTION
## Background
This PR is to create the oRPC route to retrieve all resources for a specific song.

## What's changed
* **New Features**
  * Added an endpoint to retrieve resources by song ID.

* **Refactor**
  * API routing now distinguishes REST/OpenAPI and RPC requests using defined route prefixes.
  * Standardized route prefixes and logging contexts for resource operations.

* **Bug Fixes / Validation**
  * Added stricter input validation for song and organization identifiers and improved organization membership checks.

## How to test
As this is a back-end update with no corresponding UI yet, the easiest way to test this is by using a tool like Insomnia/Postman, etc. Send a `GET` request to `http://localhost:3000/api/rpc/resource/song/:song-id`. You will also (temporarily) need to send an `organizationId` query param until the middleware is updated to use the user context instead of an input.

You should receive a `200` response along with the resource attached to that specific song:
```json
[
	{
		"id": "1680dd4c-a63d-4e33-a5ad-7fb277971796",
		"songId": "b0f2aac3-3736-4398-b6af-f52423bab919",
		"organizationId": "4f89f472-29b5-4a6b-9d8b-e418b6bdf9a1",
		"url": "https://unfit-thread.org/",
		"title": "integrate enterprise AI",
		"status": "queued",
		"metaTitle": null,
		"metaDescription": null,
		"faviconUrl": null,
		"imageUrl": null,
		"lastFetchedAt": null,
		"createdAt": "2025-12-14T20:02:13.138Z",
		"updatedAt": "2025-12-25T14:10:26.740Z"
	}
]
```