### PR TITLE
[SWY-172] Add global search quick actions

### DIFF
--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -79,6 +79,9 @@ export default function SetListPage({
     useState<boolean>(false);
   const [prePopulatedSetSectionId, setPrePopulatedSetSectionId] =
     useState<ConfigureSongForSetProps["prePopulatedSetSectionId"]>(undefined);
+  const [preSelectedSongId, setPreSelectedSongId] = useState<string | null>(
+    null,
+  );
   const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] =
     useState<boolean>(false);
   const [newSetSectionType, setNewSetSectionType] =
@@ -94,6 +97,7 @@ export default function SetListPage({
       searchParams.addSongDialogOpen,
     );
     const setSectionIdFromUrl = getSearchParamValue(searchParams.setSectionId);
+    const songIdFromUrl = getSearchParamValue(searchParams.songId);
 
     const isSongSearchDialogOpenFromUrl = [null, undefined, "false", "0"].every(
       (falsyValue) => addSongDialogOpen !== falsyValue,
@@ -101,6 +105,7 @@ export default function SetListPage({
 
     setIsSongSearchDialogOpen(isSongSearchDialogOpenFromUrl);
     setPrePopulatedSetSectionId(setSectionIdFromUrl);
+    setPreSelectedSongId(songIdFromUrl ?? null);
   }, [searchParams]);
 
   const validateParams = useCallback(() => {
@@ -374,6 +379,7 @@ export default function SetListPage({
         existingSetSections={setData.sections}
         setId={setData.id}
         prePopulatedSetSectionId={prePopulatedSetSectionId}
+        preSelectedSongId={preSelectedSongId}
       />
     </PageContentContainer>
   );

--- a/src/modules/search/components/Search.tsx
+++ b/src/modules/search/components/Search.tsx
@@ -21,6 +21,7 @@ import {
   GLOBAL_SEARCH_RESULT_COUNT_LIMIT,
   type SearchFilter,
 } from "@modules/search/utils/getVisibleGlobalSearchResults";
+import { AddSongToSetDialog } from "@modules/songs/forms/AddSongToSet/components/AddSongToSetDialog";
 import { trpc } from "@lib/trpc";
 import { cn } from "@lib/utils";
 
@@ -28,7 +29,7 @@ import { SearchFilterControls } from "./SearchFilterControls";
 import { SearchResultsList } from "./SearchResultsList";
 import { SearchShortcutLegend } from "./SearchShortcutLegend";
 import { SearchTrigger } from "./SearchTrigger";
-import { type SearchToggleFilter } from "./types";
+import { type SearchSongResult, type SearchToggleFilter } from "./types";
 
 type SearchProps = {
   className?: string;
@@ -38,7 +39,7 @@ const MIN_SEARCH_LENGTH = 2;
 const SEARCH_DEBOUNCE_DELAY = 300;
 
 export const Search: React.FC<SearchProps> = ({ className }) => {
-  const params = useParams<{ organization?: string }>();
+  const params = useParams<{ organization?: string; setId?: string }>();
   const router = useRouter();
   const searchDescriptionId = useId();
   const [open, setOpen] = useState(false);
@@ -53,9 +54,13 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
     songs: false,
     tags: false,
   });
+  const [songToAddToSet, setSongToAddToSet] = useState<SearchSongResult | null>(
+    null,
+  );
   const openRef = useRef(open);
 
   const organizationId = params.organization;
+  const currentSetId = params.setId;
   const normalizedSearchInput = debouncedSearchInput.trim();
   const normalizedSearchQuery = normalizedSearchInput.toLowerCase();
   const hasSearchableInput = searchInput.trim().length >= MIN_SEARCH_LENGTH;
@@ -230,6 +235,32 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
     router.push(`/${organizationId}/songs/${songId}`);
   };
 
+  const addSongToCurrentSet = (result: SearchSongResult) => {
+    if (!organizationId || !currentSetId) {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    params.set("addSongDialogOpen", "1");
+    params.set("songId", result.songId);
+
+    handleOpenChange(false);
+    router.push(`/${organizationId}/sets/${currentSetId}?${params}`);
+  };
+
+  const addSongToSet = (result: SearchSongResult) => {
+    handleOpenChange(false);
+    setSongToAddToSet(result);
+  };
+
+  const addSongToSetDialogSong = songToAddToSet
+    ? {
+        id: songToAddToSet.songId,
+        name: songToAddToSet.name,
+        preferredKey: songToAddToSet.preferredKey,
+      }
+    : null;
+
   return (
     <>
       <SearchTrigger
@@ -296,6 +327,10 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
             isError={isSearchError}
             isLoading={shouldShowLoading}
             normalizedSearchInput={normalizedSearchInput}
+            onAddSongToCurrentSet={
+              currentSetId ? addSongToCurrentSet : undefined
+            }
+            onAddSongToSet={addSongToSet}
             onSongSelect={openSong}
             resultCountLabel={searchResultCountLabel}
             visibleResultCount={visibleResultCount}
@@ -307,6 +342,18 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
           <SearchShortcutLegend escapeShortcutLabel={escapeShortcutLabel} />
         )}
       </CommandDialog>
+      {addSongToSetDialogSong && (
+        <AddSongToSetDialog
+          song={addSongToSetDialogSong}
+          open={!!songToAddToSet}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSongToAddToSet(null);
+            }
+          }}
+          trigger={null}
+        />
+      )}
     </>
   );
 };

