### PR TITLE
[SWY-119] Updates song details page rendering method

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -66,6 +66,8 @@ const config = {
       "warn",
       {
         groups: [
+          // 0. server-only
+          ["^\\u0000server-only$"],
           // 1. React, Next.js and external packages (excluding internal aliases)
           [
             "^react",

--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -1,6 +1,16 @@
 "use client";
-import { api } from "@/trpc/react";
+import { useCallback, useEffect, useState } from "react";
+import { redirect, useSearchParams } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
+import { CaretDown, CaretUp } from "@phosphor-icons/react";
+import { Archive, Plus } from "@phosphor-icons/react/dist/ssr";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
+import { toast } from "sonner";
+import { validate as uuidValidate } from "uuid";
+
+import { Alert, AlertDescription, AlertTitle } from "@components/ui/alert";
+import { Button } from "@components/ui/button";
+import { type ComboboxOption } from "@components/ui/combobox";
 import { HStack } from "@components/HStack";
 import { PageContentContainer } from "@components/PageContentContainer";
 import {
@@ -11,12 +21,7 @@ import {
   ResponsiveDialogTitle,
 } from "@components/ResponsiveDialog";
 import { Text } from "@components/Text";
-import { Alert, AlertDescription, AlertTitle } from "@components/ui/alert";
-import { Button } from "@components/ui/button";
-import { type ComboboxOption } from "@components/ui/combobox";
 import { VStack } from "@components/VStack";
-import { type SetSectionWithSongs } from "@lib/types";
-import { cn } from "@lib/utils";
 import { useSetQuery } from "@modules/sets/api";
 import { SetActionsMenu } from "@modules/sets/components/SetActionsMenu";
 import { SetDetails } from "@modules/sets/components/SetDetails";
@@ -29,13 +34,9 @@ import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeC
 import { ArchivedBanner } from "@modules/shared/components";
 import { type ConfigureSongForSetProps } from "@modules/songs/components/ConfigureSongForSet/ConfigureSongForSet";
 import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
-import { CaretDown, CaretUp } from "@phosphor-icons/react";
-import { Archive, Plus } from "@phosphor-icons/react/dist/ssr";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
-import { redirect, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
-import { validate as uuidValidate } from "uuid";
+import { trpc } from "@lib/trpc";
+import { type SetSectionWithSongs } from "@lib/types";
+import { cn } from "@lib/utils";
 import { useResponsive } from "@/hooks/useResponsive";
 
 type SetListPageProps = {
@@ -59,8 +60,8 @@ export default function SetListPage({ params }: SetListPageProps) {
   const [isAddSectionDialogOpen, setIsAddSectionDialogOpen] =
     useState<boolean>(false);
 
-  const createSetSectionMutation = api.setSection.create.useMutation();
-  const apiUtils = api.useUtils();
+  const createSetSectionMutation = trpc.setSection.create.useMutation();
+  const apiUtils = trpc.useUtils();
 
   useEffect(() => {
     const addSongDialogOpen = searchParams.get("addSongDialogOpen");
@@ -114,7 +115,7 @@ export default function SetListPage({ params }: SetListPageProps) {
     data: userData,
     isLoading: isUserQueryLoading,
     error: userQueryError,
-  } = api.user.getUser.useQuery({ userId: userId! }, { enabled: !!userId }); // we use a non-null assertion here since the query will be disabled if userId is falsy
+  } = trpc.user.getUser.useQuery({ userId: userId! }, { enabled: !!userId }); // we use a non-null assertion here since the query will be disabled if userId is falsy
   const userMembership = userData?.memberships[0];
 
   validateParams();

--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -126,7 +126,7 @@ export default async function SetListPage({
           <SongNotes songId={song.id} organizationId={params.organization} />
         </VStack>
       </Card>
-      <SongResources songId={params.songId} songResources={songResources} />
+      <SongResources songId={params.songId} />
       <Card title="Play history" collapsible>
         <div className="grid grid-cols-[16px_1fr] gap-y-4">
           {playHistory.length > 0 &&

--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -20,7 +20,7 @@ export default async function SongPage({
   }
 
   const userData = await trpc.user.getUser({ userId });
-  const userMembership = userData?.memberships[0];
+  const userMembership = userData?.memberships.find((membership) => membership.organization.id === params.organization);
 
   if (!userMembership) {
     redirect("/");

--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -19,7 +19,7 @@ import { SongKeySelect } from "@modules/songs/components/SongKeySelect/SongKeySe
 import { SongResources } from "@modules/songs/components/SongResources";
 import { SongTags } from "@modules/songs/components/SongTags/SongTags";
 import { serverApi } from "@lib/orpc/server";
-import { api } from "@/trpc/server";
+import { HydrateClient, trpc } from "@lib/trpc/server";
 
 export default async function SetListPage({
   params,
@@ -34,7 +34,7 @@ export default async function SetListPage({
     redirect("/");
   }
 
-  const userData = await api.user.getUser({ userId });
+  const userData = await trpc.user.getUser({ userId });
   const userMembership = userData?.memberships[0];
 
   if (!userMembership) {
@@ -42,11 +42,12 @@ export default async function SetListPage({
   }
 
   const song = await api.song.get({
+  const song = await trpc.song.get({
     organizationId: userMembership.organizationId,
     songId: params.songId,
   });
 
-  const playHistory = await api.song.getPlayHistory({
+  const playHistory = await trpc.song.getPlayHistory({
     organizationId: userMembership.organizationId,
     songId: params.songId,
   });

--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -1,24 +1,10 @@
 import { redirect } from "next/navigation";
 import { auth } from "@clerk/nextjs/server";
-import { formatDistanceToNow } from "date-fns";
 
-import { Skeleton } from "@components/ui/skeleton";
-import { Card } from "@components/Card/Card";
-import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
-import { VStack } from "@components/VStack";
-import { PlayHistoryItem } from "@modules/SetListCard";
-import { ArchivedBanner } from "@modules/shared/components";
-import {
-  SongDetailsPageHeader,
-  SongDetailsPageLoading,
-  SongNotes,
-} from "@modules/songs/components";
-import { SongDetailsItem } from "@modules/songs/components/SongDetailsItem/SongDetailsItem";
-import { SongKeySelect } from "@modules/songs/components/SongKeySelect/SongKeySelect";
-import { SongResources } from "@modules/songs/components/SongResources";
-import { SongTags } from "@modules/songs/components/SongTags/SongTags";
-import { serverApi } from "@lib/orpc/server";
+import { SongDetailsPage } from "@modules/songs/components/SongDetailsPage/SongDetailsPage";
+import { getServerQueryClient } from "@lib/orpc/get-server-query-client";
+import { orpcServerTQ } from "@lib/orpc/tanstack-server";
 import { HydrateClient, trpc } from "@lib/trpc/server";
 
 export default async function SetListPage({
@@ -26,7 +12,7 @@ export default async function SetListPage({
 }: {
   params: { organization: string; songId: string };
 }) {
-  const dateFormatter = new Intl.DateTimeFormat("en-US");
+  const queryClient = getServerQueryClient();
 
   const { userId } = auth();
 
@@ -37,112 +23,40 @@ export default async function SetListPage({
   const userData = await trpc.user.getUser({ userId });
   const userMembership = userData?.memberships[0];
 
-  if (!userMembership) {
-    redirect("/");
-  }
-
-  const song = await api.song.get({
-  const song = await trpc.song.get({
-    organizationId: userMembership.organizationId,
-    songId: params.songId,
-  });
-
-  const playHistory = await trpc.song.getPlayHistory({
-    organizationId: userMembership.organizationId,
-    songId: params.songId,
-  });
-
   if (!userData) {
     return <Text>Loading user data...</Text>;
   }
 
-  const lastPlayInstance =
-    playHistory && playHistory.length > 0 ? playHistory[0] : undefined;
-
-  if (!song) {
-    return <SongDetailsPageLoading />;
+  if (!userMembership) {
+    redirect("/");
   }
 
-  const songResources = await serverApi.resource.getBySongId({
-    organizationId: userMembership.organizationId,
+  await trpc.song.get.prefetch({
     songId: params.songId,
+    organizationId: userMembership.organizationId,
   });
 
+  await trpc.song.getPlayHistory.prefetch({
+    songId: params.songId,
+    organizationId: userMembership.organizationId,
+  });
+
+  await queryClient.prefetchQuery(
+    orpcServerTQ.resource.getBySongId.queryOptions({
+      input: {
+        songId: params.songId,
+        organizationId: userMembership.organizationId,
+      },
+    }),
+  );
+
   return (
-    <>
-      <SongDetailsPageHeader song={song} userMembership={userMembership} />
-      {song?.isArchived && <ArchivedBanner itemType="song" songId={song.id} />}
-      <Card title="Song details" collapsible>
-        <VStack as="dl" className="gap-4 md:gap-6">
-          <SongDetailsItem icon="MusicNoteSimple" label="Preferred Key">
-            <dd>
-              <SongKeySelect
-                songId={song.id}
-                preferredKey={song.preferredKey}
-                userMembership={userMembership}
-              />
-            </dd>
-          </SongDetailsItem>
-          <SongDetailsItem icon="ClockCounterClockwise" label="Last Played">
-            <dd>
-              {!playHistory && <Skeleton className="h-4 w-[250px]" />}
-              {playHistory && lastPlayInstance ? (
-                <HStack className="gap-[3px] leading-4">
-                  <Text
-                    asElement="span"
-                    style="body-small"
-                    className="text-slate-700"
-                  >
-                    {formatDistanceToNow(lastPlayInstance.set.date, {
-                      addSuffix: true,
-                      includeSeconds: false,
-                    })}
-                  </Text>
-                  <Text
-                    asElement="span"
-                    style="body-small"
-                    className="text-slate-500"
-                  >
-                    for
-                  </Text>
-                  <Text
-                    asElement="span"
-                    style="body-small"
-                    className="text-slate-700"
-                  >
-                    {lastPlayInstance?.set.eventType}
-                  </Text>
-                </HStack>
-              ) : (
-                <Text style="body-small" className="text-slate-700">
-                  Hasn&apos;t been played in a set yet
-                </Text>
-              )}
-            </dd>
-          </SongDetailsItem>
-          <SongDetailsItem icon="Tag" label="Tags">
-            <SongTags songId={song.id} organizationId={params.organization} />
-          </SongDetailsItem>
-          <SongNotes songId={song.id} organizationId={params.organization} />
-        </VStack>
-      </Card>
-      <SongResources songId={params.songId} />
-      <Card title="Play history" collapsible>
-        <div className="grid grid-cols-[16px_1fr] gap-y-4">
-          {playHistory.length > 0 &&
-            playHistory.map((playInstance) => (
-              <PlayHistoryItem
-                key={`${playInstance.set.id}-${playInstance.section.position}`}
-                date={dateFormatter.format(new Date(playInstance.set.date))}
-                eventType={playInstance.set.eventType}
-                songKey={playInstance.song.key}
-                setSection={playInstance.section.typeName}
-                setId={playInstance.set.id}
-              />
-            ))}
-          <PlayHistoryItem date={dateFormatter.format(song.createdAt)} />
-        </div>
-      </Card>
-    </>
+    <HydrateClient>
+      <SongDetailsPage
+        songId={params.songId}
+        organizationId={params.organization}
+        userMembership={userMembership}
+      />
+    </HydrateClient>
   );
 }

--- a/src/app/[organization]/songs/[songId]/page.tsx
+++ b/src/app/[organization]/songs/[songId]/page.tsx
@@ -1,13 +1,12 @@
 import { redirect } from "next/navigation";
 import { auth } from "@clerk/nextjs/server";
 
-import { Text } from "@components/Text";
 import { SongDetailsPage } from "@modules/songs/components/SongDetailsPage/SongDetailsPage";
 import { getServerQueryClient } from "@lib/orpc/get-server-query-client";
 import { orpcServerTQ } from "@lib/orpc/tanstack-server";
 import { HydrateClient, trpc } from "@lib/trpc/server";
 
-export default async function SetListPage({
+export default async function SongPage({
   params,
 }: {
   params: { organization: string; songId: string };
@@ -22,10 +21,6 @@ export default async function SetListPage({
 
   const userData = await trpc.user.getUser({ userId });
   const userMembership = userData?.memberships[0];
-
-  if (!userData) {
-    return <Text>Loading user data...</Text>;
-  }
 
   if (!userMembership) {
     redirect("/");
@@ -54,7 +49,7 @@ export default async function SetListPage({
     <HydrateClient>
       <SongDetailsPage
         songId={params.songId}
-        organizationId={params.organization}
+        organizationId={userMembership.organizationId}
         userMembership={userMembership}
       />
     </HydrateClient>

--- a/src/app/api/organizationMemberships/create/route.ts
+++ b/src/app/api/organizationMemberships/create/route.ts
@@ -1,14 +1,15 @@
-import { type NewOrganizationMembership } from "@/lib/types";
-import { api } from "@/trpc/server";
+import { NextResponse } from "next/server";
 import { TRPCError } from "@trpc/server";
 import { getHTTPStatusCodeFromError } from "@trpc/server/http";
-import { NextResponse } from "next/server";
+
+import { trpc } from "@lib/trpc/server";
+import { type NewOrganizationMembership } from "@/lib/types";
 
 export async function POST(request: Request) {
   const createOrganizationMembershipInput: NewOrganizationMembership =
     (await request.json()) as NewOrganizationMembership;
   try {
-    const newOrganizationMembership = await api.organizationMemberships.create(
+    const newOrganizationMembership = await trpc.organizationMemberships.create(
       createOrganizationMembershipInput,
     );
     return NextResponse.json({ newOrganizationMembership });

--- a/src/app/api/organizationMemberships/isMemberOfOrganization/route.ts
+++ b/src/app/api/organizationMemberships/isMemberOfOrganization/route.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { getHTTPStatusCodeFromError } from "@trpc/server/http";
 import { z } from "zod";
 
-import { api } from "@/trpc/server";
+import { trpc } from "@lib/trpc/server";
 
 /**
  * @deprecated
@@ -26,7 +26,7 @@ export async function POST(request: Request) {
 
   try {
     const isMemberOfOrganization =
-      await api.organizationMemberships.isMemberOfOrganization(input);
+      await trpc.organizationMemberships.isMemberOfOrganization(input);
     return NextResponse.json({ isMemberOfOrganization });
   } catch (error: unknown) {
     if (error instanceof TRPCError) {

--- a/src/app/api/organizations/[organizationId]/route.ts
+++ b/src/app/api/organizations/[organizationId]/route.ts
@@ -1,8 +1,9 @@
-import { api } from "@/trpc/server";
+import { NextResponse } from "next/server";
 import { TRPCError } from "@trpc/server";
 import { getHTTPStatusCodeFromError } from "@trpc/server/http";
-import { NextResponse } from "next/server";
 import { z } from "zod";
+
+import { trpc } from "@lib/trpc/server";
 
 type GetOrganizationParams = {
   organizationId: string;
@@ -24,7 +25,7 @@ export async function GET(
   }
 
   try {
-    const isMemberOfOrganization = await api.organization.organization(
+    const isMemberOfOrganization = await trpc.organization.organization(
       validatedParams.data,
     );
     return NextResponse.json({ isMemberOfOrganization });

--- a/src/app/api/organizations/create/route.ts
+++ b/src/app/api/organizations/create/route.ts
@@ -1,14 +1,15 @@
-import { type NewOrganization } from "@/lib/types";
-import { api } from "@/trpc/server";
+import { NextResponse } from "next/server";
 import { TRPCError } from "@trpc/server";
 import { getHTTPStatusCodeFromError } from "@trpc/server/http";
-import { NextResponse } from "next/server";
+
+import { trpc } from "@lib/trpc/server";
+import { type NewOrganization } from "@/lib/types";
 
 export async function POST(request: Request) {
   const createOrganizationInput: NewOrganization =
     (await request.json()) as NewOrganization;
   try {
-    const newOrganization = await api.organization.create(
+    const newOrganization = await trpc.organization.create(
       createOrganizationInput,
     );
     return NextResponse.json({ newOrganization });

--- a/src/app/api/users/hello/route.ts
+++ b/src/app/api/users/hello/route.ts
@@ -1,10 +1,11 @@
-import { api } from "@/trpc/server";
-import { TRPCError } from "@trpc/server";
 import { NextResponse } from "next/server";
+import { TRPCError } from "@trpc/server";
+
+import { trpc } from "@lib/trpc/server";
 
 export async function GET() {
   try {
-    const greeting = await api.user.hello();
+    const greeting = await trpc.user.hello();
     return NextResponse.json({ greeting });
   } catch (error: unknown) {
     if (error instanceof TRPCError) {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,6 +1,6 @@
-import { api } from "@/trpc/server";
+import { trpc } from "@lib/trpc/server";
 
 export async function GET(_request: Request) {
-  const users = await api.user.getAll();
+  const users = await trpc.user.getAll();
   return Response.json({ users });
 }

--- a/src/app/create-team/page.tsx
+++ b/src/app/create-team/page.tsx
@@ -1,5 +1,6 @@
-import { api } from "@/trpc/server";
 import { TRPCError } from "@trpc/server";
+
+import { trpc } from "@lib/trpc/server";
 import { NEW_USER_SIGN_UP_KEY } from "@app/create-team/consts";
 import { Text } from "@/components/Text";
 import { CreateTeamForm } from "@/modules/onboarding/createTeam";
@@ -16,7 +17,7 @@ export default async function CreateTeamPage({
   if (shouldCreateNewUser) {
     console.log("🖥 - Should create a new user - create-team page");
     try {
-      const newUser = await api.user.createMe();
+      const newUser = await trpc.user.createMe();
       console.log("🖥 - User created - create-team page", newUser);
     } catch (createUserError) {
       console.log(

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,8 @@ import { OrganizationHeader } from "@/components/OrganizationHeader";
 import { SanbiStoreProvider } from "@/providers/sanbi-store-provider";
 import { TRPCReactProvider } from "@/trpc/react";
 
+import { Providers } from "./providers";
+
 import "@/styles/globals.css";
 
 import "@lib/orpc/server-client";
@@ -43,27 +45,20 @@ export default function RootLayout({
           <meta name="viewport" content="width=device-width, initial-scale=1" />
         </head>
         <body>
-          <TRPCReactProvider>
-            <SanbiStoreProvider>
-              <TooltipProvider>
-                <Toaster position="bottom-center" richColors />
-                <div
-                  className={`min-[1025px]:grid ${gridColumns} min-h-screen`}
-                >
-                  <SignedIn>
-                    <div className="hidden rounded-b border border-t-0 border-slate-100 bg-slate-50 min-[1025px]:sticky min-[1025px]:top-0 min-[1025px]:block min-[1025px]:px-8 min-[1025px]:py-6">
-                      <OrganizationHeader />
-                      <GlobalNav />
-                    </div>
-                  </SignedIn>
-                  <div className="flex min-h-screen flex-col">
-                    <Navbar />
-                    {children}
-                  </div>
+          <Providers>
+            <div className={`min-[1025px]:grid ${gridColumns} min-h-screen`}>
+              <SignedIn>
+                <div className="hidden rounded-b border border-t-0 border-slate-100 bg-slate-50 min-[1025px]:sticky min-[1025px]:top-0 min-[1025px]:block min-[1025px]:px-8 min-[1025px]:py-6">
+                  <OrganizationHeader />
+                  <GlobalNav />
                 </div>
-              </TooltipProvider>
-            </SanbiStoreProvider>
-          </TRPCReactProvider>
+              </SignedIn>
+              <div className="flex min-h-screen flex-col">
+                <Navbar />
+                {children}
+              </div>
+            </div>
+          </Providers>
         </body>
       </html>
     </ClerkProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,13 +2,9 @@ import { Poppins } from "next/font/google";
 import { ClerkProvider, SignedIn } from "@clerk/nextjs";
 import { auth } from "@clerk/nextjs/server";
 
-import { Toaster } from "@components/ui/sonner";
-import { TooltipProvider } from "@components/ui/tooltip";
 import { GlobalNav } from "@components/GlobalNav";
 import { Navbar } from "@components/Navbar";
 import { OrganizationHeader } from "@/components/OrganizationHeader";
-import { SanbiStoreProvider } from "@/providers/sanbi-store-provider";
-import { TRPCReactProvider } from "@/trpc/react";
 
 import { Providers } from "./providers";
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
-import { db } from "@/server/db";
-import { organizations } from "@/server/db/schema";
-import { api } from "@/trpc/server";
-import { auth } from "@clerk/nextjs/server";
-import { eq } from "drizzle-orm";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { trpc } from "@lib/trpc/server";
+import { db } from "@/server/db";
+import { organizations } from "@/server/db/schema";
 
 export default async function Home() {
   const { userId } = auth();
@@ -26,7 +27,7 @@ export default async function Home() {
     );
   }
 
-  const userMembership = await api.organizationMemberships.forUser({
+  const userMembership = await trpc.organizationMemberships.forUser({
     userId,
   });
 

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,48 @@
+// src/app/providers.tsx
+"use client";
+
+import React from "react";
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+import { Toaster } from "@components/ui/sonner";
+import { TooltipProvider } from "@components/ui/tooltip";
+import { orpc } from "@lib/orpc/client";
+import { ORPCContext } from "@lib/orpc/react";
+import { makeQueryClient } from "@lib/tanstack/query-client";
+import { TRPCProvider } from "@lib/trpc/client";
+import { SanbiStoreProvider } from "@/providers/sanbi-store-provider";
+
+let browserQueryClient: QueryClient | undefined;
+
+export const getClientQueryClient = () => {
+  if (typeof window === "undefined") {
+    return makeQueryClient();
+  }
+
+  browserQueryClient ??= makeQueryClient();
+  return browserQueryClient;
+};
+
+export const Providers = (props: { children: React.ReactNode }) => {
+  const queryClient = getClientQueryClient();
+
+  const orpcClient = orpc as unknown as React.ContextType<typeof ORPCContext>;
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TRPCProvider queryClient={queryClient}>
+        <ORPCContext.Provider value={orpcClient}>
+          <SanbiStoreProvider>
+            <TooltipProvider>
+              <Toaster position="bottom-center" richColors />
+              {props.children}
+            </TooltipProvider>
+          </SanbiStoreProvider>
+        </ORPCContext.Provider>
+      </TRPCProvider>
+
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+};

--- a/src/components/GlobalNav/GlobalNav.tsx
+++ b/src/components/GlobalNav/GlobalNav.tsx
@@ -1,16 +1,17 @@
 "use client";
 
+import { useAuth } from "@clerk/nextjs";
 import {
   HouseLine,
   MagnifyingGlass,
   MusicNoteSimple,
   Playlist,
 } from "@phosphor-icons/react/dist/ssr";
-import { NavLink } from "@components/NavLink";
-import { useAuth } from "@clerk/nextjs";
-import { api } from "@/trpc/react";
-import { Skeleton } from "@components/ui/skeleton";
 import { skipToken } from "@tanstack/react-query";
+
+import { Skeleton } from "@components/ui/skeleton";
+import { NavLink } from "@components/NavLink";
+import { trpc } from "@lib/trpc";
 import { NewItemResponsiveDialog } from "@/modules/shared/components";
 
 export const GlobalNav = () => {
@@ -19,7 +20,7 @@ export const GlobalNav = () => {
     isPending,
     isError,
     data: userData,
-  } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
+  } = trpc.user.getUser.useQuery(userId ? { userId } : skipToken);
   const user = userData;
 
   if (isPending) {

--- a/src/components/OrganizationHeader/OrganizationHeader.tsx
+++ b/src/components/OrganizationHeader/OrganizationHeader.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { api } from "@/trpc/react";
-import { useAuth } from "@clerk/nextjs";
-import { Skeleton } from "@components/ui/skeleton";
-import { skipToken } from "@tanstack/react-query";
-import Link from "next/link";
 import React from "react";
+import Link from "next/link";
+import { useAuth } from "@clerk/nextjs";
+import { skipToken } from "@tanstack/react-query";
+
+import { Skeleton } from "@components/ui/skeleton";
 import { OrganizationHeaderLink } from "@components/OrganizationHeader/OrganizationHeaderLink";
+import { trpc } from "@lib/trpc";
 
 export const OrganizationHeader: React.FC = () => {
   const { userId, isSignedIn } = useAuth();
@@ -15,7 +16,7 @@ export const OrganizationHeader: React.FC = () => {
     isPending,
     isError,
     data: userData,
-  } = api.user.getUser.useQuery(userId ? { userId } : skipToken);
+  } = trpc.user.getUser.useQuery(userId ? { userId } : skipToken);
   const user = userData;
 
   if (isPending) {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,7 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    await import("../sentry.server.config");
     await import("./lib/orpc/server-client");
+    await import("../sentry.server.config");
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {

--- a/src/lib/orpc/client.ts
+++ b/src/lib/orpc/client.ts
@@ -19,6 +19,9 @@ const link = new RPCLink({
   ],
 });
 
-export const api: RouterClient<typeof appRouter> = createORPCClient(link);
+export const orpcClient: RouterClient<typeof appRouter> =
+  createORPCClient(link);
 
-export const orpc = createTanstackQueryUtils(api);
+export const orpc = createTanstackQueryUtils(orpcClient, {
+  path: ["orpc"],
+});

--- a/src/lib/orpc/get-server-query-client.ts
+++ b/src/lib/orpc/get-server-query-client.ts
@@ -1,7 +1,7 @@
+import "server-only";
+
 import { cache } from "react";
 
 import { makeQueryClient } from "@lib/tanstack/query-client";
-
-import "server-only";
 
 export const getServerQueryClient = cache(makeQueryClient);

--- a/src/lib/orpc/get-server-query-client.ts
+++ b/src/lib/orpc/get-server-query-client.ts
@@ -1,0 +1,7 @@
+import { cache } from "react";
+
+import { makeQueryClient } from "@lib/tanstack/query-client";
+
+import "server-only";
+
+export const getServerQueryClient = cache(makeQueryClient);

--- a/src/lib/orpc/index.ts
+++ b/src/lib/orpc/index.ts
@@ -1,5 +1,0 @@
-export * from "./client";
-export * from "./react";
-export * from "./server";
-export * from "./server-client";
-export * from "./shared";

--- a/src/lib/orpc/index.ts
+++ b/src/lib/orpc/index.ts
@@ -1,0 +1,5 @@
+export * from "./client";
+export * from "./react";
+export * from "./server";
+export * from "./server-client";
+export * from "./shared";

--- a/src/lib/orpc/react.tsx
+++ b/src/lib/orpc/react.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import React from "react";
+import type { createTanstackQueryUtils } from "@orpc/tanstack-query";
+
+type ORPCUtils = ReturnType<typeof createTanstackQueryUtils>;
+
+export const ORPCContext = React.createContext<ORPCUtils | undefined>(
+  undefined,
+);
+
+export const useORPC = () => {
+  const orpcUtils = React.useContext(ORPCContext);
+
+  if (!orpcUtils) {
+    throw new Error(
+      "ORPCContext is not set. Wrap your app in <ORPCContext.Provider>.",
+    );
+  }
+
+  return orpcUtils;
+};

--- a/src/lib/orpc/server-client.ts
+++ b/src/lib/orpc/server-client.ts
@@ -1,10 +1,10 @@
+import "server-only";
+
 import { createRouterClient, type RouterClient } from "@orpc/server";
 import * as Sentry from "@sentry/nextjs";
 
 import { createORPCContext } from "@server/orpc/base";
 import { appRouter } from "@server/orpc/routers";
-
-import "server-only";
 
 declare global {
   // eslint-disable-next-line no-var

--- a/src/lib/orpc/server.ts
+++ b/src/lib/orpc/server.ts
@@ -1,6 +1,7 @@
+import "server-only";
+
 import * as Sentry from "@sentry/nextjs";
 
-import "server-only";
 import "@lib/orpc/server-client";
 
 if (!globalThis.$orpc) {
@@ -8,4 +9,4 @@ if (!globalThis.$orpc) {
   throw new Error("ORPC client not initialized");
 }
 
-export const serverApi = globalThis.$orpc;
+export const orpcServer = globalThis.$orpc;

--- a/src/lib/orpc/tanstack-server.ts
+++ b/src/lib/orpc/tanstack-server.ts
@@ -1,0 +1,9 @@
+import "server-only";
+
+import { createTanstackQueryUtils } from "@orpc/tanstack-query";
+
+import { orpcServer } from "./server";
+
+export const orpcServerTQ = createTanstackQueryUtils(orpcServer, {
+  path: ["orpc"],
+});

--- a/src/lib/tanstack/query-client.ts
+++ b/src/lib/tanstack/query-client.ts
@@ -1,0 +1,20 @@
+import {
+  defaultShouldDehydrateQuery,
+  QueryClient,
+} from "@tanstack/react-query";
+
+export const makeQueryClient = () => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+      },
+      dehydrate: {
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === "pending",
+      },
+    },
+  });
+};

--- a/src/lib/trpc/client.tsx
+++ b/src/lib/trpc/client.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { type QueryClient } from "@tanstack/react-query";
 import { loggerLink, unstable_httpBatchStreamLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
@@ -11,17 +10,6 @@ import SuperJSON from "superjson";
 import { getBaseUrl } from "@server/utils/urls/getBaseUrl";
 import { type AppRouter } from "@/server/api/root";
 
-// const createQueryClient = () => new QueryClient();
-
-// let clientQueryClientSingleton: QueryClient | undefined = undefined;
-// const getQueryClient = () => {
-//   if (typeof window === "undefined") {
-//     // Server: always make a new query client
-//     return createQueryClient();
-//   }
-//   // Browser: use singleton pattern to keep the same query client
-//   return (clientQueryClientSingleton ??= createQueryClient());
-// };
 
 export const trpc = createTRPCReact<AppRouter>();
 

--- a/src/lib/trpc/index.ts
+++ b/src/lib/trpc/index.ts
@@ -1,0 +1,1 @@
+export * from "./client";

--- a/src/lib/trpc/server.tsx
+++ b/src/lib/trpc/server.tsx
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { cache } from "react";
 import { headers } from "next/headers";
 import { createHydrationHelpers } from "@trpc/react-query/rsc";
@@ -5,8 +7,6 @@ import { createHydrationHelpers } from "@trpc/react-query/rsc";
 import { makeQueryClient } from "@lib/tanstack/query-client";
 import { type appRouter, createCaller } from "@/server/api/root";
 import { createTRPCContext } from "@/server/api/trpc";
-
-import "server-only";
 
 export const getQueryClient = cache(makeQueryClient);
 /**

--- a/src/lib/trpc/server.tsx
+++ b/src/lib/trpc/server.tsx
@@ -1,11 +1,14 @@
-import "server-only";
-
-import { headers } from "next/headers";
 import { cache } from "react";
+import { headers } from "next/headers";
+import { createHydrationHelpers } from "@trpc/react-query/rsc";
 
-import { createCaller } from "@/server/api/root";
+import { makeQueryClient } from "@lib/tanstack/query-client";
+import { type appRouter, createCaller } from "@/server/api/root";
 import { createTRPCContext } from "@/server/api/trpc";
 
+import "server-only";
+
+export const getQueryClient = cache(makeQueryClient);
 /**
  * This wraps the `createTRPCContext` helper and provides the required context for the tRPC API when
  * handling a tRPC call from a React Server Component.
@@ -20,3 +23,8 @@ const createContext = cache(() => {
 });
 
 export const api = createCaller(createContext);
+
+export const { trpc, HydrateClient } = createHydrationHelpers<typeof appRouter>(
+  api,
+  getQueryClient,
+);

--- a/src/lib/types/db.ts
+++ b/src/lib/types/db.ts
@@ -1,3 +1,4 @@
+import { type RouterOutputs } from "@lib/trpc";
 import {
   type eventTypes,
   type organizationMemberships,
@@ -12,7 +13,6 @@ import {
   type tags,
   type users,
 } from "@server/db/schema";
-import { type RouterOutputs } from "@/trpc/react";
 
 export type NewOrganization = typeof organizations.$inferInsert;
 export type Organization = typeof organizations.$inferSelect;

--- a/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
+++ b/src/modules/SetListCard/components/SetSectionActionMenu/SetSectionActionMenu.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { DropdownMenuSeparator } from "@components/ui/dropdown-menu";
 import { type Dispatch, type SetStateAction, useState } from "react";
-import { api } from "@/trpc/react";
+import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { useUserQuery } from "@modules/users/api/queries";
+
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -14,14 +13,16 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@components/ui/alert-dialog";
-import { type SongItemWithActionsMenuProps } from "@modules/SetListCard/components/SongItem";
-import { useParams, useRouter } from "next/navigation";
+import { Button } from "@components/ui/button";
+import { DropdownMenuSeparator } from "@components/ui/dropdown-menu";
 import { ActionMenu, ActionMenuItem } from "@components/ActionMenu";
+import { Text } from "@components/Text";
+import { VStack } from "@components/VStack";
+import { type SongItemWithActionsMenuProps } from "@modules/SetListCard/components/SongItem";
 import { type SetSectionCardProps } from "@modules/sets/components/SetSectionCard";
 import { type SwapSetSectionPositionDirection } from "@modules/setSections/api/mutations";
-import { Button } from "@components/ui/button";
-import { VStack } from "@components/VStack";
-import { Text } from "@components/Text";
+import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
 
 type SetSectionActionMenuProps = {
   /** set section the action menu is attached to */
@@ -56,7 +57,7 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
   isInLastSection,
   setIsEditingSectionType,
 }) => {
-  const apiUtils = api.useUtils();
+  const apiUtils = trpc.useUtils();
   const [isActionMenuOpen, setIsActionMenuOpen] = useState<boolean>(false);
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] =
     useState<boolean>(false);
@@ -75,13 +76,13 @@ export const SetSectionActionMenu: React.FC<SetSectionActionMenuProps> = ({
   const userMembership = userData?.memberships[0];
 
   const swapSetSectionWithPreviousMutation =
-    api.setSection.swapWithPrevious.useMutation();
+    trpc.setSection.swapWithPrevious.useMutation();
   const swapSetSectionWithNextMutation =
-    api.setSection.swapWithNext.useMutation();
+    trpc.setSection.swapWithNext.useMutation();
   const moveSetSectionToFirstMutation =
-    api.setSection.moveToFirst.useMutation();
-  const moveSetSectionToLastMutation = api.setSection.moveToLast.useMutation();
-  const deleteSetSectionMutation = api.setSection.delete.useMutation();
+    trpc.setSection.moveToFirst.useMutation();
+  const moveSetSectionToLastMutation = trpc.setSection.moveToLast.useMutation();
+  const deleteSetSectionMutation = trpc.setSection.delete.useMutation();
 
   if (
     !!userQueryError ||

--- a/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
+++ b/src/modules/SetListCard/components/SongActionMenu/SongActionMenu.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { Button } from "@components/ui/button";
-import { DropdownMenuSeparator } from "@components/ui/dropdown-menu";
 import { type Dispatch, type SetStateAction, useState } from "react";
-import { api } from "@/trpc/react";
+import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { useUserQuery } from "@modules/users/api/queries";
+
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -14,15 +12,18 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@components/ui/alert-dialog";
-import { type SetSectionSongWithSongData } from "@lib/types";
+import { Button } from "@components/ui/button";
+import { DropdownMenuSeparator } from "@components/ui/dropdown-menu";
+import { ActionMenu, ActionMenuItem } from "@components/ActionMenu";
 import { type SongItemWithActionsMenuProps } from "@modules/SetListCard/components/SongItem";
+import { ReplaceSongDialog } from "@modules/songs/components/ReplaceSongDialog";
+import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
+import { type SetSectionSongWithSongData } from "@lib/types";
 import {
   type MoveSectionDirection,
   type SwapSongDirection,
 } from "@server/mutations";
-import { useParams, useRouter } from "next/navigation";
-import { ReplaceSongDialog } from "@modules/songs/components/ReplaceSongDialog";
-import { ActionMenu, ActionMenuItem } from "@components/ActionMenu";
 
 type SongActionMenuProps = {
   /** set section song object */
@@ -60,7 +61,7 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
   isInLastSection,
   setIsEditingDetails,
 }) => {
-  const apiUtils = api.useUtils();
+  const apiUtils = trpc.useUtils();
   const [isSongActionMenuOpen, setIsSongActionMenuOpen] =
     useState<boolean>(false);
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] =
@@ -79,15 +80,15 @@ export const SongActionMenu: React.FC<SongActionMenuProps> = ({
   } = useUserQuery();
   const userMembership = userData?.memberships[0];
 
-  const deleteSetSectionSongMutation = api.setSectionSong.delete.useMutation();
+  const deleteSetSectionSongMutation = trpc.setSectionSong.delete.useMutation();
   const swapSongWithPreviousMutation =
-    api.setSectionSong.swapSongWithPrevious.useMutation();
+    trpc.setSectionSong.swapSongWithPrevious.useMutation();
   const swapSongWithNextMutation =
-    api.setSectionSong.swapSongWithNext.useMutation();
+    trpc.setSectionSong.swapSongWithNext.useMutation();
   const moveSongToPreviousSectionMutation =
-    api.setSectionSong.moveSongToPreviousSection.useMutation();
+    trpc.setSectionSong.moveSongToPreviousSection.useMutation();
   const moveSongToNextSectionMutation =
-    api.setSectionSong.moveSongToNextSection.useMutation();
+    trpc.setSectionSong.moveSongToNextSection.useMutation();
 
   if (
     !!userQueryError ||

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -13,10 +13,10 @@ import { VStack } from "@components/VStack";
 import { SongContent } from "@modules/SetListCard/components/SongContent";
 import { EditSongContentFormFields } from "@modules/SetListCard/forms/EditSongContent/components";
 import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
 import { type SetSectionSongWithSongData } from "@lib/types";
 import { insertSetSectionSongSchema } from "@lib/types/zod";
 import { cn } from "@lib/utils";
-import { api } from "@/trpc/react";
 
 import { SongActionMenu } from "../SongActionMenu/SongActionMenu";
 
@@ -83,9 +83,9 @@ export const SongItem: React.FC<SongItemProps> = ({
 }) => {
   const [isEditingDetails, setIsEditingDetails] = useState<boolean>(false);
 
-  const apiUtils = api.useUtils();
+  const apiUtils = trpc.useUtils();
   const updateSetSectionSongMutation =
-    api.setSectionSong.updateDetails.useMutation();
+    trpc.setSectionSong.updateDetails.useMutation();
 
   const updateSetSectionSongForm = useForm({
     resolver: zodResolver(updateSetSectionSongsSchema),

--- a/src/modules/SetListCard/components/SongItem/SongItem.tsx
+++ b/src/modules/SetListCard/components/SongItem/SongItem.tsx
@@ -83,7 +83,7 @@ export const SongItem: React.FC<SongItemProps> = ({
 }) => {
   const [isEditingDetails, setIsEditingDetails] = useState<boolean>(false);
 
-  const apiUtils = trpc.useUtils();
+  const trpcUtils = trpc.useUtils();
   const updateSetSectionSongMutation =
     trpc.setSectionSong.updateDetails.useMutation();
 
@@ -134,7 +134,7 @@ export const SongItem: React.FC<SongItemProps> = ({
         async onSuccess() {
           toast.dismiss();
           toast.success("Updated song");
-          await apiUtils.set.get.invalidate({
+          await trpcUtils.set.get.invalidate({
             setId,
             organizationId: userMembership.organizationId,
           });

--- a/src/modules/eventTypes/components/EventTypeSelect.tsx
+++ b/src/modules/eventTypes/components/EventTypeSelect.tsx
@@ -18,7 +18,7 @@ import { Skeleton } from "@components/ui/skeleton";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
 import { useUserQuery } from "@modules/users/api/queries";
-import { api } from "@/trpc/react";
+import { trpc } from "@lib/trpc";
 
 type EventTypeSelectBaseProps = Omit<SelectProps, "value"> & {
   onSelectChange: (eventTypeId: string) => void;
@@ -58,7 +58,7 @@ export const EventTypeSelect: React.FC<EventTypeSelectProps> = ({
     data: eventTypeData,
     isError: eventTypeQueryError,
     isLoading: eventTypeQueryLoading,
-  } = api.eventType.getEventTypes.useQuery(
+  } = trpc.eventType.getEventTypes.useQuery(
     userMembership
       ? { organizationId: userMembership.organizationId }
       : skipToken,

--- a/src/modules/onboarding/createTeam/components/createTeamForm.tsx
+++ b/src/modules/onboarding/createTeam/components/createTeamForm.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@clerk/nextjs";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type z } from "zod";
 
+import { trpc } from "@lib/trpc";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -17,7 +18,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { insertOrganizationSchema } from "@/lib/types/zod";
-import { api } from "@/trpc/react";
 
 export type CreateTeamFormFields = z.infer<typeof insertOrganizationSchema>;
 
@@ -38,11 +38,11 @@ export const CreateTeamForm: React.FC = () => {
     mode: "onBlur",
   });
 
-  const createOrganizationMutation = api.organization.create.useMutation();
-  const deleteOrganizationMutation = api.organization.delete.useMutation();
+  const createOrganizationMutation = trpc.organization.create.useMutation();
+  const deleteOrganizationMutation = trpc.organization.delete.useMutation();
 
   const createOrganizationMembershipMutation =
-    api.organizationMemberships.create.useMutation({
+    trpc.organizationMemberships.create.useMutation({
       onError(error, variables) {
         deleteOrganizationMutation.mutate({
           organizationId: variables.organizationId,

--- a/src/modules/sets/api/queries.ts
+++ b/src/modules/sets/api/queries.ts
@@ -1,5 +1,6 @@
-import { api } from "@/trpc/react";
 import { validate as uuidValidate } from "uuid";
+
+import { trpc } from "@lib/trpc";
 
 export const useSetQuery = (params: {
   setId: string;
@@ -7,7 +8,7 @@ export const useSetQuery = (params: {
   userId: string;
 }) => {
   const { setId, organizationId, userId } = params;
-  return api.set.get.useQuery(
+  return trpc.set.get.useQuery(
     {
       organizationId,
       setId: params.setId,

--- a/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
+++ b/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
@@ -10,9 +10,9 @@ import { type z } from "zod";
 import { Button } from "@components/ui/button";
 import { TextareaFormField } from "@components/TextareaFormField";
 import { sanitizeInput } from "@lib/string";
+import { trpc } from "@lib/trpc";
 import { type SetType } from "@lib/types";
 import { insertSetSchema } from "@lib/types/zod";
-import { api } from "@/trpc/react";
 
 import { SetDatePickerFormField } from "../forms/SetDatePickerFormField";
 import { SetEventTypeSelectFormField } from "../forms/SetEventTypeSelectFormField";
@@ -43,20 +43,20 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({
     mode: "onChange",
   });
 
-  const createSetMutation = api.set.create.useMutation();
+  const createSetMutation = trpc.set.create.useMutation();
 
   if (!userId) {
     return null;
   }
 
-  const { data: userData, isError } = api.user.getUser.useQuery({ userId });
+  const { data: userData, isError } = trpc.user.getUser.useQuery({ userId });
 
   const {
     data: eventTypeData,
     isError: eventTypeQueryError,
     isFetching: isEventTypeQueryFetching,
     isFetched: isEventTypeQueryFetched,
-  } = api.eventType.getEventTypes.useQuery(
+  } = trpc.eventType.getEventTypes.useQuery(
     userData?.memberships[0]
       ? { organizationId: userData.memberships[0].organizationId }
       : skipToken,

--- a/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
+++ b/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
@@ -63,14 +63,17 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
 
   const createSongMutation = trpc.song.create.useMutation();
 
+  const { data: userData, isError: isGetUserQueryError } =
+    trpc.user.getUser.useQuery({
+      userId: userId!,
+    }, {
+      enabled: !!userId
+    });
+
   if (!userId) {
     return null;
   }
 
-  const { data: userData, isError: isGetUserQueryError } =
-    trpc.user.getUser.useQuery({
-      userId,
-    });
 
   const handleCreateSongSubmit = async (formValues: CreateSongFormFields) => {
     const toastId = toast.loading("Creating song...");

--- a/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
+++ b/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
@@ -1,4 +1,11 @@
-import { Input } from "@components/ui/input";
+import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@clerk/nextjs";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { Button } from "@components/ui/button";
 import {
   Form,
   FormControl,
@@ -6,11 +13,7 @@ import {
   FormItem,
   FormLabel,
 } from "@components/ui/form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { insertSongSchema } from "@lib/types/zod";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
-import { Button } from "@components/ui/button";
+import { Input } from "@components/ui/input";
 import {
   Select,
   SelectContent,
@@ -18,14 +21,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@components/ui/select";
+import { sanitizeInput } from "@lib/string";
+import { trpc } from "@lib/trpc";
+import { insertSongSchema } from "@lib/types/zod";
 import { Textarea } from "@/components/ui/textarea";
 import { songKeys } from "@/lib/constants";
-import { useRouter } from "next/navigation";
-import { useAuth } from "@clerk/nextjs";
-import { api } from "@/trpc/react";
-import { toast } from "sonner";
 import { formatSongKey } from "@/lib/string/formatSongKey";
-import { sanitizeInput } from "@lib/string";
 
 const createSongFormSchema = insertSongSchema
   .pick({
@@ -60,14 +61,14 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
     mode: "onChange",
   });
 
-  const createSongMutation = api.song.create.useMutation();
+  const createSongMutation = trpc.song.create.useMutation();
 
   if (!userId) {
     return null;
   }
 
   const { data: userData, isError: isGetUserQueryError } =
-    api.user.getUser.useQuery({
+    trpc.user.getUser.useQuery({
       userId,
     });
 

--- a/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
+++ b/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import {
-  type DropdownMenuContentProps,
-  DropdownMenuSeparator,
-} from "@components/ui/dropdown-menu";
-import { api } from "@/trpc/react";
-import { toast } from "sonner";
+import { type Dispatch, type SetStateAction, useState } from "react";
 import { useRouter } from "next/navigation";
+import { AlertDialogDescription } from "@radix-ui/react-alert-dialog";
+import { toast } from "sonner";
+
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -15,10 +13,14 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@components/ui/alert-dialog";
-import { AlertDialogDescription } from "@radix-ui/react-alert-dialog";
-import { type SetStateAction, type Dispatch, useState } from "react";
 import { Button } from "@components/ui/button";
+import {
+  type DropdownMenuContentProps,
+  DropdownMenuSeparator,
+} from "@components/ui/dropdown-menu";
 import { ActionMenu, ActionMenuItem } from "@components/ActionMenu";
+import { trpc } from "@lib/trpc";
+
 import { DuplicateSetDialog } from "../DuplicateSetDialog/DuplicateSetDialog";
 
 export type SetActionsMenuProps = {
@@ -48,10 +50,10 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
     useState<boolean>(false);
   const [isDuplicatingSet, setIsDuplicatingSet] = useState<boolean>(false);
 
-  const deleteSetMutation = api.set.delete.useMutation();
-  const archiveSetMutation = api.set.archive.useMutation();
-  const unarchiveSetMutation = api.set.unarchive.useMutation();
-  const apiUtils = api.useUtils();
+  const deleteSetMutation = trpc.set.delete.useMutation();
+  const archiveSetMutation = trpc.set.archive.useMutation();
+  const unarchiveSetMutation = trpc.set.unarchive.useMutation();
+  const apiUtils = trpc.useUtils();
 
   // TODO: move to mutations
   const deleteSet = () => {

--- a/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
+++ b/src/modules/sets/components/SetActionsMenu/SetActionsMenu.tsx
@@ -53,7 +53,7 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
   const deleteSetMutation = trpc.set.delete.useMutation();
   const archiveSetMutation = trpc.set.archive.useMutation();
   const unarchiveSetMutation = trpc.set.unarchive.useMutation();
-  const apiUtils = trpc.useUtils();
+  const trpcUtils = trpc.useUtils();
 
   // TODO: move to mutations
   const deleteSet = () => {
@@ -86,7 +86,7 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
       {
         async onSuccess() {
           toast.success("Set has been archived", { id: toastId });
-          await apiUtils.set.get.invalidate({ setId, organizationId });
+          await trpcUtils.set.get.invalidate({ setId, organizationId });
         },
         onError(error) {
           toast.error(`Set could not be archived: ${error.message}`, {
@@ -107,7 +107,7 @@ export const SetActionsMenu: React.FC<SetActionsMenuProps> = ({
       {
         async onSuccess() {
           toast.success("Set has been unarchived", { id: toastId });
-          await apiUtils.set.get.invalidate({ setId, organizationId });
+          await trpcUtils.set.get.invalidate({ setId, organizationId });
         },
         onError(error) {
           toast.error(`Set could not be unarchived: ${error.message}`, {

--- a/src/modules/sets/components/SetNotes/SetNotes.tsx
+++ b/src/modules/sets/components/SetNotes/SetNotes.tsx
@@ -1,13 +1,14 @@
-import { api } from "@/trpc/react";
-import { HStack } from "@components/HStack";
-import { Text } from "@components/Text";
-import { Button } from "@components/ui/button";
-import { Textarea } from "@components/ui/textarea";
-import { VStack } from "@components/VStack";
-import { sanitizeInput } from "@lib/string/sanitizeInput";
 import { useState } from "react";
 import { toast } from "sonner";
 import unescapeHTML from "validator/es/lib/unescape";
+
+import { Button } from "@components/ui/button";
+import { Textarea } from "@components/ui/textarea";
+import { HStack } from "@components/HStack";
+import { Text } from "@components/Text";
+import { VStack } from "@components/VStack";
+import { sanitizeInput } from "@lib/string/sanitizeInput";
+import { trpc } from "@lib/trpc";
 
 type SetNotesProps = {
   setId: string;
@@ -23,8 +24,8 @@ export const SetNotes: React.FC<SetNotesProps> = ({
   const [isEditingNotes, setIsEditingNotes] = useState<boolean>(false);
   const [notes, setNotes] = useState<string>(value ?? "");
 
-  const updateNotesMutation = api.set.updateNotes.useMutation();
-  const apiUtils = api.useUtils();
+  const updateNotesMutation = trpc.set.updateNotes.useMutation();
+  const apiUtils = trpc.useUtils();
 
   const handleUpdateNotes = () => {
     const toastId = toast.loading("Updating set notes...");

--- a/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
+++ b/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react";
-import { Combobox, type ComboboxOption } from "@components/ui/combobox";
-import { Input } from "@components/ui/input";
-import { Button } from "@components/ui/button";
-import { CommandGroup } from "@components/ui/command";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
-import { cn } from "@lib/utils";
-import { api } from "@/trpc/react";
 import { toast } from "sonner";
+
+import { Button } from "@components/ui/button";
+import { Combobox, type ComboboxOption } from "@components/ui/combobox";
+import { CommandGroup } from "@components/ui/command";
+import { Input } from "@components/ui/input";
 import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
+import { trpc } from "@lib/trpc";
+import { cn } from "@lib/utils";
 
 export type SetSectionTypeComboboxProps = {
   /** Available set section type options */
@@ -53,8 +54,8 @@ export const SetSectionTypeCombobox: React.FC<SetSectionTypeComboboxProps> = ({
   const [newSetSectionInputValue, setNewSetSectionInputValue] =
     useState<string>("");
 
-  const createSetSectionTypeMutation = api.setSectionType.create.useMutation();
-  const apiUtils = api.useUtils();
+  const createSetSectionTypeMutation = trpc.setSectionType.create.useMutation();
+  const apiUtils = trpc.useUtils();
 
   const {
     options: setSectionTypesOptions,

--- a/src/modules/sets/components/forms/DuplicateSetForm.tsx
+++ b/src/modules/sets/components/forms/DuplicateSetForm.tsx
@@ -20,10 +20,10 @@ import { type CreateSetFormFields } from "@modules/sets/components/CreateSetForm
 import { SetDatePickerFormField } from "@modules/sets/components/forms/SetDatePickerFormField";
 import { useUserQuery } from "@modules/users/api/queries";
 import { sanitizeInput } from "@lib/string";
+import { trpc } from "@lib/trpc";
 import { type SetSectionWithSongs } from "@lib/types";
 import { insertSetSchema } from "@lib/types/zod";
 import { useResponsive } from "@/hooks/useResponsive";
-import { api } from "@/trpc/react";
 
 import { SetEventTypeSelectFormField } from "./SetEventTypeSelectFormField";
 import { SetSectionList } from "../SetSectionList/SetSectionList";
@@ -51,7 +51,7 @@ export const DuplicateSetForm: React.FC<DuplicateSetFormProps> = ({
 
   const router = useRouter();
 
-  const duplicateSetMutation = api.set.duplicate.useMutation();
+  const duplicateSetMutation = trpc.set.duplicate.useMutation();
 
   const {
     data: userData,

--- a/src/modules/sets/components/forms/EditSetDetailsForm.tsx
+++ b/src/modules/sets/components/forms/EditSetDetailsForm.tsx
@@ -9,9 +9,9 @@ import { VStack } from "@components/VStack";
 import { type CreateSetFormFields } from "@modules/sets/components/CreateSetForm";
 import { SetDatePickerFormField } from "@modules/sets/components/forms/SetDatePickerFormField";
 import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
 import { type SetWithSectionsSongsAndEventType } from "@lib/types";
 import { updateSetDetailsSchema } from "@lib/types/zod";
-import { api } from "@/trpc/react";
 
 import { SetEventTypeSelectFormField } from "./SetEventTypeSelectFormField";
 
@@ -31,8 +31,8 @@ export const EditSetDetailsForm: React.FC<EditSetDetailsFormProps> = ({
   set,
   setIsEditing,
 }) => {
-  const updateSetDetailsMutation = api.set.updateDetails.useMutation();
-  const apiUtils = api.useUtils();
+  const updateSetDetailsMutation = trpc.set.updateDetails.useMutation();
+  const apiUtils = trpc.useUtils();
 
   const {
     data: userData,

--- a/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
+++ b/src/modules/sets/components/forms/EditSetSectionTypeForm.tsx
@@ -24,10 +24,10 @@ import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeC
 import { useSectionTypesOptions } from "@modules/sets/hooks/useSetSectionTypes";
 import { useUserQuery } from "@modules/users/api/queries";
 import { pluralize } from "@lib/string";
+import { trpc } from "@lib/trpc";
 import { insertSetSectionSchema } from "@lib/types/zod";
 import { cn } from "@lib/utils";
 import { useResponsive } from "@/hooks/useResponsive";
-import { api } from "@/trpc/react";
 
 import { type SetSectionCardProps } from "../SetSectionCard";
 
@@ -63,8 +63,8 @@ export const EditSetSectionTypeForm: React.FC<EditSetSectionTypeFormProps> = ({
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const changeSetSectionTypeMutation = api.setSection.changeType.useMutation();
-  const apiUtils = api.useUtils();
+  const changeSetSectionTypeMutation = trpc.setSection.changeType.useMutation();
+  const apiUtils = trpc.useUtils();
 
   const updateSetSectionForm = useForm<UpdateSetSectionFormFields>({
     resolver: zodResolver(updateSetSectionSchema),

--- a/src/modules/sets/hooks/useSetSectionTypes.ts
+++ b/src/modules/sets/hooks/useSetSectionTypes.ts
@@ -1,11 +1,12 @@
-import { api } from "@/trpc/react";
-import { type ComboboxOption } from "@components/ui/combobox";
 import { useEffect, useState } from "react";
+
+import { type ComboboxOption } from "@components/ui/combobox";
+import { trpc } from "@lib/trpc";
 
 export function useSectionTypesOptions(organizationId?: string) {
   const [options, setOptions] = useState<ComboboxOption[]>([]);
 
-  const { data, error, isLoading } = api.setSectionType.getTypes.useQuery(
+  const { data, error, isLoading } = trpc.setSectionType.getTypes.useQuery(
     { organizationId: organizationId! }, // we use a type assertion here since the query will be disabled if organizationId is falsy
     { enabled: !!organizationId },
   );

--- a/src/modules/shared/components/ArchivedBanner.tsx
+++ b/src/modules/shared/components/ArchivedBanner.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import { HStack } from "@components/HStack";
-import { Alert, AlertDescription, AlertTitle } from "@components/ui/alert";
-import { Button } from "@components/ui/button";
-import { VStack } from "@components/VStack";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@clerk/nextjs";
 import { Archive, CaretDown } from "@phosphor-icons/react";
 import { CaretUp } from "@phosphor-icons/react/dist/ssr";
-import { useState } from "react";
-import { Text } from "@components/Text";
-import { api } from "@/trpc/react";
 import { toast } from "sonner";
-import { useAuth } from "@clerk/nextjs";
-import { useRouter } from "next/navigation";
+
+import { Alert, AlertDescription, AlertTitle } from "@components/ui/alert";
+import { Button } from "@components/ui/button";
+import { HStack } from "@components/HStack";
+import { Text } from "@components/Text";
+import { VStack } from "@components/VStack";
+import { trpc } from "@lib/trpc";
 
 // This is needed since setting text-amber-900 on the icons doesn't seem to work
 const AMBER_900 = "#78350f";
@@ -40,15 +41,15 @@ export const ArchivedBanner: React.FC<ArchivedBannerProps> = ({
   const { userId, isLoaded: isAuthLoaded } = useAuth();
   const router = useRouter();
 
-  const { data: userData, error: userQueryError } = api.user.getUser.useQuery(
+  const { data: userData, error: userQueryError } = trpc.user.getUser.useQuery(
     { userId: userId ?? "" },
     { enabled: Boolean(userId) },
   );
   const userMembership = userData?.memberships?.[0];
 
-  const unarchiveSetMutation = api.set.unarchive.useMutation();
-  const unarchiveSongMutation = api.song.unarchive.useMutation();
-  const apiUtils = api.useUtils();
+  const unarchiveSetMutation = trpc.set.unarchive.useMutation();
+  const unarchiveSongMutation = trpc.song.unarchive.useMutation();
+  const apiUtils = trpc.useUtils();
 
   if (!isAuthLoaded || !userData || !!userQueryError || !userMembership) {
     return null;

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -45,11 +45,11 @@ import { type SongSearchDialogSteps } from "@modules/songs/components/SongSearch
 import { useUserQuery } from "@modules/users/api/queries";
 import { songKeys } from "@lib/constants";
 import { formatSongKey } from "@lib/string/formatSongKey";
+import { trpc } from "@lib/trpc";
 import { type SetSectionWithSongs } from "@lib/types";
 import { insertSetSectionSongSchema } from "@lib/types/zod";
 import { cn } from "@lib/utils";
 import { useResponsive } from "@/hooks/useResponsive";
-import { api } from "@/trpc/react";
 
 const createSetSectionSongsSchema = insertSetSectionSongSchema
   .pick({
@@ -118,9 +118,9 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
 
   const shouldAddSongBeDisabled = !isDirty || !isValid || isSubmitting;
 
-  const addSetSectionSongMutation = api.setSectionSong.create.useMutation();
-  const createSetSectionMutation = api.setSection.create.useMutation();
-  const apiUtils = api.useUtils();
+  const addSetSectionSongMutation = trpc.setSectionSong.create.useMutation();
+  const createSetSectionMutation = trpc.setSection.create.useMutation();
+  const apiUtils = trpc.useUtils();
 
   const {
     data: userData,
@@ -135,7 +135,7 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   }
 
   const { data: lastPlayInstance, isLoading: isLastPlayInstanceQueryLoading } =
-    api.song.getLastPlayInstance.useQuery({
+    trpc.song.getLastPlayInstance.useQuery({
       organizationId: userMembership.organizationId,
       songId: selectedSong.songId,
     });
@@ -144,7 +144,7 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
     data: sectionsForSetData,
     error: sectionsForSetQueryError,
     isLoading: isSectionsForSetQueryLoading,
-  } = api.setSection.getSectionsForSet.useQuery(
+  } = trpc.setSection.getSectionsForSet.useQuery(
     { organizationId: userMembership.organizationId, setId },
     { enabled: !!userMembership, placeholderData: existingSetSections },
   );

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -19,9 +19,9 @@ import {
   type SongSearchResult,
 } from "@modules/songs/components/SongSearch";
 import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
 import { type SetSectionSongWithSongData } from "@lib/types";
 import { cn } from "@lib/utils";
-import { api } from "@/trpc/react";
 
 export type ReplaceSongDialogSteps = "search" | "confirm";
 
@@ -49,7 +49,7 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
   currentSong,
   setId,
 }) => {
-  const apiUtils = api.useUtils();
+  const apiUtils = trpc.useUtils();
   const {
     data: userData,
     isLoading: userQueryLoading,
@@ -64,7 +64,7 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
   );
 
   const replaceSongMutation =
-    api.setSectionSong.replaceSong.useMutation<Error>();
+    trpc.setSectionSong.replaceSong.useMutation<Error>();
 
   if (!userData || !userMembership) {
     return null;

--- a/src/modules/songs/components/SongActionsMenu/SongsActionsMenu.tsx
+++ b/src/modules/songs/components/SongActionsMenu/SongsActionsMenu.tsx
@@ -1,22 +1,16 @@
 "use client";
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@components/ui/dropdown-menu";
+import { type Dispatch, type SetStateAction, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   Archive,
   BoxArrowUp,
   DotsThree,
   Trash,
 } from "@phosphor-icons/react/dist/ssr";
-import { Text } from "@components/Text";
-import { api } from "@/trpc/react";
+import { AlertDialogDescription } from "@radix-ui/react-alert-dialog";
 import { toast } from "sonner";
-import { useRouter } from "next/navigation";
+
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -25,10 +19,17 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@components/ui/alert-dialog";
-import { AlertDialogDescription } from "@radix-ui/react-alert-dialog";
-import { type Dispatch, type SetStateAction, useState } from "react";
 import { Button } from "@components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@components/ui/dropdown-menu";
 import { ActionMenu, ActionMenuItem } from "@components/ActionMenu";
+import { Text } from "@components/Text";
+import { trpc } from "@lib/trpc";
 
 type SongActionsMenuProps = {
   songId: string;
@@ -51,7 +52,7 @@ export const SongActionsMenu: React.FC<SongActionsMenuProps> = ({
     useState<boolean>(false);
 
   // TODO: move to mutations
-  const deleteSongMutation = api.song.delete.useMutation();
+  const deleteSongMutation = trpc.song.delete.useMutation();
   const deleteSong = (organizationId: string, songId: string) => {
     setIsConfirmationDialogOpen(false);
 
@@ -70,7 +71,7 @@ export const SongActionsMenu: React.FC<SongActionsMenuProps> = ({
   };
 
   // TODO: move to mutations
-  const archiveSongMutation = api.song.archive.useMutation();
+  const archiveSongMutation = trpc.song.archive.useMutation();
   const archiveSong = (organizationId: string, songId: string) => {
     setIsSongActionsMenuOpen(false);
     archiveSongMutation.mutate(
@@ -88,7 +89,7 @@ export const SongActionsMenu: React.FC<SongActionsMenuProps> = ({
   };
 
   // TODO: move to mutations
-  const unarchiveSongMutation = api.song.unarchive.useMutation();
+  const unarchiveSongMutation = trpc.song.unarchive.useMutation();
   const unarchiveSong = (organizationId: string, songId: string) => {
     setIsSongActionsMenuOpen(false);
     unarchiveSongMutation.mutate(

--- a/src/modules/songs/components/SongDetailsPage/SongDetailsPage.tsx
+++ b/src/modules/songs/components/SongDetailsPage/SongDetailsPage.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import type React from "react";
+import { notFound } from "next/navigation";
+import { formatDistanceToNow } from "date-fns";
+
+import { Skeleton } from "@components/ui/skeleton";
+import { Card } from "@components/Card/Card";
+import { HStack } from "@components/HStack";
+import { Text } from "@components/Text";
+import { VStack } from "@components/VStack";
+import { PlayHistoryItem } from "@modules/SetListCard";
+import { ArchivedBanner } from "@modules/shared/components";
+import {
+  SongDetailsPageHeader,
+  SongDetailsPageLoading,
+  SongNotes,
+} from "@modules/songs/components";
+import { SongDetailsItem } from "@modules/songs/components/SongDetailsItem/SongDetailsItem";
+import { SongKeySelect } from "@modules/songs/components/SongKeySelect/SongKeySelect";
+import { SongResources } from "@modules/songs/components/SongResources";
+import { SongTags } from "@modules/songs/components/SongTags/SongTags";
+import { trpc } from "@lib/trpc";
+import { type OrganizationMembershipWithOrganization } from "@lib/types";
+
+type SongDetailsPageProps = {
+  songId: string;
+  organizationId: string;
+  userMembership: OrganizationMembershipWithOrganization;
+};
+
+export const SongDetailsPage: React.FC<SongDetailsPageProps> = ({
+  songId,
+  organizationId,
+  userMembership,
+}) => {
+  const { data: song, isLoading: isSongLoading } = trpc.song.get.useQuery({
+    songId,
+    organizationId,
+  });
+
+  const { data: playHistory, isLoading: isPlayHistoryLoading } =
+    trpc.song.getPlayHistory.useQuery({
+      songId,
+      organizationId,
+    });
+
+  const isLoading = isSongLoading || isPlayHistoryLoading;
+
+  if (isLoading) {
+    return <SongDetailsPageLoading />;
+  }
+
+  if (!song) {
+    return notFound();
+  }
+
+  const dateFormatter = new Intl.DateTimeFormat("en-US");
+
+  const lastPlayInstance =
+    playHistory && playHistory.length > 0 ? playHistory[0] : undefined;
+
+  return (
+    <>
+      <SongDetailsPageHeader song={song} userMembership={userMembership} />
+      {song?.isArchived && <ArchivedBanner itemType="song" songId={song.id} />}
+      <Card title="Song details" collapsible>
+        <VStack as="dl" className="gap-4 md:gap-6">
+          <SongDetailsItem icon="MusicNoteSimple" label="Preferred Key">
+            <dd>
+              <SongKeySelect
+                songId={song.id}
+                preferredKey={song.preferredKey}
+                userMembership={userMembership}
+              />
+            </dd>
+          </SongDetailsItem>
+          <SongDetailsItem icon="ClockCounterClockwise" label="Last Played">
+            <dd>
+              {!playHistory && <Skeleton className="h-4 w-[250px]" />}
+              {playHistory && lastPlayInstance ? (
+                <HStack className="gap-[3px] leading-4">
+                  <Text
+                    asElement="span"
+                    style="body-small"
+                    className="text-slate-700"
+                  >
+                    {formatDistanceToNow(lastPlayInstance.set.date, {
+                      addSuffix: true,
+                      includeSeconds: false,
+                    })}
+                  </Text>
+                  <Text
+                    asElement="span"
+                    style="body-small"
+                    className="text-slate-500"
+                  >
+                    for
+                  </Text>
+                  <Text
+                    asElement="span"
+                    style="body-small"
+                    className="text-slate-700"
+                  >
+                    {lastPlayInstance?.set.eventType}
+                  </Text>
+                </HStack>
+              ) : (
+                <Text style="body-small" className="text-slate-700">
+                  Hasn&apos;t been played in a set yet
+                </Text>
+              )}
+            </dd>
+          </SongDetailsItem>
+          <SongDetailsItem icon="Tag" label="Tags">
+            <SongTags songId={song.id} organizationId={organizationId} />
+          </SongDetailsItem>
+          <SongNotes songId={song.id} organizationId={organizationId} />
+        </VStack>
+      </Card>
+      <SongResources songId={songId} />
+      <Card title="Play history" collapsible>
+        <div className="grid grid-cols-[16px_1fr] gap-y-4">
+          {playHistory &&
+            playHistory.length > 0 &&
+            playHistory.map((playInstance) => (
+              <PlayHistoryItem
+                key={`${playInstance.set.id}-${playInstance.section.position}`}
+                date={dateFormatter.format(new Date(playInstance.set.date))}
+                eventType={playInstance.set.eventType}
+                songKey={playInstance.song.key}
+                setSection={playInstance.section.typeName}
+                setId={playInstance.set.id}
+              />
+            ))}
+          <PlayHistoryItem date={dateFormatter.format(song.createdAt)} />
+        </div>
+      </Card>
+    </>
+  );
+};

--- a/src/modules/songs/components/SongDetailsPage/SongDetailsPage.tsx
+++ b/src/modules/songs/components/SongDetailsPage/SongDetailsPage.tsx
@@ -77,7 +77,6 @@ export const SongDetailsPage: React.FC<SongDetailsPageProps> = ({
           </SongDetailsItem>
           <SongDetailsItem icon="ClockCounterClockwise" label="Last Played">
             <dd>
-              {!playHistory && <Skeleton className="h-4 w-[250px]" />}
               {playHistory && lastPlayInstance ? (
                 <HStack className="gap-[3px] leading-4">
                   <Text

--- a/src/modules/songs/components/SongDetailsPage/SongDetailsPage.tsx
+++ b/src/modules/songs/components/SongDetailsPage/SongDetailsPage.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import type React from "react";
-import { notFound } from "next/navigation";
 import { formatDistanceToNow } from "date-fns";
 
-import { Skeleton } from "@components/ui/skeleton";
 import { Card } from "@components/Card/Card";
 import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
@@ -34,7 +32,7 @@ export const SongDetailsPage: React.FC<SongDetailsPageProps> = ({
   organizationId,
   userMembership,
 }) => {
-  const { data: song, isLoading: isSongLoading } = trpc.song.get.useQuery({
+  const { data: song, isLoading: isSongLoading, error: songQueryError } = trpc.song.get.useQuery({
     songId,
     organizationId,
   });
@@ -51,8 +49,9 @@ export const SongDetailsPage: React.FC<SongDetailsPageProps> = ({
     return <SongDetailsPageLoading />;
   }
 
-  if (!song) {
-    return notFound();
+  if (songQueryError ?? !song) {
+    // TODO: add error handling for song not found
+    return;
   }
 
   const dateFormatter = new Intl.DateTimeFormat("en-US");

--- a/src/modules/songs/components/SongDetailsPage/SongDetailsPageHeader/SongDetailsPageHeader.tsx
+++ b/src/modules/songs/components/SongDetailsPage/SongDetailsPageHeader/SongDetailsPageHeader.tsx
@@ -11,9 +11,9 @@ import { HStack } from "@components/HStack";
 import { SongDetailsPageName } from "@modules/songs/components";
 import { SongActionsMenu } from "@modules/songs/components/SongActionsMenu";
 import { AddSongToSetDialog } from "@modules/songs/forms/AddSongToSet/components/AddSongToSetDialog";
+import { trpc } from "@lib/trpc";
 import { type UserData } from "@lib/types/api";
 import { type AppRouter } from "@server/api/root";
-import { api } from "@/trpc/react";
 
 export type SongDetailsPageHeaderProps = {
   song: inferProcedureOutput<AppRouter["song"]["get"]>;
@@ -29,7 +29,7 @@ export const SongDetailsPageHeader: React.FC<SongDetailsPageHeaderProps> = ({
   const router = useRouter();
 
   const updateSongFavoriteStatusMutation =
-    api.song.updateFavoriteStatus.useMutation();
+    trpc.song.updateFavoriteStatus.useMutation();
 
   const updateSongFavoriteStatus = () => {
     const toastId = toast.loading(

--- a/src/modules/songs/components/SongDetailsPage/SongDetailsPageLoading/SongDetailsPageLoading.tsx
+++ b/src/modules/songs/components/SongDetailsPage/SongDetailsPageLoading/SongDetailsPageLoading.tsx
@@ -12,13 +12,13 @@ export const SongDetailsPageLoading: React.FC = () => (
     <HStack className="gap-4">
       <Skeleton className="h-10 w-full" />
       <HStack className="items-start gap-2">
-        <Button>
+        <Button disabled>
           <Plus /> Add to a set
         </Button>
         <Button variant="outline" disabled size="sm">
           <Heart />
         </Button>
-        <Button variant={"outline"} size="sm">
+        <Button variant={"outline"} size="sm" disabled>
           <DotsThree className="text-slate-900" size={16} />
         </Button>
       </HStack>

--- a/src/modules/songs/components/SongDetailsPage/SongDetailsPageLoading/SongDetailsPageLoading.tsx
+++ b/src/modules/songs/components/SongDetailsPage/SongDetailsPageLoading/SongDetailsPageLoading.tsx
@@ -1,13 +1,28 @@
+import { DotsThree, Heart, Plus } from "@phosphor-icons/react/dist/ssr";
+
+import { Button } from "@components/ui/button";
+import { Skeleton } from "@components/ui/skeleton";
 import { Card } from "@components/Card/Card";
 import { HStack } from "@components/HStack";
-import { PageContentContainer } from "@components/PageContentContainer";
-import { Skeleton } from "@components/ui/skeleton";
 import { VStack } from "@components/VStack";
 import { SongDetailsItem } from "@modules/songs/components";
 
 export const SongDetailsPageLoading: React.FC = () => (
-  <PageContentContainer>
-    <Skeleton className="h-8 w-full" />
+  <>
+    <HStack className="gap-4">
+      <Skeleton className="h-10 w-full" />
+      <HStack className="items-start gap-2">
+        <Button>
+          <Plus /> Add to a set
+        </Button>
+        <Button variant="outline" disabled size="sm">
+          <Heart />
+        </Button>
+        <Button variant={"outline"} size="sm">
+          <DotsThree className="text-slate-900" size={16} />
+        </Button>
+      </HStack>
+    </HStack>
     <Card title="Song details" collapsible>
       <VStack as="dl" className="gap-4 md:gap-6">
         <SongDetailsItem icon="MusicNoteSimple" label="Preferred Key">
@@ -37,17 +52,21 @@ export const SongDetailsPageLoading: React.FC = () => (
         </SongDetailsItem>
       </VStack>
     </Card>
-    <HStack as="section" className="justify-between gap-2">
-      <Skeleton className="w-full" />
-      <Skeleton className="size-6" />
-      <Skeleton className="size-6" />
-    </HStack>
-    <Card title="Resources" collapsible>
-      <div className="grid grid-cols-[repeat(auto-fill,_124px)] grid-rows-[repeat(auto-fill,_92px)] gap-2">
-        <Skeleton className="h-full w-full" />
-        <Skeleton className="h-full w-full" />
-        <Skeleton className="h-full w-full" />
-      </div>
+    <Card
+      title="Resources"
+      collapsible
+      button={
+        <Button size="sm" variant="ghost" disabled>
+          <Plus className="text-slate-900" size={16} />
+          <span className="hidden sm:inline">Add resource</span>
+        </Button>
+      }
+    >
+      <ul className="grid gap-3 md:grid-cols-2">
+        <Skeleton className="h-16" />
+        <Skeleton className="h-16" />
+        <Skeleton className="h-16" />
+      </ul>
     </Card>
     <Card title="Play history" collapsible>
       <div className="grid grid-cols-[16px_1fr] gap-y-4">
@@ -78,5 +97,5 @@ export const SongDetailsPageLoading: React.FC = () => (
         </VStack>
       </div>
     </Card>
-  </PageContentContainer>
+  </>
 );

--- a/src/modules/songs/components/SongDetailsPage/SongDetailsPageLoading/SongDetailsPageLoading.tsx
+++ b/src/modules/songs/components/SongDetailsPage/SongDetailsPageLoading/SongDetailsPageLoading.tsx
@@ -63,9 +63,15 @@ export const SongDetailsPageLoading: React.FC = () => (
       }
     >
       <ul className="grid gap-3 md:grid-cols-2">
-        <Skeleton className="h-16" />
-        <Skeleton className="h-16" />
-        <Skeleton className="h-16" />
+        <li>
+          <Skeleton className="h-16" />
+        </li>
+        <li>
+          <Skeleton className="h-16" />
+        </li>
+        <li>
+          <Skeleton className="h-16" />
+        </li>
       </ul>
     </Card>
     <Card title="Play history" collapsible>

--- a/src/modules/songs/components/SongDetailsPage/SongDetailsPageSongName/SongDetailsPageSongName.tsx
+++ b/src/modules/songs/components/SongDetailsPage/SongDetailsPageSongName/SongDetailsPageSongName.tsx
@@ -1,27 +1,27 @@
 "use client";
 
-import { api } from "@/trpc/react";
-import { HStack } from "@components/HStack";
-import { PageTitle } from "@components/PageTitle";
-import { Badge as ShadCNBadge } from "@components/ui/badge";
-import { Button } from "@components/ui/button";
-import { Textarea } from "@components/ui/textarea";
-import { VStack } from "@components/VStack";
-import { songNameSchema } from "@lib/types/zod";
-import { cn } from "@lib/utils";
-import { type SongDetailsPageHeaderProps } from "@modules/songs/components/";
-import { Archive } from "@phosphor-icons/react";
-import { useRouter } from "next/navigation";
 import React, {
   type Dispatch,
   type SetStateAction,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
 } from "react";
+import { useRouter } from "next/navigation";
+import { Archive } from "@phosphor-icons/react";
 import { toast } from "sonner";
+
+import { Badge as ShadCNBadge } from "@components/ui/badge";
+import { Button } from "@components/ui/button";
+import { Textarea } from "@components/ui/textarea";
+import { HStack } from "@components/HStack";
+import { PageTitle } from "@components/PageTitle";
 import { Text } from "@components/Text";
+import { VStack } from "@components/VStack";
+import { type SongDetailsPageHeaderProps } from "@modules/songs/components/";
+import { trpc } from "@lib/trpc";
+import { songNameSchema } from "@lib/types/zod";
+import { cn } from "@lib/utils";
 
 type SongDetailsPageNameProps = {
   song: SongDetailsPageHeaderProps["song"];
@@ -42,8 +42,8 @@ export const SongDetailsPageName: React.FC<SongDetailsPageNameProps> = ({
 
   const router = useRouter();
 
-  const updateSongNameMutation = api.song.updateName.useMutation();
-  const apiUtils = api.useUtils();
+  const updateSongNameMutation = trpc.song.updateName.useMutation();
+  const apiUtils = trpc.useUtils();
 
   useEffect(() => {
     setSongName(song.name);

--- a/src/modules/songs/components/SongKeySelect/SongKeySelect.tsx
+++ b/src/modules/songs/components/SongKeySelect/SongKeySelect.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { api } from "@/trpc/react";
-import { SongKey } from "@components/SongKey";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
 import { Button } from "@components/ui/button";
 import {
   Select,
@@ -9,13 +11,12 @@ import {
   SelectItem,
   SelectTrigger,
 } from "@components/ui/select";
+import { SongKey } from "@components/SongKey";
 import { type SongKey as SongKeyType, songKeys } from "@lib/constants";
 import { formatSongKey } from "@lib/string/formatSongKey";
+import { trpc } from "@lib/trpc";
 import { type Song } from "@lib/types";
 import { type UserData } from "@lib/types/api";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { toast } from "sonner";
 
 type SongKeySelectProps = {
   songId: string;
@@ -29,7 +30,7 @@ export const SongKeySelect: React.FC<SongKeySelectProps> = ({
   userMembership,
 }) => {
   const updateSongPreferredKeyMutation =
-    api.song.updatePreferredKey.useMutation();
+    trpc.song.updatePreferredKey.useMutation();
   const router = useRouter();
   const [songKey, setSongKey] = useState<Song["preferredKey"]>(
     preferredKey ?? null,

--- a/src/modules/songs/components/SongNotes/SongNotes.tsx
+++ b/src/modules/songs/components/SongNotes/SongNotes.tsx
@@ -7,18 +7,14 @@ import unescapeHTML from "validator/es/lib/unescape";
 import { Button } from "@components/ui/button";
 import { Skeleton } from "@components/ui/skeleton";
 import { Textarea } from "@components/ui/textarea";
-
 import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
-
 import { SongDetailsItem } from "@modules/songs/components";
-
 import { formatNumber } from "@lib/numbers/formatNumber";
+import { trpc } from "@lib/trpc";
 import { MAX_SONG_NOTES_LENGTH } from "@lib/types/zod";
 import { cn } from "@lib/utils";
-
-import { api } from "@/trpc/react";
 
 type SongNotesProps = {
   songId: string;
@@ -33,13 +29,13 @@ export const SongNotes: React.FC<SongNotesProps> = ({
     data: song,
     isLoading: isSongQueryLoading,
     error: songQueryError,
-  } = api.song.get.useQuery({ songId, organizationId });
+  } = trpc.song.get.useQuery({ songId, organizationId });
 
   const [isEditingNotes, setIsEditingNotes] = useState<boolean>(false);
   const [notes, setNotes] = useState<string>(song?.notes ?? "");
 
-  const updateNotesMutation = api.song.updateNotes.useMutation();
-  const apiUtils = api.useUtils();
+  const updateNotesMutation = trpc.song.updateNotes.useMutation();
+  const apiUtils = trpc.useUtils();
 
   const handleUpdateNotes = () => {
     const toastId = toast.loading("Updating song notes...");

--- a/src/modules/songs/components/SongResources/SongResources.tsx
+++ b/src/modules/songs/components/SongResources/SongResources.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Plus } from "@phosphor-icons/react";
 
 import { Button } from "@components/ui/button";
+import { Skeleton } from "@components/ui/skeleton";
 import { Card } from "@components/Card/Card";
 import {
   ResponsiveDialog,
@@ -12,24 +13,47 @@ import {
   ResponsiveDialogTrigger,
 } from "@components/ResponsiveDialog";
 import { CreateResourceForm } from "@modules/songs/forms/CreateResourceForm";
-import { type Resource } from "@lib/types";
+import { useSongResources } from "@modules/songs/queries/useSongResources";
 
 import { ResourceCard } from "../ResourceCard";
 
 type SongResourcesProps = {
   songId: string;
-  songResources: Resource[];
 };
 
-export const SongResources: React.FC<SongResourcesProps> = ({
-  songId,
-  songResources,
-}) => {
+export const SongResources: React.FC<SongResourcesProps> = ({ songId }) => {
   const [isAddResourceDialogOpen, setIsAddResourceDialogOpen] = useState(false);
+
+  const {
+    data: songResources,
+    isLoading: isSongResourcesLoading,
+    error: songResourcesError,
+  } = useSongResources(songId);
 
   const onSuccess = () => {
     setIsAddResourceDialogOpen(false);
   };
+
+  if (isSongResourcesLoading) {
+    return (
+      <Card
+        title="Resources"
+        collapsible
+        button={
+          <Button size="sm" variant="ghost" disabled>
+            <Plus className="text-slate-900" size={16} />
+            <span className="hidden sm:inline">Add resource</span>
+          </Button>
+        }
+      >
+        <ul className="grid gap-3 md:grid-cols-2">
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+        </ul>
+      </Card>
+    );
+  }
 
   return (
     <ResponsiveDialog
@@ -49,11 +73,12 @@ export const SongResources: React.FC<SongResourcesProps> = ({
         }
       >
         <ul className="grid gap-3 md:grid-cols-2">
-          {songResources.length > 0 &&
+          {songResources &&
+            songResources.length > 0 &&
             songResources.map((songResource) => (
               <ResourceCard key={songResource.id} resource={songResource} />
             ))}
-          {songResources.length === 0 && (
+          {!songResources && (
             // Empty state will be implemented in SWY-118
             <div>No song resources yet. Create one?</div>
           )}

--- a/src/modules/songs/components/SongResources/SongResources.tsx
+++ b/src/modules/songs/components/SongResources/SongResources.tsx
@@ -27,6 +27,7 @@ export const SongResources: React.FC<SongResourcesProps> = ({ songId }) => {
   const {
     data: songResources,
     isLoading: isSongResourcesLoading,
+    // TODO: SWY-118 to implement empty and error state
     error: songResourcesError,
   } = useSongResources(songId);
 

--- a/src/modules/songs/components/SongResources/SongResources.tsx
+++ b/src/modules/songs/components/SongResources/SongResources.tsx
@@ -48,9 +48,15 @@ export const SongResources: React.FC<SongResourcesProps> = ({ songId }) => {
         }
       >
         <ul className="grid gap-3 md:grid-cols-2">
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
+          <li>
+            <Skeleton className="h-16" />
+          </li>
+          <li>
+            <Skeleton className="h-16" />
+          </li>
+          <li>
+            <Skeleton className="h-16" />
+          </li>
         </ul>
       </Card>
     );

--- a/src/modules/songs/components/SongResources/SongResources.tsx
+++ b/src/modules/songs/components/SongResources/SongResources.tsx
@@ -78,7 +78,7 @@ export const SongResources: React.FC<SongResourcesProps> = ({ songId }) => {
             songResources.map((songResource) => (
               <ResourceCard key={songResource.id} resource={songResource} />
             ))}
-          {!songResources && (
+          {songResources && songResources.length === 0 && (
             // Empty state will be implemented in SWY-118
             <div>No song resources yet. Create one?</div>
           )}

--- a/src/modules/songs/components/SongSearch/SongSearch.tsx
+++ b/src/modules/songs/components/SongSearch/SongSearch.tsx
@@ -1,5 +1,20 @@
 "use client";
 
+import { useState } from "react";
+import { redirect } from "next/navigation";
+import { useAuth } from "@clerk/nextjs";
+import { CaretRight } from "@phosphor-icons/react/dist/ssr";
+import { CommandLoading } from "cmdk";
+import { useDebounceValue } from "usehooks-ts";
+
+import { Text } from "@components/Text";
+import {
+  SongListItem,
+  type SongListItemProps,
+} from "@modules/songs/components/SongListItem";
+import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
+import { type Song, type Tag } from "@lib/types";
 import {
   CommandEmpty,
   CommandGroup,
@@ -7,20 +22,6 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { api } from "@/trpc/react";
-import { useAuth } from "@clerk/nextjs";
-import { Text } from "@components/Text";
-import { useUserQuery } from "@modules/users/api/queries";
-import { CommandLoading } from "cmdk";
-import { redirect } from "next/navigation";
-import { useState } from "react";
-import { useDebounceValue } from "usehooks-ts";
-import {
-  SongListItem,
-  type SongListItemProps,
-} from "@modules/songs/components/SongListItem";
-import { CaretRight } from "@phosphor-icons/react/dist/ssr";
-import { type Tag, type Song } from "@lib/types";
 
 export type SongSearchResult =
   | (Pick<Song, "name" | "preferredKey" | "isArchived"> & {
@@ -61,7 +62,7 @@ export const SongSearch: React.FC<SongSearchProps> = ({
     data: songSearchData,
     error: songSearchError,
     isLoading: songSearchLoading,
-  } = api.song.search.useQuery(
+  } = trpc.song.search.useQuery(
     {
       organizationId: userMembership!.organizationId, // we use a type assertion here since if this isn't true, the query will be disabled
       searchInput: debouncedSearchQuery,

--- a/src/modules/songs/components/SongTagSelector/SongTagSelector.tsx
+++ b/src/modules/songs/components/SongTagSelector/SongTagSelector.tsx
@@ -1,7 +1,15 @@
-import { useResponsive } from "@/hooks/useResponsive";
-import { api, type RouterOutputs } from "@/trpc/react";
-import { HStack } from "@components/HStack";
-import { KeyboardShortcut } from "@components/KeyboardShortcut";
+import { type KeyboardEventHandler, useEffect, useRef, useState } from "react";
+import {
+  ArrowDown,
+  ArrowUp,
+  Check,
+  KeyReturn,
+  MagnifyingGlass,
+  Plus,
+  X,
+} from "@phosphor-icons/react";
+import { toast } from "sonner";
+
 import { Button } from "@components/ui/button";
 import {
   Dialog,
@@ -17,20 +25,13 @@ import {
 } from "@components/ui/popover";
 import { ScrollArea } from "@components/ui/scroll-area";
 import { Skeleton } from "@components/ui/skeleton";
+import { HStack } from "@components/HStack";
+import { KeyboardShortcut } from "@components/KeyboardShortcut";
 import { VStack } from "@components/VStack";
+import { type RouterOutputs, trpc } from "@lib/trpc";
 import { tagNameSchema } from "@lib/types/zod";
 import { cn } from "@lib/utils";
-import {
-  ArrowDown,
-  ArrowUp,
-  Check,
-  KeyReturn,
-  MagnifyingGlass,
-  Plus,
-  X,
-} from "@phosphor-icons/react";
-import { type KeyboardEventHandler, useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
+import { useResponsive } from "@/hooks/useResponsive";
 
 /**
  * Type for organization tag returned from the API
@@ -60,8 +61,8 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
 
   const { isDesktop } = useResponsive();
 
-  const createSongTagMutation = api.songTag.create.useMutation();
-  const createTagMutation = api.tag.create.useMutation({
+  const createSongTagMutation = trpc.songTag.create.useMutation();
+  const createTagMutation = trpc.tag.create.useMutation({
     onSuccess: (newTag) => {
       createSongTagMutation.mutate({
         songId,
@@ -70,14 +71,14 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
       });
     },
   });
-  const deleteSongTagMutation = api.songTag.delete.useMutation();
-  const apiUtils = api.useUtils();
+  const deleteSongTagMutation = trpc.songTag.delete.useMutation();
+  const apiUtils = trpc.useUtils();
 
   const {
     data: organizationTags,
     isLoading: isOrganizationTagsQueryLoading,
     error: organizationTagsQueryError,
-  } = api.tag.getByOrganization.useQuery({
+  } = trpc.tag.getByOrganization.useQuery({
     organizationId,
   });
 
@@ -85,7 +86,7 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
     data: songTags,
     isLoading: isSongTagsQueryLoading,
     error: songTagsQueryError,
-  } = api.songTag.getBySongId.useQuery({
+  } = trpc.songTag.getBySongId.useQuery({
     songId,
     organizationId,
   });

--- a/src/modules/songs/components/SongTags/SongTags.tsx
+++ b/src/modules/songs/components/SongTags/SongTags.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 import { Badge } from "@components/ui/badge";
 import { Skeleton } from "@components/ui/skeleton";
 import { HStack } from "@components/HStack";
-import { api, type RouterOutputs } from "@/trpc/react";
+import { type RouterOutputs, trpc } from "@lib/trpc";
 
 import { SongTagSelector } from "../SongTagSelector/SongTagSelector";
 
@@ -28,14 +28,14 @@ export const SongTags: React.FC<SongTagsProps> = ({
     string | null
   >(null);
 
-  const deleteSongTagMutation = api.songTag.delete.useMutation();
-  const apiUtils = api.useUtils();
+  const deleteSongTagMutation = trpc.songTag.delete.useMutation();
+  const apiUtils = trpc.useUtils();
 
   const {
     data: songTags,
     isLoading: isSongTagsQueryLoading,
     error: songTagsQueryError,
-  } = api.songTag.getBySongId.useQuery({
+  } = trpc.songTag.getBySongId.useQuery({
     songId,
     organizationId,
   });

--- a/src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx
@@ -13,8 +13,8 @@ import { SongContent } from "@modules/SetListCard/components/SongContent";
 import { SelectedSetCard } from "@modules/songs/forms/AddSongToSet/components";
 import { useUserQuery } from "@modules/users/api/queries";
 import { type SongKey as SongKeyType } from "@lib/constants";
+import { trpc } from "@lib/trpc";
 import { type AppRouter } from "@server/api/root";
-import { api } from "@/trpc/react";
 
 type ReviewStepProps = {
   selectedSetId: string;
@@ -41,16 +41,16 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
     return null;
   }
 
-  const apiUtils = api.useUtils();
+  const apiUtils = trpc.useUtils();
   const addSetSectionSongAndReorderSongsMutation =
-    api.setSectionSong.addAndReorderSongs.useMutation();
+    trpc.setSectionSong.addAndReorderSongs.useMutation();
 
-  const { data: setData } = api.set.get.useQuery({
+  const { data: setData } = trpc.set.get.useQuery({
     setId: selectedSetId,
     organizationId: userMembership.organizationId,
   });
 
-  const { data: setSectionData } = api.setSection.get.useQuery({
+  const { data: setSectionData } = trpc.setSection.get.useQuery({
     setSectionId: selectedSetSection,
     organizationId: userMembership.organizationId,
   });

--- a/src/modules/songs/forms/AddSongToSet/components/SelectedSetCard/SelectedSetCard.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SelectedSetCard/SelectedSetCard.tsx
@@ -16,7 +16,7 @@ import {
   FRIENDLY_FORMAT_CALENDAR_WEEK_DIFFERENCE_THRESHOLD,
 } from "@lib/date";
 import { pluralize } from "@lib/string";
-import { type RouterOutputs } from "@/trpc/react";
+import { type RouterOutputs } from "@lib/trpc";
 
 type SelectedSetCardProps = {
   set: RouterOutputs["set"]["get"];

--- a/src/modules/songs/forms/AddSongToSet/components/SetSectionSelectionStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSectionSelectionStep.tsx
@@ -13,9 +13,9 @@ import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeC
 import { SelectedSetCard } from "@modules/songs/forms/AddSongToSet/components";
 import { type SelectedSet } from "@modules/songs/forms/AddSongToSet/components/AddSongToSetDialog";
 import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
 import { cn } from "@lib/utils";
 import { useResponsive } from "@/hooks/useResponsive";
-import { api } from "@/trpc/react";
 
 type SetSectionSelectionStepProps = {
   selectedSet: SelectedSet | null;
@@ -35,10 +35,10 @@ export const SetSectionSelectionStep: React.FC<
   const { textSize, isDesktop } = useResponsive();
   const { userMembership } = useUserQuery();
 
-  const createSetSectionMutation = api.setSection.create.useMutation();
-  const apiUtils = api.useUtils();
+  const createSetSectionMutation = trpc.setSection.create.useMutation();
+  const apiUtils = trpc.useUtils();
 
-  const { data: setData } = api.set.get.useQuery(
+  const { data: setData } = trpc.set.get.useQuery(
     {
       setId: selectedSet!.id,
       organizationId: userMembership!.organizationId,

--- a/src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx
@@ -20,7 +20,7 @@ import {
   FRIENDLY_FORMAT_CALENDAR_WEEK_DIFFERENCE_THRESHOLD,
 } from "@lib/date";
 import { pluralize } from "@lib/string";
-import { api } from "@/trpc/react";
+import { trpc } from "@lib/trpc";
 
 import {
   type SetSelectionEventTypeFilters,
@@ -63,7 +63,7 @@ export const SetSelectionAllUpcomingSets: React.FC<
     isFetchingNextPage,
     isLoading,
     error: getInfiniteSetsQueryError,
-  } = api.set.getInfinite.useInfiniteQuery(
+  } = trpc.set.getInfinite.useInfiniteQuery(
     {
       organizationId: userMembership.organizationId,
       dateRange: dateFilter?.from

--- a/src/modules/songs/forms/AddSongToSet/components/SetSelectionFilters.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSelectionFilters.tsx
@@ -20,8 +20,8 @@ import { VStack } from "@components/VStack";
 import { EventTypeSelect } from "@modules/eventTypes/components";
 import { type SetSelectionEventTypeFilters } from "@modules/songs/forms/AddSongToSet/components/SetSelectionStep";
 import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
 import { useResponsive } from "@/hooks/useResponsive";
-import { api } from "@/trpc/react";
 
 type SetSelectionFiltersProps = {
   eventTypeFilters: SetSelectionEventTypeFilters;
@@ -54,7 +54,7 @@ export const SetSelectionFilters: React.FC<SetSelectionFiltersProps> = ({
     data: eventTypeData,
     isError: eventTypeQueryError,
     isLoading: eventTypeQueryLoading,
-  } = api.eventType.getEventTypes.useQuery(
+  } = trpc.eventType.getEventTypes.useQuery(
     userMembership
       ? { organizationId: userMembership.organizationId }
       : skipToken,

--- a/src/modules/songs/forms/AddSongToSet/components/SetSelectionUpcomingSets.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSelectionUpcomingSets.tsx
@@ -18,7 +18,7 @@ import {
   FRIENDLY_FORMAT_CALENDAR_WEEK_DIFFERENCE_THRESHOLD,
 } from "@lib/date";
 import { pluralize } from "@lib/string";
-import { api } from "@/trpc/react";
+import { trpc } from "@lib/trpc";
 
 type SetSelectionAllUpcomingSetsProps = {
   onSetSelect: SetSelectionStepProps["onSetSelect"];
@@ -42,7 +42,7 @@ export const SetSelectionUpcomingSets: React.FC<
     data: upcomingSetsData,
     isLoading: isUpcomingSetsQueryLoading,
     error: upcomingSetsQueryError,
-  } = api.set.getUpcoming.useQuery(
+  } = trpc.set.getUpcoming.useQuery(
     {
       organizationId: userMembership?.organizationId ?? "",
     },

--- a/src/modules/songs/forms/AddSongToSet/components/SetSongKeyStep/SetSongKeyStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSongKeyStep/SetSongKeyStep.tsx
@@ -9,9 +9,9 @@ import { VStack } from "@components/VStack";
 import { useUserQuery } from "@modules/users/api/queries";
 import { type SongKey, songKeys } from "@lib/constants";
 import { formatSongKey } from "@lib/string/formatSongKey";
+import { trpc } from "@lib/trpc";
 import { cn } from "@lib/utils";
 import { useResponsive } from "@/hooks/useResponsive";
-import { api } from "@/trpc/react";
 
 type SetSongKeyStepProps = {
   songId: string;
@@ -34,7 +34,7 @@ export const SetSongKeyStep: React.FC<SetSongKeyStepProps> = ({
   } = useUserQuery();
 
   const { data: lastPlayInstance, isLoading: isLastPlayInstanceQueryLoading } =
-    api.song.getLastPlayInstance.useQuery(
+    trpc.song.getLastPlayInstance.useQuery(
       {
         organizationId: userMembership?.organizationId ?? "",
         songId,

--- a/src/modules/songs/forms/AddSongToSet/components/SetSongPositionStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSongPositionStep.tsx
@@ -11,8 +11,8 @@ import { type DraggableSongItem } from "@modules/shared/components/DraggableSong
 import { DraggableSongList } from "@modules/shared/components/DraggableSongList/DraggableSongList";
 import { useUserQuery } from "@modules/users/api/queries";
 import { clamp } from "@lib/numbers";
+import { trpc } from "@lib/trpc";
 import { type AppRouter } from "@server/api/root";
-import { api } from "@/trpc/react";
 
 export type DraggableSongListItem = Omit<DraggableSongItem, "songKey"> &
   Partial<Pick<DraggableSongItem, "songKey">> & {
@@ -39,7 +39,7 @@ export const SetSongPositionStep: React.FC<SetSongPositionStepProps> = ({
 
   const { userMembership } = useUserQuery();
 
-  const { data: setSectionData } = api.setSection.get.useQuery(
+  const { data: setSectionData } = trpc.setSection.get.useQuery(
     {
       setSectionId: selectedSetSection!,
       organizationId: userMembership?.organizationId ?? "",

--- a/src/modules/songs/forms/CreateResourceForm/CreateResourceForm.tsx
+++ b/src/modules/songs/forms/CreateResourceForm/CreateResourceForm.tsx
@@ -18,8 +18,8 @@ import {
 import { Input } from "@components/ui/input";
 import { VStack } from "@components/VStack";
 import { orpc } from "@lib/orpc/client";
+import { trpc } from "@lib/trpc";
 import { insertResourceSchema } from "@lib/types/zod";
-import { api as trpcApi } from "@/trpc/react";
 
 const createResourceFormSchema = insertResourceSchema.pick({
   title: true,
@@ -54,7 +54,7 @@ export const CreateResourceForm: React.FC<CreateResourceFormProps> = ({
   });
 
   // TODO: handle if there is no user data (assume this will be handled before it reaches here though?)
-  const { data: userData } = trpcApi.user.getUser.useQuery(
+  const { data: userData } = trpc.user.getUser.useQuery(
     {
       userId: userId!, // using non-null assertion since this query is only enabled if userId is not null
     },

--- a/src/modules/songs/queries/useSongResources.ts
+++ b/src/modules/songs/queries/useSongResources.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { skipToken, useQuery } from "@tanstack/react-query";
+import { validate as uuidValidate } from 'uuid';
 
 import { useUserQuery } from "@modules/users/api/queries";
 import { orpc } from "@lib/orpc/client";
@@ -10,13 +11,12 @@ export const useSongResources = (songId: string) => {
 
   return useQuery(
     orpc.resource.getBySongId.queryOptions({
-      input: userMembership
+      input: userMembership && uuidValidate(songId)
         ? {
             songId,
             organizationId: userMembership.organizationId,
           }
         : skipToken,
-      enabled: !!userMembership,
     }),
   );
 };

--- a/src/modules/songs/queries/useSongResources.ts
+++ b/src/modules/songs/queries/useSongResources.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { skipToken, useQuery } from "@tanstack/react-query";
+
+import { useUserQuery } from "@modules/users/api/queries";
+import { orpc } from "@lib/orpc/client";
+
+export const useSongResources = (songId: string) => {
+  const { userMembership } = useUserQuery();
+
+  return useQuery(
+    orpc.resource.getBySongId.queryOptions({
+      input: userMembership
+        ? {
+            songId,
+            organizationId: userMembership.organizationId,
+          }
+        : skipToken,
+      enabled: !!userMembership,
+    }),
+  );
+};

--- a/src/modules/users/api/queries.ts
+++ b/src/modules/users/api/queries.ts
@@ -1,14 +1,14 @@
 import { useAuth } from "@clerk/nextjs";
 import { validate as uuidValidate } from "uuid";
 
-import { api } from "@/trpc/react";
+import { trpc } from "@lib/trpc";
 
 export const useUserQuery = () => {
   const { userId, isLoaded: isAuthLoaded } = useAuth();
 
   const isQueryEnabled = isAuthLoaded && !!userId && uuidValidate(userId);
 
-  const user = api.user.getUser.useQuery(
+  const user = trpc.user.getUser.useQuery(
     {
       userId: userId ?? "", // providing empty string fallback as the query will not be enabled if the userId is null
     },

--- a/src/server/queries.ts
+++ b/src/server/queries.ts
@@ -1,7 +1,8 @@
-import { api } from "@/trpc/server";
-import { TRPCError } from "@trpc/server";
 import { redirect } from "next/navigation";
+import { TRPCError } from "@trpc/server";
 import { validate as uuidValidate } from "uuid";
+
+import { trpc } from "@lib/trpc/server";
 
 export async function getOrganization(organizationId: string) {
   if (!uuidValidate(organizationId)) {
@@ -12,7 +13,7 @@ export async function getOrganization(organizationId: string) {
   }
 
   try {
-    const organization = await api.organization.organization({
+    const organization = await trpc.organization.organization({
       organizationId,
     });
     return organization;


### PR DESCRIPTION
## Background
This PR is to update the song details page to optimize the rendering method and appropriately split up what is SSR versus client-rendered.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Song Details page with richer layout, detailed play history, and improved loading skeletons.
  * New centralized Providers wrapper for app-wide state, data, and UI contexts.

* **Improvements**
  * More consistent prefetch/hydration for faster, more reliable page loads and redirects.
  * Resources and notes show clearer loading and empty states, improving UX during data fetches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




## How to test
- Go to a song's detail page and confirm you can see the skeleton while the page is loading the required data
- Navigate around the app and ensure that all the data fetching happens as expected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR successfully refactors the song details page to use a hybrid SSR/client rendering approach with proper data prefetching. The main architectural improvement is the introduction of centralized provider setup and consistent use of TanStack Query for both TRPC and ORPC calls across server and client boundaries.

**Key improvements:**
- Created `src/app/providers.tsx` to consolidate all app-wide context providers (QueryClient, TRPC, ORPC, UI contexts) with proper client-side caching
- Split `src/app/[organization]/songs/[songId]/page.tsx` into SSR page (for prefetching) and `SongDetailsPage` client component (for rendering)
- Implemented proper data prefetching for song data, play history, and resources in the RSC layer
- Fixed organizationId lookup to use slug-based membership matching instead of assuming first membership
- Refactored `SongResources` to use client-side query hook with proper loading states
- Created new infrastructure files for server-side TanStack Query utilities (`orpc/tanstack-server.ts`, `orpc/get-server-query-client.ts`)
- Standardized TRPC usage across the app with new `lib/trpc/client.tsx` and `lib/trpc/server.tsx` files

**Previous issues addressed:**
- Empty state logic in `SongResources` was fixed (commit eb72187)
- Organization membership lookup corrected to use UUID instead of slug

The refactor follows Next.js App Router best practices for data fetching patterns and provides better UX with loading skeletons during client-side hydration.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no critical issues found
- The refactoring follows established Next.js App Router patterns correctly, with proper separation between server and client components. All previously identified issues have been addressed in follow-up commits. The code is well-structured, maintains type safety, and the architectural changes are consistent across all affected files.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/providers.tsx | New centralized providers wrapper consolidating QueryClient, TRPC, ORPC, and UI contexts with proper client-side query client caching |
| src/app/[organization]/songs/[songId]/page.tsx | Refactored to SSR with prefetching, moved rendering logic to client component, fixed organizationId lookup via slug matching |
| src/modules/songs/components/SongDetailsPage/SongDetailsPage.tsx | New client component for song details with proper loading states and client-side data hydration |
| src/lib/trpc/server.tsx | New server-side TRPC setup with hydration helpers for RSC prefetching pattern |
| src/lib/trpc/client.tsx | New client-side TRPC provider accepting external QueryClient for shared state |
| src/lib/orpc/tanstack-server.ts | New server-side ORPC TanStack Query utilities for prefetching in RSC |
| src/lib/tanstack/query-client.ts | Centralized QueryClient factory with pending query dehydration for SSR |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant RSC as Song Page RSC
    participant Auth as Clerk Auth
    participant TRPC as TRPC Server
    participant ORPC as ORPC Server
    participant DB as Database
    participant Client as SongDetailsPage Client

    Browser->>RSC: Navigate to /[org]/songs/[id]
    RSC->>Auth: auth()
    Auth-->>RSC: userId
    
    RSC->>TRPC: trpc.user.getUser.prefetch()
    TRPC->>DB: Query user & memberships
    DB-->>TRPC: User data
    TRPC-->>RSC: User with memberships
    
    Note over RSC: Find membership by org slug
    
    RSC->>TRPC: trpc.song.get.prefetch()
    TRPC->>DB: Query song data
    DB-->>TRPC: Song data
    TRPC-->>RSC: Prefetched
    
    RSC->>TRPC: trpc.song.getPlayHistory.prefetch()
    TRPC->>DB: Query play history
    DB-->>TRPC: Play history
    TRPC-->>RSC: Prefetched
    
    RSC->>ORPC: orpcServerTQ.resource.getBySongId.queryOptions()
    ORPC->>DB: Query resources
    DB-->>ORPC: Resources
    ORPC-->>RSC: Prefetched
    
    RSC->>Browser: HTML with HydrateClient wrapper
    Browser->>Client: Mount SongDetailsPage
    
    Note over Client: Data already in cache from SSR
    
    Client->>Client: trpc.song.get.useQuery() (from cache)
    Client->>Client: trpc.song.getPlayHistory.useQuery() (from cache)
    Client->>Client: Render with hydrated data
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - Best practices and guidelines for Next.js application development with TypeScript, TRPC, and related... ([source](https://app.greptile.com/review/custom-context?memory=0b1855e5-0e77-43cc-b186-e359b3162aeb))

<!-- /greptile_comment -->