### PR TITLE
[SWY-126] Upgrade date-fns to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.1.1",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.4.0",
     "dompurify": "^3.4.5",
     "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       date-fns:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^4.4.0
+        version: 4.4.0
       dompurify:
         specifier: ^3.4.5
         version: 3.4.5
@@ -4336,11 +4336,8 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
-
-  date-fns@4.3.0:
-    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -11397,9 +11394,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns@3.6.0: {}
-
-  date-fns@4.3.0: {}
+  date-fns@4.4.0: {}
 
   dateformat@4.6.3: {}
 
@@ -13708,7 +13703,7 @@ snapshots:
   react-day-picker@10.0.1(@types/react@19.2.15)(react@19.2.6):
     dependencies:
       '@date-fns/tz': 1.5.0
-      date-fns: 4.3.0
+      date-fns: 4.4.0
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.15

--- a/src/modules/sets/components/forms/SetDatePickerFormField.tsx
+++ b/src/modules/sets/components/forms/SetDatePickerFormField.tsx
@@ -1,9 +1,7 @@
 import { useFormContext } from "react-hook-form";
-import { addWeeks, differenceInCalendarDays, nextSunday } from "date-fns";
 
 import {
   DatePicker,
-  type DatePickerPreset,
   type DatePickerValue,
 } from "@components/ui/datePicker";
 import {
@@ -12,37 +10,13 @@ import {
   FormItem,
   FormLabel,
 } from "@components/ui/form";
-import { getFirstSundayOfNextMonth } from "@lib/date/getFirstSundayOfNextMonth";
+
+import { getSetDatePickerPresets } from "./getSetDatePickerPresets";
 
 export const SetDatePickerFormField: React.FC = () => {
   const { control } = useFormContext();
+  const datePresets = getSetDatePickerPresets();
 
-  const upcomingSunday = nextSunday(new Date());
-  const upcomingSundayInDays = differenceInCalendarDays(
-    upcomingSunday,
-    new Date(),
-  );
-  const sundayAfterNextInDays = differenceInCalendarDays(
-    addWeeks(upcomingSunday, 1),
-    new Date(),
-  );
-
-  const firstSundayOfNextMonthInDays = differenceInCalendarDays(
-    getFirstSundayOfNextMonth(),
-    new Date(),
-  );
-
-  const datePresets: DatePickerPreset[] = [
-    {
-      value: `${upcomingSundayInDays}`,
-      label: "Upcoming Sunday",
-    },
-    { value: `${sundayAfterNextInDays}`, label: "Sunday After Next" },
-    {
-      value: `${firstSundayOfNextMonthInDays}`,
-      label: "First Sunday of Next Month",
-    },
-  ];
   return (
     <FormField
       control={control}

--- a/src/modules/sets/components/forms/__tests__/getSetDatePickerPresets.test.ts
+++ b/src/modules/sets/components/forms/__tests__/getSetDatePickerPresets.test.ts
@@ -1,0 +1,41 @@
+import { getSetDatePickerPresets } from "../getSetDatePickerPresets";
+
+describe("getSetDatePickerPresets", () => {
+  it("returns preset offsets from a weekday base date", () => {
+    const baseDate = new Date(2026, 5, 2);
+
+    expect(getSetDatePickerPresets(baseDate)).toEqual([
+      {
+        value: "5",
+        label: "Upcoming Sunday",
+      },
+      {
+        value: "12",
+        label: "Sunday After Next",
+      },
+      {
+        value: "33",
+        label: "First Sunday of Next Month",
+      },
+    ]);
+  });
+
+  it("treats upcoming Sunday as the following Sunday when today is Sunday", () => {
+    const baseDate = new Date(2026, 5, 7);
+
+    expect(getSetDatePickerPresets(baseDate)).toEqual([
+      {
+        value: "7",
+        label: "Upcoming Sunday",
+      },
+      {
+        value: "14",
+        label: "Sunday After Next",
+      },
+      {
+        value: "28",
+        label: "First Sunday of Next Month",
+      },
+    ]);
+  });
+});

--- a/src/modules/sets/components/forms/getSetDatePickerPresets.ts
+++ b/src/modules/sets/components/forms/getSetDatePickerPresets.ts
@@ -1,0 +1,27 @@
+import { addWeeks, differenceInCalendarDays, nextSunday } from "date-fns";
+
+import { type DatePickerPreset } from "@components/ui/datePicker";
+import { getFirstSundayOfNextMonth } from "@lib/date/getFirstSundayOfNextMonth";
+
+export const getSetDatePickerPresets = (
+  baseDate = new Date(),
+): DatePickerPreset[] => {
+  const upcomingSunday = nextSunday(baseDate);
+  const sundayAfterNext = addWeeks(upcomingSunday, 1);
+  const firstSundayOfNextMonth = getFirstSundayOfNextMonth(baseDate);
+
+  return [
+    {
+      value: `${differenceInCalendarDays(upcomingSunday, baseDate)}`,
+      label: "Upcoming Sunday",
+    },
+    {
+      value: `${differenceInCalendarDays(sundayAfterNext, baseDate)}`,
+      label: "Sunday After Next",
+    },
+    {
+      value: `${differenceInCalendarDays(firstSundayOfNextMonth, baseDate)}`,
+      label: "First Sunday of Next Month",
+    },
+  ];
+};


### PR DESCRIPTION
## Summary
[SWY-126]
- Upgrade Sanbi's direct `date-fns` dependency from `^3.6.0` to `^4.4.0`.
- Deduplicate the lockfile so `react-day-picker` also resolves through `date-fns@4.4.0`.
- Extract set date picker preset calculations into a pure helper with focused Sunday offset coverage.

## Why

Date handling is central to set planning, friendly date labels, and date picker presets. This keeps existing local calendar-date behavior while making the v4 upgrade explicit and test-backed.

## Validation

- `pnpm test -- --runTestsByPath src/lib/date/__tests__/formatFriendlyDate.test.ts src/lib/date/__tests__/getFirstSundayOfNextMonth.test.ts src/components/ui/__tests__/DatePicker.test.tsx src/modules/sets/components/forms/__tests__/getSetDatePickerPresets.test.ts --runInBand`
- `pnpm test -- --runInBand`
- `pnpm type-check`
- `pnpm exec eslint src/modules/sets/components/forms/SetDatePickerFormField.tsx src/modules/sets/components/forms/getSetDatePickerPresets.ts src/modules/sets/components/forms/__tests__/getSetDatePickerPresets.test.ts`

`pnpm lint:next` exits with 0 errors but still reports existing repo-wide warnings unrelated to this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades `date-fns` from `^3.6.0` to `^4.4.0` and deduplicates the lockfile so both the direct dependency and `react-day-picker`'s transitive dependency resolve to the same `4.4.0`. Alongside the upgrade, the inline preset-offset calculations are extracted from `SetDatePickerFormField` into a new pure helper `getSetDatePickerPresets`, backed by focused unit tests.

- **date-fns v4 upgrade**: The v4 release introduces only type-level breaking changes, so all runtime behavior of `nextSunday`, `addWeeks`, `differenceInCalendarDays`, and the other calendar helpers used here is unchanged. The lockfile previously carried both `3.6.0` and `4.3.0`; this PR collapses them to a single `4.4.0`, consistent with `react-day-picker` v9.1.0+'s own upgrade to date-fns v4.
- **`getSetDatePickerPresets` extraction**: The helper accepts an optional `baseDate` (defaulting to `new Date()`) making it fully testable without mocks. Preset offset arithmetic is identical to the previous inline calculation, and `getFirstSundayOfNextMonth` is correctly forwarded `baseDate` rather than relying on its own `new Date()` default.
- **Test coverage**: Two cases are covered — a Tuesday base date and a Sunday base date (explicitly verifying that `nextSunday` on a Sunday advances a full week, not zero days).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the upgrade is runtime-compatible, the lockfile deduplication is clean, and the extracted helper preserves the original arithmetic exactly.

date-fns v4 carries only type-level breaking changes, so none of the calendar helpers used here behave differently at runtime. The preset-offset extraction reproduces the original inline logic faithfully, passes baseDate through to getFirstSundayOfNextMonth instead of letting each call fall back to its own new Date(), and is validated by unit tests that hand-verify both a weekday and a Sunday boundary case.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Bumps the direct date-fns dependency from ^3.6.0 to ^4.4.0; the upgrade is safe since date-fns v4 breaking changes are type-only. |
| src/modules/sets/components/forms/getSetDatePickerPresets.ts | New pure helper that calculates the three date picker preset offsets (upcoming Sunday, Sunday after next, first Sunday of next month); logic is correct and testable in isolation. |
| src/modules/sets/components/forms/SetDatePickerFormField.tsx | Removes inline preset calculation, delegates to getSetDatePickerPresets(); behavior is preserved and component is now thinner. |
| src/modules/sets/components/forms/__tests__/getSetDatePickerPresets.test.ts | Tests cover a weekday base date (Tuesday) and the Sunday edge case where nextSunday skips to the following week; all expected offset values are arithmetically verified. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as SetDatePickerFormField
    participant G as getSetDatePickerPresets
    participant F as getFirstSundayOfNextMonth
    participant DP as DatePicker (UI)

    C->>G: getSetDatePickerPresets()
    Note over G: baseDate = new Date()
    G->>G: nextSunday(baseDate)
    G->>G: addWeeks(upcomingSunday, 1)
    G->>F: getFirstSundayOfNextMonth(baseDate)
    F-->>G: firstSundayOfNextMonth
    G->>G: differenceInCalendarDays(each target, baseDate)
    G-->>C: DatePickerPreset[]
    C->>DP: "presets={datePresets}"
    DP->>DP: onValueChange → addDays(new Date(), parseInt(value))
```

<sub>Reviews (1): Last reviewed commit: ["Cover set date picker presets"](https://github.com/justaddcl/sanbi/commit/403fbada46a2296a251f9d3deb5070b70fb7d5fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36107301)</sub>

<!-- /greptile_comment -->