--- a/src/modules/search/components/Search.tsx
+++ b/src/modules/search/components/Search.tsx
@@ -37,6 +37,7 @@ type SearchProps = {
 
 const MIN_SEARCH_LENGTH = 2;
 const SEARCH_DEBOUNCE_DELAY = 300;
+const DIALOG_EXIT_ANIMATION_DELAY = 200;
 
 export const Search: React.FC<SearchProps> = ({ className }) => {
   const params = useParams<{ organization?: string; setId?: string }>();
@@ -57,7 +58,12 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
   const [songToAddToSet, setSongToAddToSet] = useState<SearchSongResult | null>(
     null,
   );
+  const [isAddSongToSetDialogOpen, setIsAddSongToSetDialogOpen] =
+    useState(false);
   const openRef = useRef(open);
+  const clearAddSongToSetDialogTimeoutRef = useRef<number | undefined>(
+    undefined,
+  );
 
   const organizationId = params.organization;
   const currentSetId = params.setId;
@@ -174,6 +180,15 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
     openRef.current = open;
   }, [open]);
 
+  useEffect(
+    () => () => {
+      if (clearAddSongToSetDialogTimeoutRef.current) {
+        window.clearTimeout(clearAddSongToSetDialogTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
@@ -240,17 +255,41 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
       return;
     }
 
-    const params = new URLSearchParams(window.location.search);
-    params.set("addSongDialogOpen", "1");
-    params.set("songId", result.songId);
+    const searchParams = new URLSearchParams(window.location.search);
+    searchParams.set("addSongDialogOpen", "1");
+    searchParams.set("songId", result.songId);
 
     handleOpenChange(false);
-    router.push(`/${organizationId}/sets/${currentSetId}?${params}`);
+    router.push(`/${organizationId}/sets/${currentSetId}?${searchParams}`);
   };
 
   const addSongToSet = (result: SearchSongResult) => {
+    if (clearAddSongToSetDialogTimeoutRef.current) {
+      window.clearTimeout(clearAddSongToSetDialogTimeoutRef.current);
+      clearAddSongToSetDialogTimeoutRef.current = undefined;
+    }
+
     handleOpenChange(false);
     setSongToAddToSet(result);
+    setIsAddSongToSetDialogOpen(true);
+  };
+
+  const handleAddSongToSetDialogOpenChange = (nextOpen: boolean) => {
+    setIsAddSongToSetDialogOpen(nextOpen);
+
+    if (clearAddSongToSetDialogTimeoutRef.current) {
+      window.clearTimeout(clearAddSongToSetDialogTimeoutRef.current);
+      clearAddSongToSetDialogTimeoutRef.current = undefined;
+    }
+
+    if (nextOpen) {
+      return;
+    }
+
+    clearAddSongToSetDialogTimeoutRef.current = window.setTimeout(() => {
+      setSongToAddToSet(null);
+      clearAddSongToSetDialogTimeoutRef.current = undefined;
+    }, DIALOG_EXIT_ANIMATION_DELAY);
   };
 
   const addSongToSetDialogSong = songToAddToSet
@@ -345,12 +384,8 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
       {addSongToSetDialogSong && (
         <AddSongToSetDialog
           song={addSongToSetDialogSong}
-          open={!!songToAddToSet}
-          onOpenChange={(open) => {
-            if (!open) {
-              setSongToAddToSet(null);
-            }
-          }}
+          open={isAddSongToSetDialogOpen}
+          onOpenChange={handleAddSongToSetDialogOpenChange}
           trigger={null}
         />
       )}

--- a/src/modules/search/components/SearchResultActions.tsx
+++ b/src/modules/search/components/SearchResultActions.tsx
@@ -1,0 +1,95 @@
+import {
+  ArrowSquareOutIcon,
+  DotsThreeIcon,
+  ListPlusIcon,
+  PlusIcon,
+} from "@phosphor-icons/react/dist/ssr";
+
+import { Button } from "@components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@components/ui/dropdown-menu";
+
+import { type SearchSongResult } from "./types";
+
+type SearchResultActionsProps = {
+  canAddToCurrentSet: boolean;
+  open: boolean;
+  result: SearchSongResult;
+  onAddToCurrentSet: (result: SearchSongResult) => void;
+  onAddToSet: (result: SearchSongResult) => void;
+  onActionSelect: () => void;
+  onOpenChange: (open: boolean) => void;
+  onOpenSong: (songId: string) => void;
+};
+
+export const SearchResultActions = ({
+  canAddToCurrentSet,
+  open,
+  result,
+  onAddToCurrentSet,
+  onAddToSet,
+  onActionSelect,
+  onOpenChange,
+  onOpenSong,
+}: SearchResultActionsProps) => (
+  <DropdownMenu open={open} onOpenChange={onOpenChange}>
+    <DropdownMenuTrigger asChild>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label={`Open actions for ${result.name}`}
+        title={`Open actions for ${result.name}`}
+        className="ml-2 h-8 w-8 shrink-0 text-slate-500 hover:text-slate-900 data-[state=open]:bg-slate-100"
+        onClick={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <DotsThreeIcon aria-hidden size={16} />
+      </Button>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent
+      align="end"
+      side="bottom"
+      className="min-w-52"
+      data-search-result-actions-menu="true"
+    >
+      <DropdownMenuItem
+        onSelect={() => {
+          onActionSelect();
+          onOpenSong(result.songId);
+        }}
+      >
+        <ArrowSquareOutIcon aria-hidden size={16} className="mr-2" />
+        Open song
+        <DropdownMenuShortcut>Enter</DropdownMenuShortcut>
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      {canAddToCurrentSet && (
+        <DropdownMenuItem
+          onSelect={() => {
+            onActionSelect();
+            onAddToCurrentSet(result);
+          }}
+        >
+          <ListPlusIcon aria-hidden size={16} className="mr-2" />
+          Add to current set
+        </DropdownMenuItem>
+      )}
+      <DropdownMenuItem
+        onSelect={() => {
+          onActionSelect();
+          onAddToSet(result);
+        }}
+      >
+        <PlusIcon aria-hidden size={16} className="mr-2" />
+        Add to a set
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);

--- a/src/modules/search/components/SearchResultsList.tsx
+++ b/src/modules/search/components/SearchResultsList.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { MusicNoteSimpleIcon, TagIcon } from "@phosphor-icons/react/dist/ssr";
 
 import { CommandItem, CommandList } from "@components/ui/command";
@@ -7,6 +7,7 @@ import { type SearchFilter } from "@modules/search/utils/getVisibleGlobalSearchR
 import { cn } from "@lib/utils";
 
 import { SearchGroupHeading } from "./SearchGroupHeading";
+import { SearchResultActions } from "./SearchResultActions";
 import { SearchResultGroup } from "./SearchResultGroup";
 import { SearchSongRow, SearchTagMatchedSongRow } from "./SearchResultRows";
 import { SearchResultsEmptyState } from "./SearchResultsEmptyState";
@@ -21,6 +22,8 @@ type SearchResultsListProps = {
   isError: boolean;
   isLoading: boolean;
   normalizedSearchInput: string;
+  onAddSongToCurrentSet?: (result: SearchSongResult) => void;
+  onAddSongToSet: (result: SearchSongResult) => void;
   onSongSelect: (songId: string) => void;
   resultCountLabel: string;
   visibleResultCount: number;
@@ -40,6 +43,8 @@ export const SearchResultsList = ({
   isError,
   isLoading,
   normalizedSearchInput,
+  onAddSongToCurrentSet,
+  onAddSongToSet,
   onSongSelect,
   resultCountLabel,
   visibleResultCount,
@@ -47,6 +52,65 @@ export const SearchResultsList = ({
   visibleTagResults,
 }: SearchResultsListProps) => {
   const shouldShowResultGroupHeadings = activeFilter === "all";
+  const canAddToCurrentSet = !!onAddSongToCurrentSet;
+  const [openActionsSongId, setOpenActionsSongId] = useState<string | null>(
+    null,
+  );
+  const listRef = useRef<HTMLDivElement>(null);
+  const suppressNextSongSelectRef = useRef(false);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (openActionsSongId && event.key === "Enter" && !event.shiftKey) {
+        const target = event.target;
+        if (
+          target instanceof Element &&
+          target.closest("[data-search-result-actions-menu='true']")
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (event.key !== "Enter" || !event.shiftKey) {
+        return;
+      }
+
+      const selectedItem = listRef.current?.querySelector(
+        "[cmdk-item][data-selected='true'][data-song-id]",
+      );
+
+      if (!(selectedItem instanceof HTMLElement)) {
+        return;
+      }
+
+      const selectedSongId = selectedItem.dataset.songId;
+      if (!selectedSongId) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      setOpenActionsSongId(selectedSongId);
+    };
+
+    document.addEventListener("keydown", handleKeyDown, { capture: true });
+
+    return () =>
+      document.removeEventListener("keydown", handleKeyDown, {
+        capture: true,
+      });
+  }, [openActionsSongId]);
+
+  const suppressNextSongSelect = () => {
+    suppressNextSongSelectRef.current = true;
+    window.setTimeout(() => {
+      suppressNextSongSelectRef.current = false;
+    }, 0);
+  };
 
   const renderSongResultItem = ({
     keyPrefix,
@@ -64,14 +128,36 @@ export const SearchResultsList = ({
       value={`${valuePrefix}-${result.songId}`}
       data-song-id={result.songId}
       className={resultItemClassName}
-      onSelect={() => onSongSelect(result.songId)}
+      onSelect={() => {
+        if (openActionsSongId || suppressNextSongSelectRef.current) {
+          suppressNextSongSelectRef.current = false;
+          return;
+        }
+
+        onSongSelect(result.songId);
+      }}
     >
       {row}
+      <SearchResultActions
+        canAddToCurrentSet={canAddToCurrentSet}
+        open={openActionsSongId === result.songId}
+        result={result}
+        onAddToCurrentSet={onAddSongToCurrentSet ?? onAddSongToSet}
+        onAddToSet={onAddSongToSet}
+        onActionSelect={suppressNextSongSelect}
+        onOpenChange={(open) => {
+          setOpenActionsSongId(open ? result.songId : null);
+        }}
+        onOpenSong={onSongSelect}
+      />
     </CommandItem>
   );
 
   return (
-    <CommandList className="max-h-[calc(100dvh_-_132px)] px-2 py-2 sm:max-h-[min(520px,calc(100dvh_-_180px))]">
+    <CommandList
+      ref={listRef}
+      className="max-h-[calc(100dvh_-_132px)] px-2 py-2 sm:max-h-[min(520px,calc(100dvh_-_180px))]"
+    >
       {isLoading && <SearchResultsLoadingState />}
       {!isLoading && isError && <SearchResultsErrorState />}
       {!isLoading && !isError && visibleResultCount === 0 && (

--- a/src/modules/search/components/SearchResultsList.tsx
+++ b/src/modules/search/components/SearchResultsList.tsx
@@ -112,6 +112,26 @@ export const SearchResultsList = ({
     }, 0);
   };
 
+  useEffect(() => {
+    if (!openActionsSongId) {
+      return;
+    }
+
+    const isOpenActionSongVisible =
+      visibleSongResults.some((result) => result.songId === openActionsSongId) ||
+      visibleTagResults.some((result) => result.songId === openActionsSongId);
+
+    if (isOpenActionSongVisible) {
+      return;
+    }
+
+    const clearStaleOpenActions = window.setTimeout(() => {
+      setOpenActionsSongId(null);
+    }, 0);
+
+    return () => window.clearTimeout(clearStaleOpenActions);
+  }, [openActionsSongId, visibleSongResults, visibleTagResults]);
+
   const renderSongResultItem = ({
     keyPrefix,
     result,

--- a/src/modules/search/components/SearchShortcutLegend.tsx
+++ b/src/modules/search/components/SearchShortcutLegend.tsx
@@ -73,6 +73,21 @@ export const SearchShortcutLegend = ({
         ]}
         label="Open"
       />
+      <SearchShortcutHint
+        keys={[
+          { content: "Shift", label: "Shift" },
+          {
+            content: (
+              <ArrowElbowDownLeftIcon
+                aria-hidden
+                size={SHORTCUT_ENTER_ICON_SIZE}
+              />
+            ),
+            label: "Enter",
+          },
+        ]}
+        label="Actions"
+      />
     </HStack>
     <SearchShortcutHint
       keys={[{ content: "Esc", label: "Escape" }]}

--- a/src/modules/search/components/__tests__/SearchResultsList.test.tsx
+++ b/src/modules/search/components/__tests__/SearchResultsList.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createSearchSongResultFixture } from "@testUtils/models/search/fixtures";
 
 import { Command } from "@components/ui/command";
 
@@ -11,16 +12,7 @@ class ResizeObserverMock {
   disconnect = jest.fn();
 }
 
-const songResult: SearchSongResult = {
-  songId: "4af1ad2a-5aac-4a35-91f9-f51edc376e03",
-  name: "Amazing Grace",
-  preferredKey: "g",
-  isArchived: false,
-  similarityScore: 0.9,
-  tags: ["Communion", "Classic"],
-  matchedTags: [],
-  lastPlayedDate: null,
-};
+const songResult = createSearchSongResultFixture();
 
 const renderSearchResultsList = ({
   onAddSongToCurrentSet,

--- a/src/modules/search/components/__tests__/SearchResultsList.test.tsx
+++ b/src/modules/search/components/__tests__/SearchResultsList.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { Command } from "@components/ui/command";
+
+import { SearchResultsList } from "../SearchResultsList";
+import { type SearchSongResult } from "../types";
+
+class ResizeObserverMock {
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+}
+
+const songResult: SearchSongResult = {
+  songId: "4af1ad2a-5aac-4a35-91f9-f51edc376e03",
+  name: "Amazing Grace",
+  preferredKey: "g",
+  isArchived: false,
+  similarityScore: 0.9,
+  tags: ["Communion", "Classic"],
+  matchedTags: [],
+  lastPlayedDate: null,
+};
+
+const renderSearchResultsList = ({
+  onAddSongToCurrentSet,
+  onAddSongToSet = jest.fn(),
+  onSongSelect = jest.fn(),
+}: {
+  onAddSongToCurrentSet?: (result: SearchSongResult) => void;
+  onAddSongToSet?: (result: SearchSongResult) => void;
+  onSongSelect?: (songId: string) => void;
+} = {}) => {
+  render(
+    <Command shouldFilter={false}>
+      <SearchResultsList
+        activeFilter="songs"
+        emptyResultsMessage="No results"
+        hasOverflow={false}
+        isError={false}
+        isLoading={false}
+        normalizedSearchInput="grace"
+        onAddSongToCurrentSet={onAddSongToCurrentSet}
+        onAddSongToSet={onAddSongToSet}
+        onSongSelect={onSongSelect}
+        resultCountLabel="1"
+        visibleResultCount={1}
+        visibleSongResults={[songResult]}
+        visibleTagResults={[]}
+      />
+    </Command>,
+  );
+
+  const resultItem = document.querySelector(
+    `[data-song-id="${songResult.songId}"]`,
+  );
+  if (!(resultItem instanceof HTMLElement)) {
+    throw new Error("Could not find rendered search result item");
+  }
+
+  return {
+    onAddSongToCurrentSet,
+    onAddSongToSet,
+    onSongSelect,
+    resultItem,
+  };
+};
+
+describe("SearchResultsList", () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+      writable: true,
+    });
+
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: jest.fn(),
+      writable: true,
+    });
+  });
+
+  it("opens the selected result action menu with Shift+Enter", async () => {
+    const { resultItem } = renderSearchResultsList();
+    resultItem.setAttribute("data-selected", "true");
+
+    fireEvent.keyDown(document, { key: "Enter", shiftKey: true });
+
+    expect(
+      await screen.findByRole("menuitem", { name: /add to a set/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not open the selected song while the action menu owns Enter", async () => {
+    const onSongSelect = jest.fn();
+    const { resultItem } = renderSearchResultsList({ onSongSelect });
+    resultItem.setAttribute("data-selected", "true");
+
+    fireEvent.keyDown(document, { key: "Enter", shiftKey: true });
+    await screen.findByRole("menuitem", { name: /add to a set/i });
+
+    fireEvent.keyDown(document, { key: "Enter" });
+    fireEvent.click(resultItem);
+
+    expect(onSongSelect).not.toHaveBeenCalled();
+  });
+
+  it("selects the add-to-set action without opening the song", async () => {
+    const onAddSongToSet = jest.fn();
+    const onSongSelect = jest.fn();
+    const { resultItem } = renderSearchResultsList({
+      onAddSongToSet,
+      onSongSelect,
+    });
+    resultItem.setAttribute("data-selected", "true");
+
+    fireEvent.keyDown(document, { key: "Enter", shiftKey: true });
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: /add to a set/i }),
+    );
+
+    expect(onAddSongToSet).toHaveBeenCalledWith(songResult);
+    expect(onSongSelect).not.toHaveBeenCalled();
+  });
+
+  it("shows the current-set action when current set context is available", async () => {
+    const onAddSongToCurrentSet = jest.fn();
+    const { resultItem } = renderSearchResultsList({
+      onAddSongToCurrentSet,
+    });
+    resultItem.setAttribute("data-selected", "true");
+
+    fireEvent.keyDown(document, { key: "Enter", shiftKey: true });
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: /add to current set/i }),
+    );
+
+    expect(onAddSongToCurrentSet).toHaveBeenCalledWith(songResult);
+  });
+
+  it("does not open an action menu when no result is selected", async () => {
+    const { resultItem } = renderSearchResultsList();
+    resultItem.removeAttribute("data-selected");
+
+    fireEvent.keyDown(document, { key: "Enter", shiftKey: true });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("menuitem", { name: /add to a set/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
+++ b/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { type Dispatch, type SetStateAction, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 
 import { CommandDialog } from "@components/ui/command";
@@ -10,6 +10,7 @@ import {
   SongSearch,
   type SongSearchResult,
 } from "@modules/songs/components/SongSearch";
+import { trpc } from "@lib/trpc";
 import { type SetSectionWithSongs } from "@lib/types";
 
 import {
@@ -27,6 +28,7 @@ type SongSearchDialogProps = {
   existingSetSections: SetSectionWithSongs[];
   setId: string;
   prePopulatedSetSectionId?: ConfigureSongForSetProps["prePopulatedSetSectionId"];
+  preSelectedSongId?: string | null;
 };
 
 export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
@@ -35,8 +37,10 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
   existingSetSections,
   setId,
   prePopulatedSetSectionId,
+  preSelectedSongId,
 }) => {
   const searchParams = useSearchParams();
+  const params = useParams<{ organization?: string }>();
   const { userId, isLoaded } = useAuth();
   const router = useRouter();
 
@@ -44,6 +48,33 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
   const [selectedSong, setSelectedSong] = useState<SongSearchResult | null>(
     null,
   );
+  const [dismissedPreSelectedSongId, setDismissedPreSelectedSongId] = useState<
+    string | null
+  >(null);
+  const { data: preSelectedSong, isLoading: isPreSelectedSongLoading } =
+    trpc.song.get.useQuery(
+      {
+        organizationId: params.organization ?? "",
+        songId: preSelectedSongId ?? "",
+      },
+      {
+        enabled: open && !!preSelectedSongId && !!params.organization,
+      },
+    );
+
+  const preSelectedSongResult =
+    preSelectedSong && dismissedPreSelectedSongId !== preSelectedSongId
+      ? {
+          songId: preSelectedSong.id,
+          name: preSelectedSong.name,
+          preferredKey: preSelectedSong.preferredKey,
+          isArchived: preSelectedSong.isArchived,
+          similarityScore: 0,
+          lastPlayedDate: null,
+        }
+      : null;
+  const activeSelectedSong = selectedSong ?? preSelectedSongResult;
+  const activeDialogStep = activeSelectedSong ? "configure" : dialogStep;
 
   if (!userId) {
     router.replace("/");
@@ -66,6 +97,10 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
       if (params.has("setSectionId")) {
         params.delete("setSectionId");
       }
+
+      if (params.has("songId")) {
+        params.delete("songId");
+      }
     }
 
     const queryString = params.toString();
@@ -84,6 +119,22 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
     }
   };
 
+  const handleDialogStepChange: Dispatch<
+    SetStateAction<SongSearchDialogSteps>
+  > = (nextStepValue) => {
+    const nextStep =
+      typeof nextStepValue === "function"
+        ? nextStepValue(dialogStep)
+        : nextStepValue;
+
+    if (nextStep === "search") {
+      setSelectedSong(null);
+      setDismissedPreSelectedSongId(preSelectedSongId ?? null);
+    }
+
+    setDialogStep(nextStep);
+  };
+
   return (
     <CommandDialog
       dialogTitle="Search songs"
@@ -93,25 +144,29 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
 
         if (!open) {
           setSelectedSong(null);
+          setDismissedPreSelectedSongId(null);
         }
 
         setDialogStep("search");
       }}
       shouldFilter={false}
       fixed
-      hasDialogContentComponentStyling={dialogStep === "configure"}
-      animated={dialogStep !== "configure"}
+      hasDialogContentComponentStyling={activeDialogStep === "configure"}
+      animated={activeDialogStep !== "configure"}
       minimalPadding
-      autoFocusInput={open && dialogStep === "search"}
+      autoFocusInput={open && activeDialogStep === "search"}
     >
-      {dialogStep === "search" && (
+      {activeDialogStep === "search" && isPreSelectedSongLoading && (
+        <Text>Loading song...</Text>
+      )}
+      {activeDialogStep === "search" && !isPreSelectedSongLoading && (
         <SongSearch onSongSelect={handleSongSelect} />
       )}
-      {dialogStep === "configure" && !!selectedSong && (
+      {activeDialogStep === "configure" && !!activeSelectedSong && (
         <ConfigureSongForSet
           existingSetSections={existingSetSections}
-          selectedSong={selectedSong}
-          setDialogStep={setDialogStep}
+          selectedSong={activeSelectedSong}
+          setDialogStep={handleDialogStepChange}
           onSubmit={() => {
             setOpen(false);
           }}

--- a/src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialog.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialog.tsx
@@ -226,11 +226,13 @@ export const AddSongToSetDialog: React.FC<AddSongToSetDialogProps> = ({
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={(open) => {
-        setDialogOpen(open);
-        if (!open) {
-          resetDialog(open);
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          resetDialog();
+          return;
         }
+
+        setDialogOpen(true);
       }}
     >
       {trigger !== null && (

--- a/src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialog.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialog.tsx
@@ -55,14 +55,25 @@ const contentMap: Record<
   },
 };
 
+export type AddSongToSetDialogSong = Pick<
+  inferProcedureOutput<AppRouter["song"]["get"]>,
+  "id" | "name" | "preferredKey"
+>;
+
 type AddSongToSetDialogProps = {
-  song: inferProcedureOutput<AppRouter["song"]["get"]>;
+  song: AddSongToSetDialogSong;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: React.ReactNode | null;
 };
 
 export const AddSongToSetDialog: React.FC<AddSongToSetDialogProps> = ({
   song,
+  open,
+  onOpenChange,
+  trigger,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [currentStep, setCurrentStep] = useState(
     AddSongToSetDialogStep.SELECT_SET,
   );
@@ -81,6 +92,15 @@ export const AddSongToSetDialog: React.FC<AddSongToSetDialogProps> = ({
   const [selectedKey, setSelectedKey] = useState<SongKey | null>(null);
 
   const totalSteps = Object.keys(AddSongToSetDialogStep).length / 2; // this is divided by 2 since the length property combines the number of keys and values
+  const isOpen = open ?? uncontrolledOpen;
+
+  const setDialogOpen = (nextOpen: boolean) => {
+    if (open === undefined) {
+      setUncontrolledOpen(nextOpen);
+    }
+
+    onOpenChange?.(nextOpen);
+  };
 
   const goBack = () => {
     if (currentStep === AddSongToSetDialogStep.SELECT_SET && isCreatingNewSet) {
@@ -97,8 +117,8 @@ export const AddSongToSetDialog: React.FC<AddSongToSetDialogProps> = ({
     }
   };
 
-  const resetDialog = () => {
-    setIsOpen(false);
+  const resetDialog = (nextOpen = false) => {
+    setDialogOpen(nextOpen);
     setIsCreatingNewSet(false);
     setCurrentStep(AddSongToSetDialogStep.SELECT_SET);
     setSelectedSet(null);
@@ -194,7 +214,6 @@ export const AddSongToSetDialog: React.FC<AddSongToSetDialogProps> = ({
             orderedSongIds={updatedSetSectionOrderedSongIds}
             songKey={selectedKey}
             onAddSong={() => {
-              setIsOpen(false);
               resetDialog();
             }}
           />
@@ -208,17 +227,21 @@ export const AddSongToSetDialog: React.FC<AddSongToSetDialogProps> = ({
     <Dialog
       open={isOpen}
       onOpenChange={(open) => {
-        setIsOpen(open);
+        setDialogOpen(open);
         if (!open) {
-          resetDialog();
+          resetDialog(open);
         }
       }}
     >
-      <DialogTrigger asChild>
-        <Button>
-          <Plus /> Add to a set
-        </Button>
-      </DialogTrigger>
+      {trigger !== null && (
+        <DialogTrigger asChild>
+          {trigger ?? (
+            <Button>
+              <Plus /> Add to a set
+            </Button>
+          )}
+        </DialogTrigger>
+      )}
       <DialogContent
         fixed
         minimalPadding
@@ -229,8 +252,8 @@ export const AddSongToSetDialog: React.FC<AddSongToSetDialogProps> = ({
           title={
             currentStep === AddSongToSetDialogStep.SELECT_SET &&
             isCreatingNewSet
-              ? contentMap[AddSongToSetDialogStep.SELECT_SET].alternateTitle ??
-                "Create new set"
+              ? (contentMap[AddSongToSetDialogStep.SELECT_SET].alternateTitle ??
+                "Create new set")
               : contentMap[currentStep].title
           }
           step={currentStep}

--- a/src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { type inferProcedureOutput } from "@trpc/server";
 import { toast } from "sonner";
 
 import { Button } from "@components/ui/button";
@@ -14,12 +13,13 @@ import { SelectedSetCard } from "@modules/songs/forms/AddSongToSet/components";
 import { useUserQuery } from "@modules/users/api/queries";
 import { type SongKey as SongKeyType } from "@lib/constants";
 import { trpc } from "@lib/trpc";
-import { type AppRouter } from "@server/api/root";
+
+import { type AddSongToSetDialogSong } from "../AddSongToSetDialog";
 
 type ReviewStepProps = {
   selectedSetId: string;
   selectedSetSection: string;
-  song: inferProcedureOutput<AppRouter["song"]["get"]>;
+  song: AddSongToSetDialogSong;
   songKey: SongKeyType;
   orderedSongIds: string[];
   onAddSong?: () => void;

--- a/src/modules/songs/forms/AddSongToSet/components/SetSongPositionStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSongPositionStep.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { type inferProcedureOutput } from "@trpc/server";
 
 import { Button } from "@components/ui/button";
 import { Input } from "@components/ui/input";
@@ -12,7 +11,8 @@ import { DraggableSongList } from "@modules/shared/components/DraggableSongList/
 import { useUserQuery } from "@modules/users/api/queries";
 import { clamp } from "@lib/numbers";
 import { trpc } from "@lib/trpc";
-import { type AppRouter } from "@server/api/root";
+
+import { type AddSongToSetDialogSong } from "./AddSongToSetDialog";
 
 export type DraggableSongListItem = Omit<DraggableSongItem, "songKey"> &
   Partial<Pick<DraggableSongItem, "songKey">> & {
@@ -21,7 +21,7 @@ export type DraggableSongListItem = Omit<DraggableSongItem, "songKey"> &
 
 type SetSongPositionStepProps = {
   selectedSetSection: string | null;
-  song: inferProcedureOutput<AppRouter["song"]["get"]>;
+  song: AddSongToSetDialogSong;
   newSongInitialPosition: number;
   onSongPositionSet: (orderedSongIds: string[]) => void;
 };

--- a/src/testUtils/models/search/fixtures.ts
+++ b/src/testUtils/models/search/fixtures.ts
@@ -1,0 +1,19 @@
+import { faker } from "@faker-js/faker";
+
+import { type SearchSongResult } from "@modules/search/components/types";
+
+import { createUuid } from "../../generators/createUuid";
+
+export const createSearchSongResultFixture = (
+  overrides: Partial<SearchSongResult> = {},
+): SearchSongResult => ({
+  songId: createUuid(),
+  name: faker.music.songName(),
+  preferredKey: "g",
+  isArchived: false,
+  similarityScore: faker.number.float({ min: 0, max: 1 }),
+  tags: [faker.music.genre(), faker.music.genre()],
+  matchedTags: [],
+  lastPlayedDate: null,
+  ...overrides,
+});

--- a/tests/e2e/sets/set-detail.authenticated.spec.ts
+++ b/tests/e2e/sets/set-detail.authenticated.spec.ts
@@ -35,6 +35,23 @@ const expectAddedSongInFullBandSection = async (
   await expect(fullBandSection).toContainText(addSongToSet.notes);
 };
 
+const openGlobalSearch = async (page: Page, isMobileProject: boolean) => {
+  if (!isMobileProject) {
+    await page.keyboard.press("ControlOrMeta+K");
+    return;
+  }
+
+  const searchButton = page.getByRole("button", {
+    name: "Open global search",
+  });
+  const trigger = await searchButton
+    .waitFor({ state: "visible", timeout: 5_000 })
+    .then(() => searchButton)
+    .catch(() => page.getByRole("textbox", { name: "Search" }));
+
+  await trigger.tap();
+};
+
 test("set detail renders seeded sections, songs, and notes", async ({
   page,
 }) => {
@@ -133,11 +150,10 @@ test("opens add-to-set from the search action menu without navigating", async ({
   const setDetailPath = `/${e2eIds.organizationId}/sets/${e2eIds.setId}`;
 
   await page.goto(setDetailPath);
-  if (isMobileProject) {
-    await page.getByRole("button", { name: "Open global search" }).tap();
-  } else {
-    await page.getByRole("button", { name: "Open global search" }).click();
-  }
+  await expect(
+    page.getByRole("heading", { name: e2eData.eventType.name }),
+  ).toBeVisible();
+  await openGlobalSearch(page, isMobileProject);
 
   const searchDialog = page.getByRole("dialog");
   await expect(searchDialog).toBeVisible();

--- a/tests/e2e/sets/set-detail.authenticated.spec.ts
+++ b/tests/e2e/sets/set-detail.authenticated.spec.ts
@@ -124,3 +124,45 @@ test("adds a song to a section from set detail", async ({ page }, testInfo) => {
   await page.reload();
   await expectAddedSongInFullBandSection(page, songToAdd);
 });
+
+test("opens add-to-set from the search action menu without navigating", async ({
+  page,
+}, testInfo) => {
+  const isMobileProject = testInfo.project.name.includes("mobile");
+  const songToAdd = getAddSongToSetSong(testInfo.project.name);
+  const setDetailPath = `/${e2eIds.organizationId}/sets/${e2eIds.setId}`;
+
+  await page.goto(setDetailPath);
+  if (isMobileProject) {
+    await page.getByRole("button", { name: "Open global search" }).tap();
+  } else {
+    await page.getByRole("button", { name: "Open global search" }).click();
+  }
+
+  const searchDialog = page.getByRole("dialog");
+  await expect(searchDialog).toBeVisible();
+  await searchDialog
+    .getByPlaceholder("Search songs or tags")
+    .fill(songToAdd.name);
+  await expect(
+    searchDialog.getByText(songToAdd.name, { exact: true }),
+  ).toBeVisible();
+
+  if (isMobileProject) {
+    await searchDialog
+      .getByRole("button", { name: `Open actions for ${songToAdd.name}` })
+      .tap();
+    await page.getByRole("menuitem", { name: /Add to a set/ }).tap();
+  } else {
+    await page.keyboard.press("Shift+Enter");
+    await expect(
+      page.getByRole("menuitem", { name: /Open song/ }),
+    ).toBeVisible();
+    await page.getByRole("menuitem", { name: /Add to a set/ }).press("Enter");
+  }
+
+  await expect(
+    page.getByRole("heading", { name: "Add to which set?" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`${setDetailPath}$`));
+});


### PR DESCRIPTION
## Background
- Linear: https://linear.app/paranoid-android/issue/SWY-172/global-search-quick-actions
- This adds the SWY-172 quick actions on top of the existing global search shell/results work so users can act on song results without first navigating to the song detail page.
- The main fix is making result action menus and add-to-set flows coexist with normal Enter navigation, so Shift+Enter can open actions on desktop while touch users can use the visible action menu.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Action menu in search results with options to open songs and add them to sets
  * Keyboard shortcut (Shift+Enter) provides quick access to search result actions
  * Songs can now be added directly to sets from search without leaving search results
  * URL-driven song pre-selection enables seamless song addition workflows

* **Tests**
  * Added end-to-end test validating add-to-set functionality from search results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Added a song result action menu in global search with actions to open a song, add it to the current set when available, or add it to another set.
- Reused the existing add-to-set dialogs by making the song add dialog controllable and by supporting a preselected song when opening the set-page add-song flow from query params.
- Added keyboard guards so action-menu Enter events do not fall through to command result navigation, plus visible shortcut help for Shift+Enter.
- Added component coverage for the search action menu behavior and Playwright coverage for desktop keyboard and mobile touch action-menu paths.

## How to test
- From a set page, open global search, search for a song, press Shift+Enter on desktop, choose "Add to a set", and confirm the add-to-set dialog opens without navigating away.
- On mobile or a narrow viewport, open global search, search for a song, tap the result action menu button, tap "Add to a set", and confirm the dialog opens on the current page.
- From a set page, use the action menu's "Add to current set" option and confirm the existing add-song-to-set configuration dialog opens with that song selected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a per-result action menu to global search results so users can open a song or add it to a set (current or chosen) without leaving the search UI. The approach reuses existing `AddSongToSetDialog` and `SongSearchDialog` by making them controllable and adding a `preSelectedSongId` URL param that the set-page uses to pre-populate the song.

- **`SearchResultsList` / `SearchResultActions`**: new controlled `DropdownMenu` per result; Shift+Enter opens the menu for the keyboard-focused item via a capture-phase `document` listener; `suppressNextSongSelectRef` + stale-closure state guard together prevent cmdk's `onSelect` from firing when an action item is selected.
- **`AddSongToSetDialog`**: refactored to support controlled `open`/`onOpenChange`/`trigger` props with a `200 ms` delayed cleanup that keeps the component mounted long enough for Radix's exit animation to complete.
- **`SongSearchDialog`**: new `preSelectedSongId` prop triggers a `trpc.song.get` query; a `dismissedPreSelectedSongId` sentinel tracks when the user has manually navigated back to the search step so the pre-selection isn't re-applied.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no data corruption, broken navigation, or dialog state leaks identified

All three action flows (keyboard Shift+Enter, mobile tap, URL-driven pre-selection) are guarded correctly. The controlled dialog pattern handles animation timing, state reset on close, and re-entry from search without leaving stale state. Unit and e2e tests cover the new paths. The only open items are minor UX polish and a listener-efficiency note.

src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx — loading text during pre-selected song fetch could surprise users who opened the dialog to search manually

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/modules/search/components/Search.tsx | Adds controlled AddSongToSetDialog with delayed cleanup (DIALOG_EXIT_ANIMATION_DELAY) and two new action handlers; correctly reads setId from route params |
| src/modules/search/components/SearchResultsList.tsx | Adds keyboard action menu (Shift+Enter), per-result action dropdowns, and dual-mechanism onSelect suppression via state + ref; logic is sound |
| src/modules/search/components/SearchResultActions.tsx | New component rendering the per-result DropdownMenu with Open song / Add to current set / Add to a set actions; stopPropagation on trigger prevents cmdk from receiving click events |
| src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialog.tsx | Refactored to support controlled open/trigger via open/onOpenChange/trigger props; correctly derives isOpen from open ?? uncontrolledOpen for backward compat |
| src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx | Adds preSelectedSongId support via TRPC query with dismissedPreSelectedSongId tracking; minor UX concern around bare loading text during song fetch |
| src/app/[organization]/sets/[setId]/page.tsx | Reads songId from URL search params and threads preSelectedSongId down to SongSearchDialog; clean URL-driven state initialization |
| src/modules/search/components/__tests__/SearchResultsList.test.tsx | New test file covering Shift+Enter to open action menu, Enter suppression while menu is open, and add-to-set / add-to-current-set action selection |
| tests/e2e/sets/set-detail.authenticated.spec.ts | Adds e2e test for add-to-set from search action menu on both desktop (Shift+Enter) and mobile (tap); helper handles both keyboard-open and tap-open search paths |
| src/testUtils/models/search/fixtures.ts | New fixture factory for SearchSongResult following project conventions with faker-generated data and override support |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant SR as SearchResultsList
    participant SA as SearchResultActions
    participant S as Search.tsx
    participant ASTSD as AddSongToSetDialog

    U->>SR: Shift+Enter
    SR->>SR: setOpenActionsSongId(songId)
    SR->>SA: "open=true"
    SA-->>U: Dropdown visible

    alt User clicks Add to a set
        U->>SA: click Add to a set
        SA->>SR: onActionSelect() suppressNextSongSelect()
        SA->>S: onAddSongToSet(result)
        S->>S: handleOpenChange(false)
        S->>S: setSongToAddToSet(result)
        S->>S: setIsAddSongToSetDialogOpen(true)
        S-->>ASTSD: "open=true song=result"
        ASTSD-->>U: Add-to-set dialog visible
    else User clicks Add to current set
        U->>SA: click Add to current set
        SA->>S: onAddSongToCurrentSet(result)
        S->>S: handleOpenChange(false)
        S->>S: "router.push setDetailPath?addSongDialogOpen=1&songId=..."
        Note over S: URL triggers SongSearchDialog with preSelectedSongId
    else User closes via Escape
        U->>SA: Escape
        SA->>SR: onOpenChange(false)
        SR->>SR: setOpenActionsSongId(null)
    end

    Note over ASTSD,S: On close handleAddSongToSetDialogOpenChange(false) starts 200ms timeout then setSongToAddToSet(null)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant SR as SearchResultsList
    participant SA as SearchResultActions
    participant S as Search.tsx
    participant ASTSD as AddSongToSetDialog

    U->>SR: Shift+Enter
    SR->>SR: setOpenActionsSongId(songId)
    SR->>SA: "open=true"
    SA-->>U: Dropdown visible

    alt User clicks Add to a set
        U->>SA: click Add to a set
        SA->>SR: onActionSelect() suppressNextSongSelect()
        SA->>S: onAddSongToSet(result)
        S->>S: handleOpenChange(false)
        S->>S: setSongToAddToSet(result)
        S->>S: setIsAddSongToSetDialogOpen(true)
        S-->>ASTSD: "open=true song=result"
        ASTSD-->>U: Add-to-set dialog visible
    else User clicks Add to current set
        U->>SA: click Add to current set
        SA->>S: onAddSongToCurrentSet(result)
        S->>S: handleOpenChange(false)
        S->>S: "router.push setDetailPath?addSongDialogOpen=1&songId=..."
        Note over S: URL triggers SongSearchDialog with preSelectedSongId
    else User closes via Escape
        U->>SA: Escape
        SA->>SR: onOpenChange(false)
        SR->>SR: setOpenActionsSongId(null)
    end

    Note over ASTSD,S: On close handleAddSongToSetDialogOpenChange(false) starts 200ms timeout then setSongToAddToSet(null)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address search review follow-ups"](https://github.com/justaddcl/sanbi/commit/e99f1b45c15c276ec249047af11dedafd01d9d41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39132380)</sub>

<!-- /greptile_comment -->