### PR TITLE
[SWY-36] Add global search shell

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { Poppins } from "next/font/google";
 import type { Decorator, Preview } from "@storybook/nextjs-vite";
 
 import { Toaster } from "@components/ui/sonner";
@@ -6,14 +7,22 @@ import { TooltipProvider } from "@components/ui/tooltip";
 
 import "../src/styles/globals.css";
 
+const poppins = Poppins({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-poppins",
+});
+
 const LightModeFrame: React.FC<React.PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     document.documentElement.classList.remove("dark");
     document.documentElement.style.colorScheme = "light";
-    document.documentElement.style.setProperty(
-      "--font-poppins",
-      "Poppins, ui-sans-serif, system-ui, sans-serif",
-    );
+    document.documentElement.classList.add(poppins.variable);
+
+    return () => {
+      document.documentElement.classList.remove(poppins.variable);
+    };
   }, []);
 
   return (

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,8 +1,10 @@
 "use client";
+import Link from "next/link";
 import { Show, SignInButton, UserButton } from "@clerk/nextjs";
+import { Sidebar } from "@phosphor-icons/react/dist/ssr";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
+
 import { Button } from "@components/ui/button";
-import { MagnifyingGlass, Sidebar } from "@phosphor-icons/react/dist/ssr";
-import { Input } from "@components/ui/input";
 import {
   Sheet,
   SheetContent,
@@ -10,11 +12,10 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@components/ui/sheet";
-import Link from "next/link";
 import { GlobalNav } from "@components/GlobalNav";
 import { OrganizationHeader } from "@components/OrganizationHeader";
+import { Search } from "@modules/search";
 import { useSanbiStore } from "@/providers/sanbi-store-provider";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 
 export const Navbar: React.FC = () => {
   const { isMobileNavOpen, setIsMobileNavOpen } = useSanbiStore(
@@ -49,11 +50,7 @@ export const Navbar: React.FC = () => {
               </SheetContent>
             </Sheet>
           </div>
-          {/* TODO: The search input will be implemented in SWY-36 and SWY-37*/}
-          <div className="relative flex w-full items-center justify-self-center rounded-lg border border-slate-200 bg-white px-3 min-[1025px]:max-w-3xl">
-            <MagnifyingGlass size={16} className="" />
-            <Input placeholder="Search" className="border-none" />
-          </div>
+          <Search className="justify-self-center" />
           <div className="grid place-content-center min-[1025px]:block min-[1025px]:place-self-end">
             <UserButton />
           </div>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -8,9 +8,9 @@ import { Command as CommandPrimitive } from "cmdk";
 import {
   Dialog,
   DialogContent,
-  DialogTitle,
   type DialogContentProps,
   type DialogProps,
+  DialogTitle,
 } from "@components/ui/dialog";
 import { cn } from "@lib/utils";
 
@@ -38,6 +38,7 @@ type CommandDialogProps = DialogProps & {
   animated?: DialogContentProps["animated"];
   minimalPadding?: boolean;
   autoFocusInput?: boolean;
+  closeButton?: DialogContentProps["closeButton"];
   className?: string;
 };
 const CommandDialog: React.FC<CommandDialogProps> = ({
@@ -50,6 +51,7 @@ const CommandDialog: React.FC<CommandDialogProps> = ({
   animated,
   minimalPadding,
   autoFocusInput = false,
+  closeButton,
   className,
   ...props
 }) => {
@@ -107,6 +109,7 @@ const CommandDialog: React.FC<CommandDialogProps> = ({
           },
           className,
         )}
+        closeButton={closeButton}
         minimalPadding={minimalPadding}
         onOpenAutoFocus={(event) => {
           if (!autoFocusInput) {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -39,6 +39,7 @@ type CommandDialogProps = DialogProps & {
   minimalPadding?: boolean;
   autoFocusInput?: boolean;
   closeButton?: DialogContentProps["closeButton"];
+  onEscapeKeyDown?: DialogContentProps["onEscapeKeyDown"];
   className?: string;
 };
 const CommandDialog: React.FC<CommandDialogProps> = ({
@@ -52,6 +53,7 @@ const CommandDialog: React.FC<CommandDialogProps> = ({
   minimalPadding,
   autoFocusInput = false,
   closeButton,
+  onEscapeKeyDown,
   className,
   ...props
 }) => {
@@ -111,6 +113,7 @@ const CommandDialog: React.FC<CommandDialogProps> = ({
         )}
         closeButton={closeButton}
         minimalPadding={minimalPadding}
+        onEscapeKeyDown={onEscapeKeyDown}
         onOpenAutoFocus={(event) => {
           if (!autoFocusInput) {
             return;

--- a/src/modules/search/components/Search.stories.tsx
+++ b/src/modules/search/components/Search.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { Search } from "./Search";
+
+const meta = {
+  title: "Search/Search",
+  component: Search,
+  args: {
+    className: "max-w-3xl",
+  },
+} satisfies Meta<typeof Search>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="grid min-h-40 place-items-center bg-slate-50 p-6">
+      <Search {...args} />
+    </div>
+  ),
+};
+
+export const Compact: Story = {
+  render: (args) => (
+    <div className="w-80 bg-slate-50 p-4">
+      <Search {...args} className="max-w-none" />
+    </div>
+  ),
+};

--- a/src/modules/search/components/Search.tsx
+++ b/src/modules/search/components/Search.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import {
+  Command as CommandIcon,
+  MagnifyingGlass,
+  X,
+} from "@phosphor-icons/react/dist/ssr";
+
+import { Button } from "@components/ui/button";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandList,
+} from "@components/ui/command";
+import { HStack } from "@components/HStack";
+import { Text } from "@components/Text";
+import { cn } from "@lib/utils";
+
+type SearchProps = {
+  className?: string;
+};
+
+const MIN_SEARCH_LENGTH = 2;
+
+const SearchKeycap = ({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label?: string;
+}) => (
+  <kbd
+    className="inline-flex h-6 min-w-6 items-center justify-center rounded border border-slate-200 bg-slate-50 px-1.5 text-[11px] leading-none font-medium text-slate-500 shadow-[0_1px_0_rgba(15,23,42,0.04)]"
+    title={label}
+  >
+    {children}
+    {label && <span className="sr-only">{label}</span>}
+  </kbd>
+);
+
+export const Search: React.FC<SearchProps> = ({ className }) => {
+  const searchDescriptionId = useId();
+  const [open, setOpen] = useState(false);
+  const [searchInput, setSearchInput] = useState("");
+
+  const normalizedSearchInput = searchInput.trim();
+  const hasSearchableInput =
+    normalizedSearchInput.length >= MIN_SEARCH_LENGTH;
+  const closeOrClearLabel = searchInput ? "Clear search" : "Close search";
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== "k" || (!event.metaKey && !event.ctrlKey)) {
+        return;
+      }
+
+      event.preventDefault();
+      setOpen(true);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+
+    if (!nextOpen) {
+      setSearchInput("");
+    }
+  };
+
+  const handleSearchControlClick = () => {
+    if (searchInput) {
+      setSearchInput("");
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className={cn(
+          "focus-visible:ring-ring flex h-10 w-full items-center gap-3 rounded-lg border border-slate-200 bg-white px-3 text-left transition-colors hover:bg-slate-50 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden min-[1025px]:max-w-3xl",
+          className,
+        )}
+        aria-label="Open global search"
+        aria-describedby={searchDescriptionId}
+        onClick={() => setOpen(true)}
+      >
+        <MagnifyingGlass aria-hidden size={16} className="text-slate-500" />
+        <span className="min-w-0 flex-1 truncate text-sm text-slate-500">
+          Search songs and tags
+        </span>
+        <HStack aria-hidden className="hidden items-center gap-1 sm:flex">
+          <SearchKeycap label="Command">
+            <CommandIcon aria-hidden size={15} />
+          </SearchKeycap>
+          <SearchKeycap>K</SearchKeycap>
+        </HStack>
+      </button>
+      <span id={searchDescriptionId} className="sr-only">
+        Opens the global search dialog. Search results will be added in a
+        follow-up ticket.
+      </span>
+
+      <CommandDialog
+        open={open}
+        onOpenChange={handleOpenChange}
+        dialogTitle="Search Sanbi"
+        fixed
+        minimalPadding
+        shouldFilter={false}
+        autoFocusInput={open}
+        closeButton={null}
+        className="max-h-[calc(100dvh_-_24px)] overflow-hidden !pb-0"
+      >
+        <HStack className="items-center border-b border-slate-100 [&_[cmdk-input-wrapper]]:border-b-0">
+          <div className="min-w-0 flex-1">
+            <CommandInput
+              value={searchInput}
+              onValueChange={setSearchInput}
+              placeholder="Search songs or tags"
+              className="h-14 text-base md:text-base"
+              onKeyDown={(event) => {
+                if (event.key !== "Escape" || !searchInput) {
+                  return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+                setSearchInput("");
+              }}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="mr-3 h-9 w-9 shrink-0 text-slate-500 hover:text-slate-900"
+            aria-label={closeOrClearLabel}
+            title={closeOrClearLabel}
+            onClick={handleSearchControlClick}
+          >
+            <X aria-hidden size={16} />
+          </Button>
+        </HStack>
+
+        <CommandList className="max-h-[calc(100dvh_-_88px)] px-4 py-8">
+          <CommandEmpty>
+            <div className="mx-auto grid max-w-sm gap-1 text-center">
+              <Text style="header-small-semibold">
+                {hasSearchableInput ? "Ready to search" : "Start with a song or tag"}
+              </Text>
+              <Text style="body-small" className="text-slate-500">
+                {hasSearchableInput
+                  ? "Results will appear here once search is connected."
+                  : "Type at least two characters to search your library."}
+              </Text>
+            </div>
+          </CommandEmpty>
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+};

--- a/src/modules/search/components/Search.tsx
+++ b/src/modules/search/components/Search.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import {
   Command as CommandIcon,
   MagnifyingGlass,
@@ -44,11 +44,16 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
   const searchDescriptionId = useId();
   const [open, setOpen] = useState(false);
   const [searchInput, setSearchInput] = useState("");
+  const openRef = useRef(open);
 
   const normalizedSearchInput = searchInput.trim();
   const hasSearchableInput =
     normalizedSearchInput.length >= MIN_SEARCH_LENGTH;
   const closeOrClearLabel = searchInput ? "Clear search" : "Close search";
+
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -57,7 +62,7 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
       }
 
       event.preventDefault();
-      if (open) {
+      if (openRef.current) {
         setOpen(false);
         setSearchInput("");
         return;
@@ -69,7 +74,7 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
     window.addEventListener("keydown", handleKeyDown);
 
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [open]);
+  }, []);
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);

--- a/src/modules/search/components/Search.tsx
+++ b/src/modules/search/components/Search.tsx
@@ -48,9 +48,7 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
   const normalizedSearchInput = searchInput.trim();
   const hasSearchableInput =
     normalizedSearchInput.length >= MIN_SEARCH_LENGTH;
-  const closeOrClearLabel = normalizedSearchInput
-    ? "Clear search"
-    : "Close search";
+  const closeOrClearLabel = searchInput ? "Clear search" : "Close search";
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -127,6 +125,14 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
         shouldFilter={false}
         autoFocusInput={open}
         closeButton={null}
+        onEscapeKeyDown={(event) => {
+          if (!searchInput) {
+            return;
+          }
+
+          event.preventDefault();
+          setSearchInput("");
+        }}
         className="max-h-[calc(100dvh_-_24px)] overflow-hidden !pb-0"
       >
         <HStack className="items-center border-b border-slate-100 [&_[cmdk-input-wrapper]]:border-b-0">
@@ -136,15 +142,6 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
               onValueChange={setSearchInput}
               placeholder="Search songs or tags"
               className="h-14 text-base md:text-base"
-              onKeyDown={(event) => {
-                if (event.key !== "Escape" || !normalizedSearchInput) {
-                  return;
-                }
-
-                event.preventDefault();
-                event.stopPropagation();
-                setSearchInput("");
-              }}
             />
           </div>
           <Button

--- a/src/modules/search/components/Search.tsx
+++ b/src/modules/search/components/Search.tsx
@@ -48,7 +48,9 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
   const normalizedSearchInput = searchInput.trim();
   const hasSearchableInput =
     normalizedSearchInput.length >= MIN_SEARCH_LENGTH;
-  const closeOrClearLabel = searchInput ? "Clear search" : "Close search";
+  const closeOrClearLabel = normalizedSearchInput
+    ? "Clear search"
+    : "Close search";
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -57,13 +59,19 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
       }
 
       event.preventDefault();
+      if (open) {
+        setOpen(false);
+        setSearchInput("");
+        return;
+      }
+
       setOpen(true);
     };
 
     window.addEventListener("keydown", handleKeyDown);
 
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [open]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -74,7 +82,7 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
   };
 
   const handleSearchControlClick = () => {
-    if (searchInput) {
+    if (normalizedSearchInput) {
       setSearchInput("");
       return;
     }
@@ -129,7 +137,7 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
               placeholder="Search songs or tags"
               className="h-14 text-base md:text-base"
               onKeyDown={(event) => {
-                if (event.key !== "Escape" || !searchInput) {
+                if (event.key !== "Escape" || !normalizedSearchInput) {
                   return;
                 }
 

--- a/src/modules/search/components/index.ts
+++ b/src/modules/search/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./Search";

--- a/src/modules/search/index.ts
+++ b/src/modules/search/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";


### PR DESCRIPTION
## Background
- Linear: [SWY-36 Global search shell](https://linear.app/paranoid-android/issue/SWY-36/global-search-shell)
- This PR adds the app-shell portion of global search: a navbar search trigger that opens a command-style dialog, supports keyboard launch, and leaves result fetching for SWY-37.
- This keeps the PR focused on the visual/search-shell behavior from the prototype while preserving the larger search-result and quick-action work for follow-up tickets.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced global search functionality accessible via Cmd/Ctrl+K keyboard shortcut for quick access to the search dialog
  * Replaced navbar search UI with a dedicated Search component featuring improved interaction patterns
  * Optimized font configuration system for better performance and styling consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Adds a `Search` module with the header trigger, Cmd/Ctrl+K shortcut, focused command dialog, clear/close behavior, empty threshold states, and Storybook coverage.
- Replaces the placeholder navbar search input with the new search shell.
- Allows `CommandDialog` consumers to override the default close button so the search dialog can use a single input-row control.
- Loads Poppins through `next/font/google` in Storybook so stories match the app typography.

## How to test
- Sign in to the web app and verify the header search control appears between the mobile nav button and user menu.
- Click the search control and verify the search dialog opens with focus in the input.
- Press Cmd+K on macOS or Ctrl+K on other platforms and verify the dialog opens.
- Type fewer than two characters, then two or more characters, and verify the shell state changes without showing real results.
- Use the X button and Escape key to clear/close the dialog, then check the `Search/Search` Storybook story uses the same Poppins typography as the app.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the global search shell: a navbar trigger button, a `CommandDialog`-based palette with a controlled input, Cmd/Ctrl+K shortcut support, two-stage Escape-to-clear behavior, and Storybook coverage. It also threads `closeButton` and `onEscapeKeyDown` passthrough props through `CommandDialog` and switches Storybook's Poppins font loading to `next/font/google`.

- **`Search` component** — new module under `src/modules/search` with `openRef`-based keyboard toggle, `handleOpenChange` cleanup, and empty/threshold states inside a `CommandList`.
- **`CommandDialog` extension** — `closeButton` and `onEscapeKeyDown` props are added so the search dialog can own its own close control instead of using the default overlay X.
- **Storybook font fix** — `LightModeFrame` now uses `next/font/google` to inject the real `--font-poppins` variable rather than a hard-coded fallback stack.

<h3>Confidence Score: 5/5</h3>

Safe to merge — new UI shell with no data persistence or auth changes; the one close-path inconsistency only affects whitespace-only input.

All changes are additive UI work. The keyboard shortcut, two-stage Escape clear, open/close state management, and CommandDialog prop additions are all correctly implemented. The one close-path inconsistency (X button bypassing handleOpenChange for whitespace-only input) is a narrow edge case that leaves transient visual noise on reopen but causes no data loss or broken flows.

src/modules/search/components/Search.tsx — the handleSearchControlClick close branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/modules/search/components/Search.tsx | New Search component with navbar trigger, Cmd/Ctrl+K shortcut, controlled dialog, and two-stage Escape/clear behaviour. Minor inconsistency: handleSearchControlClick calls setOpen(false) directly rather than handleOpenChange(false), leaving stale whitespace in searchInput on X-close. |
| src/components/ui/command.tsx | Adds closeButton and onEscapeKeyDown passthrough props to CommandDialog, threaded cleanly through to DialogContent; no logic changes to existing behaviour. |
| src/components/Navbar/Navbar.tsx | Removes placeholder search input and import noise, replaces with Search component; straightforward swap with no functional regressions. |
| .storybook/preview.tsx | Switches from a manual CSS-variable assignment to next/font/google Poppins, adding a proper cleanup on unmount; cleaner and more representative of the app's real font pipeline. |
| src/modules/search/components/Search.stories.tsx | Adds Default and Compact Storybook stories for the Search component; well-scoped and covers both unconstrained and width-limited layouts. |
| src/modules/search/index.ts | New module barrel export; correct pattern. |
| src/modules/search/components/index.ts | New component barrel export; correct pattern. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User]) -->|clicks trigger button| B[setOpen true]
    A -->|Cmd/Ctrl+K| C{openRef.current?}
    C -->|yes| D[setOpen false\nsetSearchInput '']
    C -->|no| B
    B --> E[Dialog opens\nautoFocusInput focuses input]
    E --> F{User interaction}
    F -->|types input| G[setSearchInput value]
    G --> H{normalizedSearchInput\nlength >= 2?}
    H -->|yes| I[Show 'Ready to search' state]
    H -->|no| J[Show 'Start with a song' state]
    F -->|clicks X button| K{normalizedSearchInput\ntruthy?}
    K -->|yes| L[setSearchInput ''\ndialog stays open]
    K -->|no| M[setOpen false\n⚠️ searchInput not cleared]
    F -->|presses Escape| N{searchInput\ntruthy?}
    N -->|yes| O[preventDefault\nsetSearchInput '']
    N -->|no| P[Dialog closes\nhandleOpenChange false\nsetSearchInput '']
    F -->|clicks overlay| P
    D --> Q([Dialog closed])
    M --> Q
    P --> Q
```

<sub>Reviews (3): Last reviewed commit: ["Avoid search shortcut listener churn"](https://github.com/justaddcl/sanbi/commit/6c15ae319f1bdb8cab86f03e81c4e23614dfd095) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36829616)</sub>

<!-- /greptile_comment -->