### PR TITLE
[SWY-128] Document ESLint 10 compatibility audit

### DIFF
--- a/docs/maintenance/eslint-10-plugin-compatibility.md
+++ b/docs/maintenance/eslint-10-plugin-compatibility.md
@@ -35,13 +35,13 @@ The active ESLint config is `eslint.config.mjs`. It uses:
 | --- | --- | --- | --- | --- |
 | `eslint` | `9.39.1` | `10.4.1` | N/A | Target major for the future migration. Latest package lists `jiti` as a peer. |
 | `eslint-config-next` | `16.2.6` | `16.2.7` | Declares `eslint: >=9.0.0` | Top-level peer range allows ESLint 10, but its dependency chain still includes plugins that do not currently declare ESLint 10 support. |
-| `typescript-eslint` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 || ^9.0.0 || ^10.0.0` | Likely compatible after upgrading to `8.60.1`. |
-| `@typescript-eslint/eslint-plugin` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 || ^9.0.0 || ^10.0.0` | Keep aligned with `@typescript-eslint/parser` and `typescript-eslint`. |
-| `@typescript-eslint/parser` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 || ^9.0.0 || ^10.0.0` | Keep aligned with `@typescript-eslint/eslint-plugin` and `typescript-eslint`. |
-| `@tanstack/eslint-plugin-query` | `5.100.14` | `5.101.0` | Yes: `^8.57.0 || ^9.0.0 || ^10.0.0` | Latest release declares ESLint 10 support. |
+| `typescript-eslint` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 \|\| ^9.0.0 \|\| ^10.0.0` | Likely compatible after upgrading to `8.60.1`. |
+| `@typescript-eslint/eslint-plugin` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 \|\| ^9.0.0 \|\| ^10.0.0` | Keep aligned with `@typescript-eslint/parser` and `typescript-eslint`. |
+| `@typescript-eslint/parser` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 \|\| ^9.0.0 \|\| ^10.0.0` | Keep aligned with `@typescript-eslint/eslint-plugin` and `typescript-eslint`. |
+| `@tanstack/eslint-plugin-query` | `5.100.14` | `5.101.0` | Yes: `^8.57.0 \|\| ^9.0.0 \|\| ^10.0.0` | Latest release declares ESLint 10 support. |
 | `eslint-plugin-drizzle` | `0.2.3` | `0.2.3` | Likely: `>=8.0.0` | The broad range includes ESLint 10, but this should still be smoke-tested because the package has not had a newer release. |
-| `eslint-plugin-import` | `2.32.0` through `eslint-config-next` | `2.32.0` | No: `^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9` | Main blocker. Sanbi also registers this plugin directly in `eslint.config.mjs`, but it is supplied transitively by `eslint-config-next`. |
-| `eslint-plugin-react-hooks` | `7.1.1` through `eslint-config-next` | `7.1.1` | Yes: `^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0` | Compatible with ESLint 10 by declared peer range. |
+| `eslint-plugin-import` | `2.32.0` through `eslint-config-next` | `2.32.0` | No: `^2 \|\| ^3 \|\| ^4 \|\| ^5 \|\| ^6 \|\| ^7.2.0 \|\| ^8 \|\| ^9` | Main blocker. Sanbi also registers this plugin directly in `eslint.config.mjs`, but it is supplied transitively by `eslint-config-next`. |
+| `eslint-plugin-react-hooks` | `7.1.1` through `eslint-config-next` | `7.1.1` | Yes: `^3.0.0 \|\| ^4.0.0 \|\| ^5.0.0 \|\| ^6.0.0 \|\| ^7.0.0 \|\| ^8.0.0-0 \|\| ^9.0.0 \|\| ^10.0.0` | Compatible with ESLint 10 by declared peer range. |
 | `eslint-plugin-simple-import-sort` | `13.0.0` | `13.0.0` | Likely: `>=5.0.0` | Broad peer range includes ESLint 10. Smoke-test during migration. |
 | `@types/eslint` | `9.6.1` | `9.6.1` | N/A | Type package has no ESLint peer dependency. Re-check during migration for an ESLint 10 type package or built-in type changes. |
 
@@ -61,14 +61,14 @@ Recommended path:
 2. Track `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-jsx-a11y`, and `eslint-config-next` for peer updates that explicitly support ESLint 10.
 3. When those peers are ready, upgrade the lint stack together:
    - `eslint@10.4.1` or newer
-   - `eslint-config-next@16.2.7` or newer
+   - A future `eslint-config-next` version that resolves the transitive blockers; `16.2.7` is not sufficient for ESLint 10
    - `typescript-eslint@8.60.1` or newer
    - `@typescript-eslint/eslint-plugin@8.60.1` or newer
    - `@typescript-eslint/parser@8.60.1` or newer
    - `@tanstack/eslint-plugin-query@5.101.0` or newer
