### PR TITLE
[SWY-139] Add song to set from song detail

### DIFF
--- a/src/modules/SetListCard/components/SongContent/SongContent.tsx
+++ b/src/modules/SetListCard/components/SongContent/SongContent.tsx
@@ -44,6 +44,7 @@ export const SongContent: React.FC<SongContentProps> = ({
 
   return (
     <HStack
+      data-testid="song-content"
       className={cn(
         "w-full items-baseline gap-3 text-xs font-semibold",
         className,

--- a/src/modules/shared/components/DraggableSongItem/DraggableSongItem.tsx
+++ b/src/modules/shared/components/DraggableSongItem/DraggableSongItem.tsx
@@ -45,7 +45,7 @@ export const DraggableSongItem: React.FC<DraggableSongItemProps> = ({
     <HStack
       ref={setNodeRef}
       style={style}
-      className={cn("gap-1 rounded-lg border p-3", "touch-none", {
+      className={cn("w-full gap-1 rounded-lg border p-3", "touch-none", {
         "opacity-40": active,
         "hover:cursor-grab": !disabled,
         "cursor-not-allowed bg-slate-100 pl-8": disabled,

--- a/src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialogHeader.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialogHeader.tsx
@@ -43,7 +43,6 @@ export const AddSongToSetDialogHeader: React.FC<
           )}
           <DialogTitle asChild>
             <h2
-              id="modal-title"
               className={cn("text-lg font-semibold", {
                 "ml-3":
                   step === AddSongToSetDialogStep.SELECT_SET &&

--- a/src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx
@@ -127,23 +127,23 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
           Does this look right?
         </Text>
 
-        <VStack className="gap-1">
+        <VStack data-testid="add-song-review-summary-group" className="gap-1">
           <Text className="font-medium text-slate-700">Adding</Text>
           <HStack className="items-center justify-between rounded-lg border border-slate-200 p-3">
             <Text className="font-medium md:text-lg">{song.name}</Text>
           </HStack>
         </VStack>
-        <VStack className="gap-1">
+        <VStack data-testid="add-song-review-summary-group" className="gap-1">
           <Text className="font-medium text-slate-700">Played in</Text>
           <HStack className="items-center justify-between rounded-lg border border-slate-200 p-3">
             <SongKey songKey={songKey} size="large" />
           </HStack>
         </VStack>
-        <VStack className="gap-1">
+        <VStack data-testid="add-song-review-summary-group" className="gap-1">
           <Text className="font-medium text-slate-700">In set</Text>
           <SelectedSetCard set={setData} countShown="songs" />
         </VStack>
-        <VStack className="gap-1">
+        <VStack data-testid="add-song-review-summary-group" className="gap-1">
           <Text className="font-medium text-slate-700">In section</Text>
           <Card
             title={setSectionData.type.name}
@@ -162,7 +162,7 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
             </VStack>
           </Card>
         </VStack>
-        <VStack className="gap-1">
+        <VStack data-testid="add-song-review-summary-group" className="gap-1">
           <Text className="font-medium text-slate-700">Song notes</Text>
           <Textarea
             value={notes}

--- a/src/modules/songs/forms/AddSongToSet/components/SetSectionSelectionStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSectionSelectionStep.tsx
@@ -137,40 +137,44 @@ export const SetSectionSelectionStep: React.FC<
         </Text>
         <VStack className="gap-4">
           {setData.sections.map((section) => (
-            <Card
+            <div
               key={section.id}
-              title={section.type.name}
-              headerClassName="p-0"
-              titleClassName="md:text-lg"
-              button={
-                <Button
-                  size="sm"
-                  onClick={(clickEvent) => {
-                    clickEvent.stopPropagation();
-                    onSelectSetSection(section.id, section.songs.length);
-                  }}
-                >
-                  <span className="md:hidden">Select</span>
-                  <span className="hidden md:inline">Select section</span>
-                </Button>
-              }
-              // collapsible
-              initialIsExpanded={false}
+              data-testid="set-section-selection-card"
             >
-              <VStack className="gap-3 md:gap-4">
-                {section.songs &&
-                  section.songs.length > 0 &&
-                  section.songs.map((setSectionSong, songPosition) => (
-                    <SongContent
-                      key={setSectionSong.id}
-                      songKey={setSectionSong.key}
-                      name={setSectionSong.song.name}
-                      notes={setSectionSong.notes}
-                      index={songPosition + 1}
-                    />
-                  ))}
-              </VStack>
-            </Card>
+              <Card
+                title={section.type.name}
+                headerClassName="p-0"
+                titleClassName="md:text-lg"
+                button={
+                  <Button
+                    size="sm"
+                    onClick={(clickEvent) => {
+                      clickEvent.stopPropagation();
+                      onSelectSetSection(section.id, section.songs.length);
+                    }}
+                  >
+                    <span className="md:hidden">Select</span>
+                    <span className="hidden md:inline">Select section</span>
+                  </Button>
+                }
+                // collapsible
+                initialIsExpanded={false}
+              >
+                <VStack className="gap-3 md:gap-4">
+                  {section.songs &&
+                    section.songs.length > 0 &&
+                    section.songs.map((setSectionSong, songPosition) => (
+                      <SongContent
+                        key={setSectionSong.id}
+                        songKey={setSectionSong.key}
+                        name={setSectionSong.song.name}
+                        notes={setSectionSong.notes}
+                        index={songPosition + 1}
+                      />
+                    ))}
+                </VStack>
+              </Card>
+            </div>
           ))}
           {!isAddingSection && (
             <Button

--- a/src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx
@@ -37,24 +37,8 @@ type SetSelectionAllUpcomingSetsProps = {
 export const SetSelectionAllUpcomingSets: React.FC<
   SetSelectionAllUpcomingSetsProps
 > = ({ eventTypeFilters, dateFilter, onCreateSetClick, onSetSelect }) => {
-  const {
-    data: userData,
-    error: userQueryError,
-    isLoading: userQueryLoading,
-    isAuthLoaded,
-  } = useUserQuery();
+  const { data: userData } = useUserQuery();
   const userMembership = userData?.memberships[0];
-
-  if (!userMembership) {
-    return (
-      <SetSelectionSection title="All upcoming sets">
-        <div className="p-4 text-center text-muted-foreground">
-          Unable to load sets. Looks like we can&apos;t verify which team
-          you&apos;re a part of
-        </div>
-      </SetSelectionSection>
-    );
-  }
 
   const {
     data: setsData,
@@ -65,11 +49,11 @@ export const SetSelectionAllUpcomingSets: React.FC<
     error: getInfiniteSetsQueryError,
   } = trpc.set.getInfinite.useInfiniteQuery(
     {
-      organizationId: userMembership.organizationId,
+      organizationId: userMembership?.organizationId ?? "",
       dateRange: dateFilter?.from
         ? {
             from: dateFilter.from,
-            to: dateFilter.to ? dateFilter.to : null,
+            to: dateFilter.to ?? null,
           }
         : null,
       eventTypeFilters: eventTypeFilters.map((filter) => filter.id),
@@ -87,8 +71,20 @@ export const SetSelectionAllUpcomingSets: React.FC<
           date: new Date(cursor.date),
         };
       },
+      enabled: !!userMembership?.organizationId,
     },
   );
+
+  if (!userMembership) {
+    return (
+      <SetSelectionSection title="All upcoming sets">
+        <div className="text-muted-foreground p-4 text-center">
+          Unable to load sets. Looks like we can&apos;t verify which team
+          you&apos;re a part of
+        </div>
+      </SetSelectionSection>
+    );
+  }
 
   if (isLoading) {
     return (
@@ -128,7 +124,7 @@ export const SetSelectionAllUpcomingSets: React.FC<
   if (!setsData) {
     return (
       <SetSelectionSection title="All upcoming sets">
-        <div className="p-4 text-center text-muted-foreground">
+        <div className="text-muted-foreground p-4 text-center">
           No sets found. Try adjusting your filters or create a new set.
         </div>
       </SetSelectionSection>
@@ -189,7 +185,9 @@ export const SetSelectionAllUpcomingSets: React.FC<
         <Button
           variant="secondary"
           size="sm"
-          onClick={() => fetchNextPage()}
+          onClick={() => {
+            void fetchNextPage();
+          }}
           disabled={isFetchingNextPage}
           className="mt-4"
         >

--- a/src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
+import { skipToken } from "@tanstack/react-query";
 import { differenceInCalendarWeeks } from "date-fns";
 import { toast } from "sonner";
 
@@ -48,16 +49,18 @@ export const SetSelectionAllUpcomingSets: React.FC<
     isLoading,
     error: getInfiniteSetsQueryError,
   } = trpc.set.getInfinite.useInfiniteQuery(
-    {
-      organizationId: userMembership?.organizationId ?? "",
-      dateRange: dateFilter?.from
-        ? {
-            from: dateFilter.from,
-            to: dateFilter.to ?? null,
-          }
-        : null,
-      eventTypeFilters: eventTypeFilters.map((filter) => filter.id),
-    },
+    userMembership
+      ? {
+          organizationId: userMembership.organizationId,
+          dateRange: dateFilter?.from
+            ? {
+                from: dateFilter.from,
+                to: dateFilter.to ?? null,
+              }
+            : null,
+          eventTypeFilters: eventTypeFilters.map((filter) => filter.id),
+        }
+      : skipToken,
     {
       getNextPageParam: (last) => {
         const cursor = last.nextCursor;
@@ -71,7 +74,6 @@ export const SetSelectionAllUpcomingSets: React.FC<
           date: new Date(cursor.date),
         };
       },
-      enabled: !!userMembership?.organizationId,
     },
   );
 

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq, gt, sql } from "drizzle-orm";
+import { and, eq, gt, gte, sql } from "drizzle-orm";
 
-import { type NewSetSectionSong, type Song } from "@lib/types";
+import { type NewSetSectionSong } from "@lib/types";
 import {
   addAndReorderSongsSchema,
   deleteSetSectionSongSchema,
@@ -36,19 +36,58 @@ export const setSectionSongRouter = createTRPCRouter({
         });
       }
 
-      const newSetSectionSong: NewSetSectionSong = {
-        songId,
-        setSectionId,
-        key: key as Song["preferredKey"],
-        position,
-        notes,
-        organizationId,
-      };
+      return ctx.db.transaction(async (transaction) => {
+        await transaction.execute(
+          sql`SELECT id FROM ${setSections} WHERE ${setSections.id} = ${setSectionId} FOR UPDATE`,
+        );
 
-      return ctx.db
-        .insert(setSectionSongs)
-        .values(newSetSectionSong)
-        .returning();
+        const setSection = await transaction.query.setSections.findFirst({
+          where: eq(setSections.id, setSectionId),
+          columns: {
+            organizationId: true,
+          },
+        });
+
+        if (!setSection) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Set section not found",
+          });
+        }
+
+        if (setSection.organizationId !== organizationId) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Not authorized to update this set section",
+          });
+        }
+
+        await transaction
+          .update(setSectionSongs)
+          .set({
+            position: sql`${setSectionSongs.position} + 1`,
+          })
+          .where(
+            and(
+              eq(setSectionSongs.setSectionId, setSectionId),
+              gte(setSectionSongs.position, position),
+            ),
+          );
+
+        const newSetSectionSong: NewSetSectionSong = {
+          songId,
+          setSectionId,
+          key,
+          position,
+          notes,
+          organizationId,
+        };
+
+        return transaction
+          .insert(setSectionSongs)
+          .values(newSetSectionSong)
+          .returning();
+      });
     }),
 
   delete: adminProcedure
@@ -304,7 +343,7 @@ export const setSectionSongRouter = createTRPCRouter({
       const [updatedSong] = await ctx.db
         .update(setSectionSongs)
         .set({
-          key: key as Song["preferredKey"],
+          key,
           ...updates,
         })
         .where(eq(setSectionSongs.id, setSectionSongId))
@@ -360,6 +399,10 @@ export const setSectionSongRouter = createTRPCRouter({
       }
 
       return await ctx.db.transaction(async (transaction) => {
+        await transaction.execute(
+          sql`SELECT id FROM ${setSections} WHERE ${setSections.id} = ${setSectionId} FOR UPDATE`,
+        );
+
         // 2. Determine the position for the new song from orderedSongIds
         const newSongPosition = orderedSongIds.indexOf(newSongTempId);
 
@@ -382,21 +425,19 @@ export const setSectionSongRouter = createTRPCRouter({
           organizationId: organizationId,
         };
 
-        // 3. Execute fetching current state and inserting new song in parallel
-        const [currentSetSectionSongs, [insertedSetSectionSong]] =
-          await Promise.all([
-            transaction.query.setSectionSongs.findMany({
-              where: eq(setSectionSongs.setSectionId, setSectionId),
-              columns: {
-                id: true,
-                position: true,
-              },
-            }),
-            transaction
-              .insert(setSectionSongs)
-              .values(newSetSectionSongData)
-              .returning(),
-          ]);
+        // 3. Fetch the locked section state, then insert the new song
+        const currentSetSectionSongs =
+          await transaction.query.setSectionSongs.findMany({
+            where: eq(setSectionSongs.setSectionId, setSectionId),
+            columns: {
+              id: true,
+              position: true,
+            },
+          });
+        const [insertedSetSectionSong] = await transaction
+          .insert(setSectionSongs)
+          .values(newSetSectionSongData)
+          .returning();
 
         if (!insertedSetSectionSong) {
           console.error(
@@ -429,55 +470,63 @@ export const setSectionSongRouter = createTRPCRouter({
         currentSetSectionSongs.forEach((song) => {
           currentPositionMap.set(song.id, song.position);
         });
+        currentPositionMap.set(insertedSetSectionSong.id, newSongPosition);
+
+        const requestedOrderedSetSectionSongIds = orderedSongIds.map(
+          (songId) =>
+            songId === newSongTempId ? insertedSetSectionSong.id : songId,
+        );
+        const requestedOrderedSetSectionSongIdsSet = new Set(
+          requestedOrderedSetSectionSongIds,
+        );
+        const missingCurrentSetSectionSongIds = currentSetSectionSongs
+          .sort(
+            (firstSong, secondSong) => firstSong.position - secondSong.position,
+          )
+          .map((song) => song.id)
+          .filter(
+            (songId) => !requestedOrderedSetSectionSongIdsSet.has(songId),
+          );
+        const finalOrderedSetSectionSongIds = [
+          ...requestedOrderedSetSectionSongIds,
+          ...missingCurrentSetSectionSongIds,
+        ];
 
         const updatedSetSectionSongs: { id: string; position: number }[] = [];
 
-        const updatePromises = orderedSongIds.reduce<Promise<unknown>[]>(
-          (updatePromises, songIdInOrderedList, desiredPosition) => {
-            // Determine the actual DB ID for the current song in the loop
-            const setSectionSongId =
-              songIdInOrderedList === newSongTempId
-                ? insertedSetSectionSong.id
-                : songIdInOrderedList;
+        const updatePromises = finalOrderedSetSectionSongIds.reduce<
+          Promise<unknown>[]
+        >((updatePromises, setSectionSongId, desiredPosition) => {
+          const currentPosition = currentPositionMap.get(setSectionSongId);
 
-            // Skip updating the newly inserted song as it already has the correct position
-            if (setSectionSongId === insertedSetSectionSong.id) {
-              return updatePromises;
-            }
+          if (
+            currentPosition === undefined ||
+            currentPosition !== desiredPosition
+          ) {
+            updatedSetSectionSongs.push({
+              id: setSectionSongId,
+              position: desiredPosition,
+            });
 
-            const currentPosition = currentPositionMap.get(setSectionSongId);
+            console.info(
+              `🤖 - [setSectionSong/addAndReorderSongs] - Attempting to update song position affected by adding the new song`,
+              {
+                setSectionSongId,
+                currentPosition,
+                desiredPosition,
+              },
+            );
 
-            // If the song is new or an existing song whose position has changed
-            if (
-              currentPosition === undefined ||
-              currentPosition !== desiredPosition
-            ) {
-              updatedSetSectionSongs.push({
-                id: setSectionSongId,
-                position: desiredPosition,
-              });
-
-              console.info(
-                `🤖 - [setSectionSong/addAndReorderSongs] - Attempting to update song position affected by adding the new song`,
-                {
-                  setSectionSongId,
-                  currentPosition,
-                  desiredPosition,
-                },
-              );
-
-              updatePromises.push(
-                transaction
-                  .update(setSectionSongs)
-                  .set({ position: desiredPosition })
-                  .where(eq(setSectionSongs.id, setSectionSongId))
-                  .execute(),
-              );
-            }
-            return updatePromises;
-          },
-          [],
-        );
+            updatePromises.push(
+              transaction
+                .update(setSectionSongs)
+                .set({ position: desiredPosition })
+                .where(eq(setSectionSongs.id, setSectionSongId))
+                .execute(),
+            );
+          }
+          return updatePromises;
+        }, []);
 
         // 5. Execute all position updates in parallel
         await Promise.all(updatePromises);

--- a/src/server/api/routers/setSectionSong.ts
+++ b/src/server/api/routers/setSectionSong.ts
@@ -480,7 +480,7 @@ export const setSectionSongRouter = createTRPCRouter({
           requestedOrderedSetSectionSongIds,
         );
         const missingCurrentSetSectionSongIds = currentSetSectionSongs
-          .sort(
+          .toSorted(
             (firstSong, secondSong) => firstSong.position - secondSong.position,
           )
           .map((song) => song.id)

--- a/src/server/db/seed-e2e.ts
+++ b/src/server/db/seed-e2e.ts
@@ -102,6 +102,16 @@ export const seedE2eDatabase = async () => {
       name: e2eData.sectionTypes.prayer,
       organizationId: e2eIds.organizationId,
     },
+    {
+      id: e2eIds.songDetailDesktopSectionTypeId,
+      name: e2eData.sectionTypes.songDetailDesktop,
+      organizationId: e2eIds.organizationId,
+    },
+    {
+      id: e2eIds.songDetailMobileSectionTypeId,
+      name: e2eData.sectionTypes.songDetailMobile,
+      organizationId: e2eIds.organizationId,
+    },
   ];
 
   const set: NewSet = {
@@ -126,6 +136,20 @@ export const seedE2eDatabase = async () => {
       setId: e2eIds.setId,
       position: 1,
       sectionTypeId: e2eIds.prayerSectionTypeId,
+      organizationId: e2eIds.organizationId,
+    },
+    {
+      id: e2eIds.songDetailDesktopSectionId,
+      setId: e2eIds.setId,
+      position: 2,
+      sectionTypeId: e2eIds.songDetailDesktopSectionTypeId,
+      organizationId: e2eIds.organizationId,
+    },
+    {
+      id: e2eIds.songDetailMobileSectionId,
+      setId: e2eIds.setId,
+      position: 3,
+      sectionTypeId: e2eIds.songDetailMobileSectionTypeId,
       organizationId: e2eIds.organizationId,
     },
   ];
@@ -171,6 +195,47 @@ export const seedE2eDatabase = async () => {
       isArchived: false,
       favoritedAt: null,
     },
+    {
+      id: e2eIds.addSongToSetFromSongDetailDesktopSongId,
+      name: e2eData.songs.addSongToSetFromSongDetailDesktop.name,
+      preferredKey:
+        e2eData.songs.addSongToSetFromSongDetailDesktop.preferredKey,
+      notes: e2eData.songs.addSongToSetFromSongDetailDesktop.notes,
+      createdBy: env.E2E_CLERK_USER_ID,
+      organizationId: e2eIds.organizationId,
+      isArchived: false,
+      favoritedAt: null,
+    },
+    {
+      id: e2eIds.addSongToSetFromSongDetailMobileSongId,
+      name: e2eData.songs.addSongToSetFromSongDetailMobile.name,
+      preferredKey: e2eData.songs.addSongToSetFromSongDetailMobile.preferredKey,
+      notes: e2eData.songs.addSongToSetFromSongDetailMobile.notes,
+      createdBy: env.E2E_CLERK_USER_ID,
+      organizationId: e2eIds.organizationId,
+      isArchived: false,
+      favoritedAt: null,
+    },
+    {
+      id: e2eIds.songDetailDesktopAnchorSongId,
+      name: e2eData.songs.songDetailDesktopAnchor.name,
+      preferredKey: "g",
+      notes: e2eData.songs.songDetailDesktopAnchor.notes,
+      createdBy: env.E2E_CLERK_USER_ID,
+      organizationId: e2eIds.organizationId,
+      isArchived: false,
+      favoritedAt: null,
+    },
+    {
+      id: e2eIds.songDetailMobileAnchorSongId,
+      name: e2eData.songs.songDetailMobileAnchor.name,
+      preferredKey: "c",
+      notes: e2eData.songs.songDetailMobileAnchor.notes,
+      createdBy: env.E2E_CLERK_USER_ID,
+      organizationId: e2eIds.organizationId,
+      isArchived: false,
+      favoritedAt: null,
+    },
   ];
 
   const setSongs: NewSetSectionSong[] = [
@@ -190,6 +255,24 @@ export const seedE2eDatabase = async () => {
       position: 0,
       key: "c",
       notes: e2eData.songs.second.setNotes,
+      organizationId: e2eIds.organizationId,
+    },
+    {
+      id: e2eIds.songDetailDesktopSetSectionSongId,
+      setSectionId: e2eIds.songDetailDesktopSectionId,
+      songId: e2eIds.songDetailDesktopAnchorSongId,
+      position: 0,
+      key: "g",
+      notes: e2eData.songs.songDetailDesktopAnchor.setNotes,
+      organizationId: e2eIds.organizationId,
+    },
+    {
+      id: e2eIds.songDetailMobileSetSectionSongId,
+      setSectionId: e2eIds.songDetailMobileSectionId,
+      songId: e2eIds.songDetailMobileAnchorSongId,
+      position: 0,
+      key: "c",
+      notes: e2eData.songs.songDetailMobileAnchor.setNotes,
       organizationId: e2eIds.organizationId,
     },
   ];

--- a/src/testUtils/e2e/fixtures.ts
+++ b/src/testUtils/e2e/fixtures.ts
@@ -5,16 +5,28 @@ export const e2eIds = {
   setId: "33333333-3333-4333-8333-333333333333",
   fullBandSectionTypeId: "44444444-4444-4444-8444-444444444444",
   prayerSectionTypeId: "55555555-5555-4555-8555-555555555555",
+  songDetailDesktopSectionTypeId: "16161616-1616-4616-8616-161616161616",
+  songDetailMobileSectionTypeId: "17171717-1717-4717-8717-171717171717",
   fullBandSectionId: "66666666-6666-4666-8666-666666666666",
   prayerSectionId: "77777777-7777-4777-8777-777777777777",
+  songDetailDesktopSectionId: "18181818-1818-4818-8818-181818181818",
+  songDetailMobileSectionId: "19191919-1919-4919-8919-191919191919",
   firstSongId: "88888888-8888-4888-8888-888888888888",
   secondSongId: "99999999-9999-4999-8999-999999999999",
   addSongToSetDesktopSongId: "12121212-1212-4121-8121-121212121212",
   addSongToSetMobileSongId: "13131313-1313-4131-8131-131313131313",
+  addSongToSetFromSongDetailDesktopSongId:
+    "14141414-1414-4414-8414-141414141414",
+  addSongToSetFromSongDetailMobileSongId:
+    "15151515-1515-4515-8515-151515151515",
+  songDetailDesktopAnchorSongId: "1c1c1c1c-1c1c-4c1c-8c1c-1c1c1c1c1c1c",
+  songDetailMobileAnchorSongId: "1d1d1d1d-1d1d-4d1d-8d1d-1d1d1d1d1d1d",
   tagId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
   resourceId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
   firstSetSectionSongId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
   secondSetSectionSongId: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+  songDetailDesktopSetSectionSongId: "1a1a1a1a-1a1a-4a1a-8a1a-1a1a1a1a1a1a",
+  songDetailMobileSetSectionSongId: "1b1b1b1b-1b1b-4b1b-8b1b-1b1b1b1b1b1b",
 } as const;
 
 export const e2eData = {
@@ -50,6 +62,8 @@ export const e2eData = {
   sectionTypes: {
     fullBand: "E2E Full Band",
     prayer: "E2E Prayer",
+    songDetailDesktop: "E2E Song Detail Desktop",
+    songDetailMobile: "E2E Song Detail Mobile",
   },
   songs: {
     first: {
@@ -61,6 +75,28 @@ export const e2eData = {
       name: "E2E Mercy Chorus",
       notes: "Keep the final chorus down.",
       setNotes: "Keys lead into prayer.",
+    },
+    songDetailDesktopAnchor: {
+      name: "E2E Song Detail Desktop Anchor",
+      notes: "Existing song for desktop song detail add-to-set positioning.",
+      setNotes: "Desktop anchor song notes.",
+    },
+    songDetailMobileAnchor: {
+      name: "E2E Song Detail Mobile Anchor",
+      notes: "Existing song for mobile song detail add-to-set positioning.",
+      setNotes: "Mobile anchor song notes.",
+    },
+    addSongToSetFromSongDetailDesktop: {
+      name: "E2E Song Detail Add Desktop",
+      notes: "Unused desktop song for add-to-set coverage.",
+      preferredKey: "a",
+      setNotes: "Desktop song detail add-to-set notes.",
+    },
+    addSongToSetFromSongDetailMobile: {
+      name: "E2E Song Detail Add Mobile",
+      notes: "Unused mobile song for add-to-set coverage.",
+      preferredKey: "b_flat",
+      setNotes: "Mobile song detail add-to-set notes.",
     },
   },
   tag: {

--- a/tests/e2e/songs/add-song-to-set.authenticated.spec.ts
+++ b/tests/e2e/songs/add-song-to-set.authenticated.spec.ts
@@ -56,24 +56,18 @@ const getSetSectionCard = (page: Page, sectionName: string) =>
 
 const getDialogCardByHeading = (root: Page | Locator, headingName: string) =>
   root
-    .getByRole("heading", { name: headingName })
-    .locator(
-      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' rounded-lg ') and contains(concat(' ', normalize-space(@class), ' '), ' border ')][1]",
-    );
+    .getByTestId("set-section-selection-card")
+    .filter({ has: root.getByRole("heading", { name: headingName }) });
 
 const getDialogSummaryGroup = (dialog: Locator, label: string) =>
   dialog
-    .getByText(label, { exact: true })
-    .locator(
-      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' gap-1 ')][1]",
-    );
+    .getByTestId("add-song-review-summary-group")
+    .filter({ has: dialog.getByText(label, { exact: true }) });
 
 const getSongRow = (root: Page | Locator, songName: string) =>
   root
-    .getByText(songName, { exact: true })
-    .locator(
-      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' w-full ') and contains(concat(' ', normalize-space(@class), ' '), ' items-baseline ')][1]",
-    );
+    .getByTestId("song-content")
+    .filter({ has: root.getByText(songName, { exact: true }) });
 
 const expectDialogStep = async (
   dialog: Locator,

--- a/tests/e2e/songs/add-song-to-set.authenticated.spec.ts
+++ b/tests/e2e/songs/add-song-to-set.authenticated.spec.ts
@@ -57,17 +57,15 @@ const getSetSectionCard = (page: Page, sectionName: string) =>
 const getDialogCardByHeading = (root: Page | Locator, headingName: string) =>
   root
     .getByTestId("set-section-selection-card")
-    .filter({ has: root.getByRole("heading", { name: headingName }) });
+    .filter({ hasText: headingName });
 
 const getDialogSummaryGroup = (dialog: Locator, label: string) =>
   dialog
     .getByTestId("add-song-review-summary-group")
-    .filter({ has: dialog.getByText(label, { exact: true }) });
+    .filter({ hasText: label });
 
 const getSongRow = (root: Page | Locator, songName: string) =>
-  root
-    .getByTestId("song-content")
-    .filter({ has: root.getByText(songName, { exact: true }) });
+  root.getByTestId("song-content").filter({ hasText: songName });
 
 const expectDialogStep = async (
   dialog: Locator,

--- a/tests/e2e/songs/add-song-to-set.authenticated.spec.ts
+++ b/tests/e2e/songs/add-song-to-set.authenticated.spec.ts
@@ -1,0 +1,245 @@
+import {
+  expect,
+  type Locator,
+  type Page,
+  test,
+  type TestInfo,
+} from "@playwright/test";
+import { e2eData, e2eIds } from "@testUtils/e2e/fixtures";
+import { eq } from "drizzle-orm";
+
+import { formatFriendlyDate } from "@lib/date";
+import { formatSongKey } from "@lib/string/formatSongKey";
+import { db } from "@server/db";
+import { setSectionSongs } from "@server/db/schema";
+
+type AddSongToSetFixture = {
+  id: string;
+  name: string;
+  notes: string;
+  preferredKey: Parameters<typeof formatSongKey>[0];
+  setNotes: string;
+  sectionName: string;
+  existingSongName: string;
+  existingSetSectionSongId: string;
+};
+
+const totalAddSongToSetSteps = 5;
+const firstSongPosition = 1;
+const expectedInitialSectionSongCount = 2;
+const selectedSongPosition = 2;
+const selectedSongKey = "d";
+
+const getAddSongToSetFixture = (
+  projectName: TestInfo["project"]["name"],
+): AddSongToSetFixture =>
+  projectName.includes("mobile")
+    ? {
+        id: e2eIds.addSongToSetFromSongDetailMobileSongId,
+        ...e2eData.songs.addSongToSetFromSongDetailMobile,
+        sectionName: e2eData.sectionTypes.songDetailMobile,
+        existingSongName: e2eData.songs.songDetailMobileAnchor.name,
+        existingSetSectionSongId: e2eIds.songDetailMobileSetSectionSongId,
+      }
+    : {
+        id: e2eIds.addSongToSetFromSongDetailDesktopSongId,
+        ...e2eData.songs.addSongToSetFromSongDetailDesktop,
+        sectionName: e2eData.sectionTypes.songDetailDesktop,
+        existingSongName: e2eData.songs.songDetailDesktopAnchor.name,
+        existingSetSectionSongId: e2eIds.songDetailDesktopSetSectionSongId,
+      };
+
+const getSetSectionCard = (page: Page, sectionName: string) =>
+  page
+    .getByTestId("set-section-card")
+    .filter({ has: page.getByRole("heading", { name: sectionName }) });
+
+const getDialogCardByHeading = (root: Page | Locator, headingName: string) =>
+  root
+    .getByRole("heading", { name: headingName })
+    .locator(
+      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' rounded-lg ') and contains(concat(' ', normalize-space(@class), ' '), ' border ')][1]",
+    );
+
+const getDialogSummaryGroup = (dialog: Locator, label: string) =>
+  dialog
+    .getByText(label, { exact: true })
+    .locator(
+      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' gap-1 ')][1]",
+    );
+
+const getSongRow = (root: Page | Locator, songName: string) =>
+  root
+    .getByText(songName, { exact: true })
+    .locator(
+      "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' w-full ') and contains(concat(' ', normalize-space(@class), ' '), ' items-baseline ')][1]",
+    );
+
+const expectDialogStep = async (
+  dialog: Locator,
+  step: number,
+  title: string,
+) => {
+  await expect(dialog.getByRole("heading", { name: title })).toBeVisible();
+  await expect(
+    dialog.getByText(`${step}/${totalAddSongToSetSteps}`, { exact: true }),
+  ).toBeVisible();
+};
+
+const dragLocatorToLocator = async (
+  page: Page,
+  source: Locator,
+  target: Locator,
+) => {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+
+  if (!sourceBox || !targetBox) {
+    throw new Error("Could not find drag source or target bounds.");
+  }
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width / 2,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 12 },
+  );
+  await page.mouse.up();
+};
+
+const getAddedSongInSelectedSection = (
+  page: Page,
+  song: AddSongToSetFixture,
+) => {
+  const selectedSection = getSetSectionCard(page, song.sectionName);
+
+  return selectedSection.locator("form").filter({
+    hasText: song.name,
+  });
+};
+
+const expectSongInSelectedSection = async (
+  page: Page,
+  song: AddSongToSetFixture,
+) => {
+  const addedSong = getAddedSongInSelectedSection(page, song);
+
+  await expect(addedSong).toBeVisible();
+  await expect(addedSong).toContainText(formatSongKey(selectedSongKey));
+  await expect(addedSong).toContainText(song.setNotes);
+};
+
+const resetAddSongToSetFixture = async (song: AddSongToSetFixture) => {
+  await db.transaction(async (transaction) => {
+    await transaction
+      .delete(setSectionSongs)
+      .where(eq(setSectionSongs.songId, song.id));
+
+    await transaction
+      .update(setSectionSongs)
+      .set({ position: 0 })
+      .where(eq(setSectionSongs.id, song.existingSetSectionSongId));
+  });
+};
+
+test("song detail workflow adds a song to an existing set section", async ({
+  page,
+}, testInfo) => {
+  const song = getAddSongToSetFixture(testInfo.project.name);
+
+  await resetAddSongToSetFixture(song);
+
+  await page.goto(`/${e2eIds.organizationId}/songs/${song.id}`);
+  await expect(page.getByRole("heading", { name: song.name })).toBeVisible();
+
+  await page.getByRole("button", { name: "Add to a set" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expectDialogStep(dialog, 1, "Add to which set?");
+
+  await dialog.getByText(e2eData.eventType.name).first().click();
+  await expectDialogStep(dialog, 2, "Which section?");
+
+  const selectedSection = getDialogCardByHeading(dialog, song.sectionName);
+  await selectedSection.getByRole("button", { name: /Select/ }).click();
+
+  await expectDialogStep(dialog, 3, "When will you play it?");
+
+  const positionInput = dialog.locator("input[type='number']");
+  const sectionSongCount = String(expectedInitialSectionSongCount);
+  const firstPosition = String(firstSongPosition);
+  const selectedPosition = String(selectedSongPosition);
+  await expect(positionInput).toHaveValue(sectionSongCount);
+  await expect(getSongRow(dialog, song.name)).toContainText(
+    `${sectionSongCount}.`,
+  );
+
+  await dragLocatorToLocator(
+    page,
+    getSongRow(dialog, song.name),
+    getSongRow(dialog, song.existingSongName),
+  );
+
+  await expect(positionInput).toHaveValue(firstPosition);
+  await expect(getSongRow(dialog, song.name)).toContainText(
+    `${firstPosition}.`,
+  );
+
+  await positionInput.fill(selectedPosition);
+  await expect(positionInput).toHaveValue(selectedPosition);
+  await expect(getSongRow(dialog, song.name)).toContainText(
+    `${selectedPosition}.`,
+  );
+
+  await page.mouse.move(0, 0);
+  const confirmSongPositionButton = dialog.getByRole("button", {
+    name: "Confirm song position",
+  });
+  await expect(confirmSongPositionButton).toBeEnabled();
+  await confirmSongPositionButton.click();
+
+  await expectDialogStep(dialog, 4, "What key will you play in?");
+  await expect(
+    dialog.getByText(`Preferred key: ${formatSongKey(song.preferredKey)}`),
+  ).toBeVisible();
+  await dialog
+    .getByRole("button", {
+      name: formatSongKey(selectedSongKey),
+      exact: true,
+    })
+    .click();
+
+  await expectDialogStep(dialog, 5, "Review");
+  await expect(getDialogSummaryGroup(dialog, "Adding")).toContainText(
+    song.name,
+  );
+  await expect(getDialogSummaryGroup(dialog, "Played in")).toContainText(
+    formatSongKey(selectedSongKey),
+  );
+  await expect(getDialogSummaryGroup(dialog, "In set")).toContainText(
+    formatFriendlyDate(e2eData.set.date),
+  );
+  await expect(getDialogSummaryGroup(dialog, "In set")).toContainText(
+    e2eData.eventType.name,
+  );
+
+  const reviewSection = getDialogSummaryGroup(dialog, "In section");
+  await expect(reviewSection).toContainText(song.sectionName);
+  await expect(reviewSection).toContainText(song.name);
+  await expect(reviewSection).toContainText(`${selectedPosition}.`);
+
+  await dialog.locator("textarea").fill(song.setNotes);
+  await dialog.getByRole("button", { name: "Add song to set" }).click();
+  await expect(page.getByText("Song added to set!")).toBeVisible();
+  await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+  await page.goto(`/${e2eIds.organizationId}/sets/${e2eIds.setId}`);
+  await expectSongInSelectedSection(page, song);
+
+  await page.reload();
+  await expectSongInSelectedSection(page, song);
+});


### PR DESCRIPTION
## Summary

Adds coverage for adding a song to an existing set section from the song detail page, including desktop and mobile e2e fixtures.

## Changes

- Stabilize set-section-song insertion and add/reorder behavior by locking the parent section while positions are updated.
- Preserve existing set-section songs that are not present in the submitted reorder payload instead of dropping them from the final position update pass.
- Fix the add-song-to-set set-selection query hook so it is called consistently while remaining disabled until membership is available.
- Add dedicated E2E seed data and a Playwright spec for the song detail add-to-set workflow.

## Validation

- `pnpm type-check`
- `pnpm exec eslint src/modules/shared/components/DraggableSongItem/DraggableSongItem.tsx src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialogHeader.tsx src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx src/server/api/routers/setSectionSong.ts src/server/db/seed-e2e.ts src/testUtils/e2e/fixtures.ts tests/e2e/songs/add-song-to-set.authenticated.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity when adding and repositioning songs within sets through enhanced transaction handling.
  * Refined song selection and retrieval behavior in the "Add Song to Set" dialog for better reliability.

* **Tests**
  * Added comprehensive end-to-end test coverage for song detail add-to-set workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds end-to-end coverage for adding a song to a set from the song detail page, and fixes two underlying correctness issues uncovered while building that test path.

- **Server-side locking**: Both `create` and `addAndReorderSongs` mutations now acquire a `SELECT ... FOR UPDATE` lock on the parent `setSections` row before modifying song positions, serializing concurrent inserts and preventing position collisions. `create` also now shifts existing songs' positions up before inserting, and `addAndReorderSongs` preserves songs absent from the client's reorder payload by appending them at the end instead of silently dropping them.
- **React hooks fix**: `SetSelectionAllUpcomingSets` previously called `useInfiniteQuery` after an early `return` guarded by `!userMembership`, violating the Rules of Hooks. The fix uses `skipToken` to disable the query when membership is unavailable and moves the guard below the hook call.
- **Test infrastructure**: Adds `data-testid` anchors replacing XPath/class-based locators, dedicated E2E seed fixtures for desktop and mobile viewports, and a full Playwright spec covering the complete add-to-set workflow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three fixes (section locking, hooks rule violation, missing-song preservation) are targeted and correct with no regressions introduced.

The server-side locking strategy is sound: FOR UPDATE on the section row serializes concurrent mutations through both the create and addAndReorderSongs paths. The hooks fix is straightforward and equivalent in behaviour. The position-preservation logic for unsubmitted songs is correct. The E2E fixtures are isolated per viewport and the reset helper is idempotent. No correctness issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/server/api/routers/setSectionSong.ts | Refactored create and addAndReorderSongs mutations: adds FOR UPDATE section locking to serialize concurrent inserts, shifts existing positions before inserting in create, and preserves songs missing from the client's reorder payload by appending them at the end rather than dropping them. |
| src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx | Fixes a React hooks rules violation by moving the early !userMembership guard to after the useInfiniteQuery call, using skipToken to disable the query when membership is unavailable. |
| tests/e2e/songs/add-song-to-set.authenticated.spec.ts | New E2E spec covering the full add-to-set flow from the song detail page for both desktop and mobile viewports, with per-run fixture reset for idempotency. |
| src/server/db/seed-e2e.ts | Adds dedicated seed rows for song-detail add-to-set desktop and mobile fixtures. |
| src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx | Adds data-testid to all five VStack summary groups, disambiguated in tests via Playwright's .filter({ hasText }) pattern. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix add to set test anchors"](https://github.com/justaddcl/sanbi/commit/4a1017ca1e6dc06ad4762a8aaf49d7a5adf0ebfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36816347)</sub>

<!-- /greptile_comment -->