### PR TITLE
[SWY-138] E2E add song to set from set detail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,8 @@ jobs:
             fi
 
             DATABASE_URL=postgresql://sanbi@localhost:5432/sanbi_e2e POSTGRES_URL=postgresql://sanbi@localhost:5432/sanbi_e2e pnpm test:e2e:ci
+      - store_test_results:
+          path: test-results/junit
       - store_artifacts:
           path: playwright-report
       - store_artifacts:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,11 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI
-    ? [["html"], ["list"]]
+    ? [
+        ["html"],
+        ["list"],
+        ["junit", { outputFile: "test-results/junit/playwright.xml" }],
+      ]
     : [["list"], ["html", { open: "never" }]],
   use: {
     baseURL,

--- a/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
+++ b/src/modules/sets/components/SetSectionCard/SetSectionCard.tsx
@@ -45,39 +45,43 @@ export const SetSectionCard: FC<SetSectionCardProps> = ({
   const [isSectionExpanded, setIsSectionExpanded] = useState<boolean>(true);
 
   return (
-    <Card
-      externalIsExpanded={isSectionExpanded}
-      header={
-        <EditSetSectionTypeForm
-          section={section}
-          setSectionsLength={setSectionsLength}
-          isExpanded={isSectionExpanded}
-          setIsExpanded={setIsSectionExpanded}
-          withActionsMenu={withActionsMenu}
-          isFirstSection={isFirstSection}
-          isLastSection={isLastSection}
-          onAddSongClick={onAddSongClick}
-        />
-      }
-    >
-      <VStack className="gap-1">
-        {songs &&
-          songs.length > 0 &&
-          section.songs.map((setSectionSong) => (
-            <SongItem
-              key={setSectionSong.id}
-              setSectionSong={setSectionSong}
-              index={sectionStartIndex + setSectionSong.position}
-              setId={setId}
-              setSectionType={type.name}
-              isInFirstSection={isFirstSection}
-              isInLastSection={isLastSection}
-              isFirstSong={setSectionSong.position === 0}
-              isLastSong={setSectionSong.position === section.songs.length - 1}
-              withActionsMenu
-            />
-          ))}
-      </VStack>
-    </Card>
+    <div data-testid="set-section-card">
+      <Card
+        externalIsExpanded={isSectionExpanded}
+        header={
+          <EditSetSectionTypeForm
+            section={section}
+            setSectionsLength={setSectionsLength}
+            isExpanded={isSectionExpanded}
+            setIsExpanded={setIsSectionExpanded}
+            withActionsMenu={withActionsMenu}
+            isFirstSection={isFirstSection}
+            isLastSection={isLastSection}
+            onAddSongClick={onAddSongClick}
+          />
+        }
+      >
+        <VStack className="gap-1">
+          {songs &&
+            songs.length > 0 &&
+            section.songs.map((setSectionSong) => (
+              <SongItem
+                key={setSectionSong.id}
+                setSectionSong={setSectionSong}
+                index={sectionStartIndex + setSectionSong.position}
+                setId={setId}
+                setSectionType={type.name}
+                isInFirstSection={isFirstSection}
+                isInLastSection={isLastSection}
+                isFirstSong={setSectionSong.position === 0}
+                isLastSong={
+                  setSectionSong.position === section.songs.length - 1
+                }
+                withActionsMenu
+              />
+            ))}
+        </VStack>
+      </Card>
+    </div>
   );
 };

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -323,7 +323,10 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                           onValueChange={field.onChange}
                           defaultValue={field.value as string}
                         >
-                          <SelectTrigger className={cn(textSize)}>
+                          <SelectTrigger
+                            aria-label="Song key"
+                            className={cn(textSize)}
+                          >
                             <SelectValue placeholder="Select song key" />
                           </SelectTrigger>
                           <SelectContent>

--- a/src/server/db/seed-e2e.ts
+++ b/src/server/db/seed-e2e.ts
@@ -151,6 +151,26 @@ export const seedE2eDatabase = async () => {
       isArchived: false,
       favoritedAt: null,
     },
+    {
+      id: e2eIds.addSongToSetDesktopSongId,
+      name: e2eData.set.addSongToSet.desktopSong.name,
+      preferredKey: e2eData.set.addSongToSet.desktopSong.preferredKey,
+      notes: e2eData.set.addSongToSet.desktopSong.notes,
+      createdBy: env.E2E_CLERK_USER_ID,
+      organizationId: e2eIds.organizationId,
+      isArchived: false,
+      favoritedAt: null,
+    },
+    {
+      id: e2eIds.addSongToSetMobileSongId,
+      name: e2eData.set.addSongToSet.mobileSong.name,
+      preferredKey: e2eData.set.addSongToSet.mobileSong.preferredKey,
+      notes: e2eData.set.addSongToSet.mobileSong.notes,
+      createdBy: env.E2E_CLERK_USER_ID,
+      organizationId: e2eIds.organizationId,
+      isArchived: false,
+      favoritedAt: null,
+    },
   ];
 
   const setSongs: NewSetSectionSong[] = [

--- a/src/testUtils/e2e/fixtures.ts
+++ b/src/testUtils/e2e/fixtures.ts
@@ -9,6 +9,8 @@ export const e2eIds = {
   prayerSectionId: "77777777-7777-4777-8777-777777777777",
   firstSongId: "88888888-8888-4888-8888-888888888888",
   secondSongId: "99999999-9999-4999-8999-999999999999",
+  addSongToSetDesktopSongId: "12121212-1212-4121-8121-121212121212",
+  addSongToSetMobileSongId: "13131313-1313-4131-8131-131313131313",
   tagId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
   resourceId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
   firstSetSectionSongId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
@@ -27,6 +29,20 @@ export const e2eData = {
   set: {
     date: "2099-06-06",
     notes: "E2E set notes for the Sunday gathering.",
+    addSongToSet: {
+      desktopSong: {
+        name: "E2E Set Detail Anthem",
+        preferredKey: "a",
+        notes: "Available for set-detail add-song coverage.",
+      },
+      mobileSong: {
+        name: "E2E Set Detail Chorus",
+        preferredKey: "e",
+        notes: "Available for mobile set-detail add-song coverage.",
+      },
+      key: "d",
+      notes: "Bring in the band after the first chorus.",
+    },
   },
   eventType: {
     name: "E2E Sunday Gathering",

--- a/tests/e2e/sets/set-detail.authenticated.spec.ts
+++ b/tests/e2e/sets/set-detail.authenticated.spec.ts
@@ -91,13 +91,13 @@ test("adds a song to a section from set detail", async ({ page }, testInfo) => {
   await dialog
     .getByPlaceholder("Search for a song...")
     .fill(songToAdd.name);
-  await expect(dialog.getByText(songToAdd.name)).toBeVisible();
-  await dialog.getByText(songToAdd.name).click();
+  await expect(dialog.getByText(songToAdd.name, { exact: true })).toBeVisible();
+  await dialog.getByText(songToAdd.name, { exact: true }).click();
 
   await expect(
     dialog.getByRole("heading", { name: "Add song to set" }),
   ).toBeVisible();
-  await expect(dialog.getByText(songToAdd.name)).toBeVisible();
+  await expect(dialog.getByText(songToAdd.name, { exact: true })).toBeVisible();
   await expect(
     dialog.getByRole("radio", { name: e2eData.sectionTypes.fullBand }),
   ).toBeChecked();

--- a/tests/e2e/sets/set-detail.authenticated.spec.ts
+++ b/tests/e2e/sets/set-detail.authenticated.spec.ts
@@ -8,7 +8,7 @@ import { expectNoA11yViolations } from "../a11y";
 
 const getSetSectionCard = (page: Page, sectionName: string) =>
   page
-    .locator(".rounded-lg.border.p-1")
+    .getByTestId("set-section-card")
     .filter({ has: page.getByRole("heading", { name: sectionName }) });
 
 type AddSongToSetSong =
@@ -71,6 +71,14 @@ test("adds a song to a section from set detail", async ({ page }, testInfo) => {
     page,
     e2eData.sectionTypes.fullBand,
   );
+  await expect(fullBandSection).toBeVisible();
+
+  if (await fullBandSection.getByText(songToAdd.name).first().isVisible()) {
+    await expectAddedSongInFullBandSection(page, songToAdd);
+    await page.reload();
+    await expectAddedSongInFullBandSection(page, songToAdd);
+    return;
+  }
 
   await fullBandSection
     .getByRole("button", {
@@ -93,7 +101,7 @@ test("adds a song to a section from set detail", async ({ page }, testInfo) => {
   await expect(
     dialog.getByRole("radio", { name: e2eData.sectionTypes.fullBand }),
   ).toBeChecked();
-  await dialog.getByRole("combobox").first().click();
+  await dialog.getByRole("combobox", { name: "Song key" }).click();
   await page
     .getByRole("option", {
       name: formatSongKey(addSongToSet.key),

--- a/tests/e2e/sets/set-detail.authenticated.spec.ts
+++ b/tests/e2e/sets/set-detail.authenticated.spec.ts
@@ -1,9 +1,39 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { e2eData, e2eIds } from "@testUtils/e2e/fixtures";
 
 import { formatDate } from "@lib/date";
+import { formatSongKey } from "@lib/string/formatSongKey";
 
 import { expectNoA11yViolations } from "../a11y";
+
+const getSetSectionCard = (page: Page, sectionName: string) =>
+  page
+    .locator(".rounded-lg.border.p-1")
+    .filter({ has: page.getByRole("heading", { name: sectionName }) });
+
+type AddSongToSetSong =
+  | typeof e2eData.set.addSongToSet.desktopSong
+  | typeof e2eData.set.addSongToSet.mobileSong;
+
+const getAddSongToSetSong = (projectName: string): AddSongToSetSong =>
+  projectName.includes("mobile")
+    ? e2eData.set.addSongToSet.mobileSong
+    : e2eData.set.addSongToSet.desktopSong;
+
+const expectAddedSongInFullBandSection = async (
+  page: Page,
+  song: AddSongToSetSong,
+) => {
+  const fullBandSection = getSetSectionCard(
+    page,
+    e2eData.sectionTypes.fullBand,
+  );
+  const addSongToSet = e2eData.set.addSongToSet;
+
+  await expect(fullBandSection).toContainText(song.name);
+  await expect(fullBandSection).toContainText(formatSongKey(addSongToSet.key));
+  await expect(fullBandSection).toContainText(addSongToSet.notes);
+};
 
 test("set detail renders seeded sections, songs, and notes", async ({
   page,
@@ -29,4 +59,60 @@ test("set detail renders seeded sections, songs, and notes", async ({
     include: "main",
     exclude: ["[data-nextjs-toast]", "nextjs-portal"],
   });
+});
+
+test("adds a song to a section from set detail", async ({ page }, testInfo) => {
+  const addSongToSet = e2eData.set.addSongToSet;
+  const songToAdd = getAddSongToSetSong(testInfo.project.name);
+
+  await page.goto(`/${e2eIds.organizationId}/sets/${e2eIds.setId}`);
+
+  const fullBandSection = getSetSectionCard(
+    page,
+    e2eData.sectionTypes.fullBand,
+  );
+
+  await fullBandSection
+    .getByRole("button", {
+      name: `Add song to ${e2eData.sectionTypes.fullBand} section`,
+    })
+    .click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await dialog
+    .getByPlaceholder("Search for a song...")
+    .fill(songToAdd.name);
+  await expect(dialog.getByText(songToAdd.name)).toBeVisible();
+  await dialog.getByText(songToAdd.name).click();
+
+  await expect(
+    dialog.getByRole("heading", { name: "Add song to set" }),
+  ).toBeVisible();
+  await expect(dialog.getByText(songToAdd.name)).toBeVisible();
+  await expect(
+    dialog.getByRole("radio", { name: e2eData.sectionTypes.fullBand }),
+  ).toBeChecked();
+  await dialog.getByRole("combobox").first().click();
+  await page
+    .getByRole("option", {
+      name: formatSongKey(addSongToSet.key),
+      exact: true,
+    })
+    .click();
+  await dialog.getByLabel("Song notes").fill(addSongToSet.notes);
+
+  const addSongButton = dialog.getByRole("button", {
+    name: "Add song",
+    exact: true,
+  });
+  await expect(addSongButton).toBeEnabled();
+  await addSongButton.click();
+
+  await expect(page.getByText("Song added to the set!")).toBeVisible();
+  await expect(dialog).toBeHidden();
+  await expectAddedSongInFullBandSection(page, songToAdd);
+
+  await page.reload();
+  await expectAddedSongInFullBandSection(page, songToAdd);
 });


### PR DESCRIPTION
## Summary

- Add dedicated E2E fixture songs for the set-detail add-song workflow.
- Extend the E2E seed so those songs exist but are not already attached to the seeded set.
- Add authenticated Playwright coverage for adding a song from a seeded set section, configuring key and notes, verifying the success toast, and confirming the song persists after reload.

## Why

SWY-138 calls for coverage of the user-facing set-detail path. This exercises the section-scoped add-song action rather than the song-detail add-to-set wizard.

## Validation

- `pnpm lint`

The local full E2E run requires `.env.e2e` values that are not present in this workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced e2e test fixtures with new test data for desktop and mobile add-song scenarios.
  * Expanded database seeding with additional song records for comprehensive testing.
  * Added automated test suite for adding songs to set sections, including form submission, success validation, and data persistence verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds E2E coverage for the "add song to set" flow from the set-detail page. It introduces dedicated fixture songs, extends the seed script, and adds a new authenticated Playwright spec.

- Two new E2E fixture songs (`addSongToSetDesktopSongId` / `addSongToSetMobileSongId`) are seeded but intentionally left out of the set sections so the test can exercise the add-song action end-to-end.
- `SetSectionCard` gains a `data-testid="set-section-card"` wrapper div and `ConfigureSongForSet` gains an `aria-label="Song key"` on the `SelectTrigger`, providing stable, semantic locators for the spec.
- The new test includes a retry-safe early-exit branch and a post-reload persistence check; CircleCI is updated to store JUnit test results alongside the existing Playwright HTML report.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely additive E2E infrastructure with minor accessibility and testability improvements to existing components.

All production code changes are minimal and non-breaking: a wrapper div for testability and an aria-label for accessibility. The new E2E test exercises a well-defined user flow, uses stable locators, and handles CI retries correctly. The seed additions are isolated to the E2E database and cannot affect production data.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/e2e/sets/set-detail.authenticated.spec.ts | New test covers add-song flow with retry-safe early-exit, stable locators, and reload persistence check. |
| src/server/db/seed-e2e.ts | Two new fixture songs added to seededSongs but deliberately excluded from setSongs so the test can add them. |
| src/testUtils/e2e/fixtures.ts | New stable UUIDs and fixture data for desktop/mobile add-song songs, cleanly separated from existing fixtures. |
| src/modules/sets/components/SetSectionCard/SetSectionCard.tsx | Adds data-testid wrapper div for stable E2E selection; no functional or rendering change. |
| src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx | Adds aria-label="Song key" to SelectTrigger to give the combobox a stable accessible name for tests and screen readers. |
| playwright.config.ts | JUnit reporter added for CI, wired to the test-results/junit directory consumed by store_test_results. |
| .circleci/config.yml | store_test_results step added before store_artifacts to enable CircleCI test analytics from the JUnit XML output. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[page.goto set detail] --> B[await fullBandSection visible]
    B --> C{songToAdd.name\nalready visible?}
    C -- Yes / retry path --> D[expectAddedSongInFullBandSection]
    D --> E[page.reload]
    E --> F[expectAddedSongInFullBandSection]
    F --> G[return early]
    C -- No / first run --> H[click Add song to section button]
    H --> I[dialog visible]
    I --> J[fill search input with songToAdd.name]
    J --> K[click song result]
    K --> L[dialog shows Add song to set heading]
    L --> M[verify section radio checked]
    M --> N[click Song key combobox\nselect formatSongKey key]
    N --> O[fill Song notes]
    O --> P[click Add song button]
    P --> Q[toast: Song added to the set!]
    Q --> R[dialog hidden]
    R --> S[expectAddedSongInFullBandSection]
    S --> T[page.reload]
    T --> U[expectAddedSongInFullBandSection\npersistence check]
```

<sub>Reviews (3): Last reviewed commit: ["Add CircleCI Playwright test summaries"](https://github.com/justaddcl/sanbi/commit/404e0c90fe2b1a1a12f93997ace2182ce02fb982) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36304524)</sub>

<!-- /greptile_comment -->