-   - `eslint-plugin-react-hooks@7.1.1` or newer
    - `eslint-plugin-simple-import-sort@13.0.0` or newer
    - `eslint-plugin-drizzle@0.2.3` or newer
+   - Transitive Next lint plugins such as `eslint-plugin-react-hooks`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y` through the compatible `eslint-config-next` release
 4. Run `pnpm lint` and address only migration-related lint or type fallout.
 
 If the ESLint 10 migration must proceed before `eslint-plugin-import` declares support, evaluate `eslint-plugin-import-x@4.16.2`, which currently declares `eslint: ^8.57.0 || ^9.0.0 || ^10.0.0`. This is not a drop-in decision for Sanbi because `eslint-config-next` still depends on `eslint-plugin-import`, so it would require validating how Next's config behaves with the replacement or waiting for Next to change its dependency chain.

--- a/docs/maintenance/eslint-10-plugin-compatibility.md
+++ b/docs/maintenance/eslint-10-plugin-compatibility.md
@@ -1,0 +1,90 @@
+# ESLint 10 Plugin Compatibility Audit
+
+Checked on: June 2, 2026
+
+## Summary
+
+Sanbi should keep ESLint pinned to the current ESLint 9 stack until the `eslint-config-next` plugin chain is ready for ESLint 10. The main package-level blocker in the lint configuration is `eslint-plugin-import@2.32.0`: it is still the latest release and its peer dependency range allows ESLint 2 through 9, but not ESLint 10.
+
+Most of the explicitly managed lint packages are already compatible with ESLint 10 or have latest releases that declare ESLint 10 support. The migration should be treated as a dependency-validation task, not only an `eslint` version bump, because `eslint-config-next` still depends on `eslint-plugin-import` and other transitive plugins.
+
+## Current Lint Stack
+
+The current Sanbi lint command is:
+
+```sh
+pnpm lint
+```
+
+`pnpm lint` runs:
+
+```sh
+eslint . && tsc --noEmit --project tsconfig.json
+```
+
+The active ESLint config is `eslint.config.mjs`. It uses:
+
+- `eslint-config-next/core-web-vitals`
+- `typescript-eslint` recommended type-checked and stylistic type-checked configs
+- `@tanstack/eslint-plugin-query` flat recommended config
+- Local plugin registrations for `@typescript-eslint`, `drizzle`, `import`, `react-hooks`, and `simple-import-sort`
+
+## Compatibility Table
+
+| Package | Current Sanbi version | Latest checked | ESLint 10 peer support | Notes |
+| --- | --- | --- | --- | --- |
+| `eslint` | `9.39.1` | `10.4.1` | N/A | Target major for the future migration. Latest package lists `jiti` as a peer. |
+| `eslint-config-next` | `16.2.6` | `16.2.7` | Declares `eslint: >=9.0.0` | Top-level peer range allows ESLint 10, but its dependency chain still includes plugins that do not currently declare ESLint 10 support. |
+| `typescript-eslint` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 || ^9.0.0 || ^10.0.0` | Likely compatible after upgrading to `8.60.1`. |
+| `@typescript-eslint/eslint-plugin` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 || ^9.0.0 || ^10.0.0` | Keep aligned with `@typescript-eslint/parser` and `typescript-eslint`. |
+| `@typescript-eslint/parser` | `8.59.4` | `8.60.1` | Yes: `^8.57.0 || ^9.0.0 || ^10.0.0` | Keep aligned with `@typescript-eslint/eslint-plugin` and `typescript-eslint`. |
+| `@tanstack/eslint-plugin-query` | `5.100.14` | `5.101.0` | Yes: `^8.57.0 || ^9.0.0 || ^10.0.0` | Latest release declares ESLint 10 support. |
+| `eslint-plugin-drizzle` | `0.2.3` | `0.2.3` | Likely: `>=8.0.0` | The broad range includes ESLint 10, but this should still be smoke-tested because the package has not had a newer release. |
+| `eslint-plugin-import` | `2.32.0` through `eslint-config-next` | `2.32.0` | No: `^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9` | Main blocker. Sanbi also registers this plugin directly in `eslint.config.mjs`, but it is supplied transitively by `eslint-config-next`. |
+| `eslint-plugin-react-hooks` | `7.1.1` through `eslint-config-next` | `7.1.1` | Yes: `^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0` | Compatible with ESLint 10 by declared peer range. |
+| `eslint-plugin-simple-import-sort` | `13.0.0` | `13.0.0` | Likely: `>=5.0.0` | Broad peer range includes ESLint 10. Smoke-test during migration. |
+| `@types/eslint` | `9.6.1` | `9.6.1` | N/A | Type package has no ESLint peer dependency. Re-check during migration for an ESLint 10 type package or built-in type changes. |
+
+## Additional `eslint-config-next` Risk
+
+`eslint-config-next@16.2.7` depends on `eslint-plugin-import@^2.32.0`, so switching Sanbi to ESLint 10 before `eslint-plugin-import` updates its peer range would leave a peer dependency conflict in the Next lint stack.
+
+The current Next plugin chain also includes `eslint-plugin-react@7.37.5` and `eslint-plugin-jsx-a11y@6.10.2`; their latest peer ranges also stop at ESLint 9. They are not registered directly in Sanbi's `eslint.config.mjs`, but they are part of the `eslint-config-next` dependency surface and should be rechecked when the migration starts.
+
+## Recommended Migration Posture
+
+Do not migrate Sanbi to ESLint 10 yet.
+
+Recommended path:
+
+1. Keep `eslint` on `9.x` for now.
+2. Track `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-jsx-a11y`, and `eslint-config-next` for peer updates that explicitly support ESLint 10.
+3. When those peers are ready, upgrade the lint stack together:
+   - `eslint@10.4.1` or newer
+   - `eslint-config-next@16.2.7` or newer
+   - `typescript-eslint@8.60.1` or newer
+   - `@typescript-eslint/eslint-plugin@8.60.1` or newer
+   - `@typescript-eslint/parser@8.60.1` or newer
+   - `@tanstack/eslint-plugin-query@5.101.0` or newer
+   - `eslint-plugin-react-hooks@7.1.1` or newer
+   - `eslint-plugin-simple-import-sort@13.0.0` or newer
+   - `eslint-plugin-drizzle@0.2.3` or newer
+4. Run `pnpm lint` and address only migration-related lint or type fallout.
+
+If the ESLint 10 migration must proceed before `eslint-plugin-import` declares support, evaluate `eslint-plugin-import-x@4.16.2`, which currently declares `eslint: ^8.57.0 || ^9.0.0 || ^10.0.0`. This is not a drop-in decision for Sanbi because `eslint-config-next` still depends on `eslint-plugin-import`, so it would require validating how Next's config behaves with the replacement or waiting for Next to change its dependency chain.
+
+## `eslint.config.mjs` Type Checking
+
+`eslint.config.mjs` currently starts with:
+
+```js
+// @ts-nocheck
+```
+
+Leave this unchanged for SWY-128. This ticket is a compatibility audit, not the actual ESLint 10 migration. Revisit the directive during the migration after the dependency versions are installed and the config's runtime and type behavior can be validated against ESLint 10.
+
+## Validation Notes
+
+- No package or lockfile changes are required for this audit.
+- No runtime tests are required because this is documentation-only.
+- The smallest useful validation for a future migration is `pnpm lint` after installing the candidate dependency set.


### PR DESCRIPTION
[SWY-128]
## What changed

Added `docs/maintenance/eslint-10-plugin-compatibility.md`, an audit of Sanbi's current lint stack and the package-level readiness for a future ESLint 10 migration.

## Compatibility findings

- Sanbi currently runs `pnpm lint`, which executes `eslint . && tsc --noEmit --project tsconfig.json`.
- The active config is `eslint.config.mjs`, using `eslint-config-next/core-web-vitals`, `typescript-eslint` type-checked configs, `@tanstack/eslint-plugin-query`, and local registrations for `@typescript-eslint`, `drizzle`, `import`, `react-hooks`, and `simple-import-sort`.
- The current stack is on `eslint@9.39.1`; the latest checked ESLint release is `10.4.1`.
- Most explicitly managed lint packages either already declare ESLint 10 peer support or have latest releases that do:
  - `typescript-eslint`, `@typescript-eslint/eslint-plugin`, and `@typescript-eslint/parser` latest checked: `8.60.1`, peer range includes ESLint 10.
  - `@tanstack/eslint-plugin-query` latest checked: `5.101.0`, peer range includes ESLint 10.
  - `eslint-plugin-react-hooks@7.1.1` declares ESLint 10 support.
  - `eslint-plugin-drizzle@0.2.3` and `eslint-plugin-simple-import-sort@13.0.0` use broad peer ranges that include ESLint 10, but should still be smoke-tested.
- The main blocker is `eslint-plugin-import@2.32.0`; it is still the latest checked release and its peer range stops at ESLint 9.
- `eslint-config-next@16.2.7` declares `eslint: >=9.0.0`, but its dependency chain still includes `eslint-plugin-import@^2.32.0`.
- The Next lint chain also includes `eslint-plugin-react@7.37.5` and `eslint-plugin-jsx-a11y@6.10.2`; their latest checked peer ranges also stop at ESLint 9.

## Recommendation

Do not migrate Sanbi to ESLint 10 yet. Keep `eslint` on `9.x` until `eslint-plugin-import`, `eslint-plugin-react`, `eslint-plugin-jsx-a11y`, and the `eslint-config-next` dependency chain explicitly support ESLint 10. When those peers are ready, upgrade the lint stack together and validate with `pnpm lint`.

If the migration must proceed earlier, evaluate `eslint-plugin-import-x@4.16.2`, which currently declares ESLint 10 support. That is not a drop-in decision for Sanbi because `eslint-config-next` still depends on `eslint-plugin-import`.

## Validation

- Documentation-only change; no package or lockfile changes.
- Cross-checked the documented package versions and peer ranges against `package.json`, `pnpm-lock.yaml`, `eslint.config.mjs`, and `npm view` registry output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added ESLint 10 compatibility audit documentation providing analysis of current configuration, peer dependency support across packages, identified upgrade blockers, recommended migration timeline and strategy, step-by-step upgrade sequence, and validation guidance for future implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new documentation file auditing ESLint 10 compatibility for Sanbi's current lint stack. It correctly identifies `eslint-plugin-import@2.32.0` as the primary blocker and recommends holding on ESLint 9.x until the `eslint-config-next` transitive dependency chain catches up.

- **Compatibility table**: covers all directly and transitively managed lint packages, documenting current versions, latest checked releases, and ESLint 10 peer ranges.
- **Migration checklist**: provides a step-by-step upgrade sequence gating the migration on the blockers resolving first, with a fallback path via `eslint-plugin-import-x` if an earlier migration is required.
- **Two minor checklist gaps**: `jiti` (an ESLint 10 peer dependency noted in the table) and `@types/eslint` (flagged for re-evaluation in the table) are not represented in the step-3 upgrade list, which could cause an engineer following the checklist to miss them.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no package, config, or lockfile modifications.

The change adds a single markdown audit document. No executable code, dependencies, or configuration is touched, so there is no regression risk. The analysis is well-researched and internally consistent, with blockers correctly identified and the migration recommendation matching the documented evidence.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/maintenance/eslint-10-plugin-compatibility.md | New documentation-only file auditing ESLint 10 migration readiness; accurately identifies blockers, compatibility status, and recommended upgrade path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: ESLint 10 Migration Decision] --> B{eslint-plugin-import declares ESLint 10 support?}
    B -- No --> C[Keep eslint on 9.x - Monitor blockers]
    B -- Yes --> D{eslint-plugin-react and eslint-plugin-jsx-a11y declare ESLint 10?}
    D -- No --> C
    D -- Yes --> E{eslint-config-next dep chain resolves blockers?}
    E -- No --> F{Must migrate early?}
    F -- No --> C
    F -- Yes --> G[Evaluate eslint-plugin-import-x - validate Next config behavior]
    E -- Yes --> H[Upgrade full stack: eslint@10 + jiti + eslint-config-next + typescript-eslint + tanstack + simple-import-sort + drizzle]
    H --> I[Run pnpm lint - Address migration fallout]
    I --> J[Re-evaluate @types/eslint for ESLint 10 built-in types]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs/maintenance/eslint-10-plugin-compatibility.md:62-64
The table notes that ESLint 10 lists `jiti` as a peer dependency, but `jiti` is absent from the step-3 upgrade checklist. An engineer following the checklist verbatim would install every other package but miss this runtime requirement, which ESLint 10 needs for config file loading.

```suggestion
3. When those peers are ready, upgrade the lint stack together:
   - `eslint@10.4.1` or newer
   - `jiti` (required as an ESLint 10 peer dependency for config file loading)
   - A future `eslint-config-next` version that resolves the transitive blockers; `16.2.7` is not sufficient for ESLint 10
```

### Issue 2 of 2
docs/maintenance/eslint-10-plugin-compatibility.md:70-71
The checklist includes `@types/eslint` nowhere — neither to update it nor to flag it for removal. ESLint 10 ships its own TypeScript types, so `@types/eslint@9.x` may conflict or become redundant. The table entry already says "Re-check during migration," but keeping that note only in the table makes it easy to miss when an engineer works through the checklist in step 3.

```suggestion
   - `eslint-plugin-drizzle@0.2.3` or newer
   - Transitive Next lint plugins such as `eslint-plugin-react-hooks`, `eslint-plugin-react`, and `eslint-plugin-jsx-a11y` through the compatible `eslint-config-next` release
   - Re-evaluate `@types/eslint@9.6.1`: ESLint 10 ships built-in TypeScript types, so this package may need to be removed or replaced
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address ESLint audit review comments"](https://github.com/justaddcl/sanbi/commit/c5c1875d45deae0b50e60e1a6dae95fa7cdd0ce6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35257152)</sub>

<!-- /greptile_comment -->