### PR TITLE
[SWY-170] Add new-set song E2E coverage

### DIFF
--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import * as React from "react";
+import {
+  CaretDown,
+  CaretUp,
+  Check,
+  CircleNotch,
+} from "@phosphor-icons/react/dist/ssr";
 
-import { cn } from "@lib/utils";
 import { Button } from "@components/ui/button";
 import {
   Command,
@@ -19,12 +24,7 @@ import {
   PopoverTrigger,
 } from "@components/ui/popover";
 import { Text } from "@components/Text";
-import {
-  CaretDown,
-  CaretUp,
-  Check,
-  CircleNotch,
-} from "@phosphor-icons/react/dist/ssr";
+import { cn } from "@lib/utils";
 
 export type ComboboxOption = {
   id: string;
@@ -67,6 +67,7 @@ export const Combobox: React.FC<React.PropsWithChildren<ComboboxProps>> = ({
         <Button
           variant="outline"
           role="combobox"
+          aria-label={value?.label ?? placeholder}
           aria-expanded={open}
           className="min-w-[300px] max-w-full justify-between"
           disabled={disabled}
@@ -108,7 +109,7 @@ export const Combobox: React.FC<React.PropsWithChildren<ComboboxProps>> = ({
                   <Check
                     className={cn(
                       "ml-auto",
-                      value && value.id === option.id
+                      value?.id === option.id
                         ? "opacity-100"
                         : "opacity-0",
                     )}

--- a/src/components/ui/datePicker.tsx
+++ b/src/components/ui/datePicker.tsx
@@ -261,7 +261,7 @@ export const DatePicker = <Mode extends CalendarMode = "single">({
             <SelectContent position="popper">
               {presets?.map((preset, presetIndex) => (
                 <SelectItem
-                  key={`${preset.value}-${preset.label}`}
+                  key={`${preset.value}-${preset.label}-${presetIndex}`}
                   value={`${preset.value}:${presetIndex}`}
                 >
                   {preset.label}

--- a/src/components/ui/datePicker.tsx
+++ b/src/components/ui/datePicker.tsx
@@ -255,12 +255,15 @@ export const DatePicker = <Mode extends CalendarMode = "single">({
               setViewMonth(selectedDate);
             }}
           >
-            <SelectTrigger>
+            <SelectTrigger aria-label={presetSelectPlaceholder}>
               <SelectValue placeholder={presetSelectPlaceholder} />
             </SelectTrigger>
             <SelectContent position="popper">
-              {presets?.map((preset) => (
-                <SelectItem key={preset.value} value={preset.value}>
+              {presets?.map((preset, presetIndex) => (
+                <SelectItem
+                  key={`${preset.value}-${preset.label}`}
+                  value={`${preset.value}:${presetIndex}`}
+                >
                   {preset.label}
                 </SelectItem>
               ))}

--- a/src/modules/eventTypes/components/EventTypeSelect.tsx
+++ b/src/modules/eventTypes/components/EventTypeSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { skipToken } from "@tanstack/react-query";
 
 import {
@@ -71,7 +71,9 @@ export const EventTypeSelect: React.FC<EventTypeSelectProps> = ({
 
   // helper ref just to avoid stale closures
   const latestValueRef = useRef(value);
-  latestValueRef.current = value;
+  useEffect(() => {
+    latestValueRef.current = value;
+  }, [value]);
 
   const handleValueChange = (selectedEventTypeId: string) => {
     onSelectChange(selectedEventTypeId);
@@ -131,7 +133,7 @@ export const EventTypeSelect: React.FC<EventTypeSelectProps> = ({
       onValueChange={handleValueChange}
       {...props}
     >
-      <SelectTrigger>
+      <SelectTrigger aria-label={displayLabel(value)}>
         <SelectValue
           placeholder={displayValue(value)}
           aria-label={displayLabel(value)}

--- a/src/modules/eventTypes/components/EventTypeSelect.tsx
+++ b/src/modules/eventTypes/components/EventTypeSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import { skipToken } from "@tanstack/react-query";
 
 import {
@@ -68,12 +68,6 @@ export const EventTypeSelect: React.FC<EventTypeSelectProps> = ({
   const isError = !!userQueryError || !!eventTypeQueryError;
 
   const [open, setOpen] = useState(false);
-
-  // helper ref just to avoid stale closures
-  const latestValueRef = useRef(value);
-  useEffect(() => {
-    latestValueRef.current = value;
-  }, [value]);
 
   const handleValueChange = (selectedEventTypeId: string) => {
     onSelectChange(selectedEventTypeId);
@@ -160,7 +154,7 @@ export const EventTypeSelect: React.FC<EventTypeSelectProps> = ({
               value={eventType.id}
               // intercept before Radix handles selection
               onMouseDownCapture={(mouseDownEvent) => {
-                if (eventType.id === latestValueRef.current) {
+                if (eventType.id === value) {
                   // stop Radix’s internal “same‐value” logic
                   mouseDownEvent.preventDefault();
                   mouseDownEvent.stopPropagation();

--- a/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
+++ b/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
@@ -45,21 +45,8 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({
 
   const createSetMutation = trpc.set.create.useMutation();
 
-  if (!userId) {
-    return null;
-  }
-
-  const { data: userData, isError } = trpc.user.getUser.useQuery({ userId });
-
-  const {
-    data: eventTypeData,
-    isError: eventTypeQueryError,
-    isFetching: isEventTypeQueryFetching,
-    isFetched: isEventTypeQueryFetched,
-  } = trpc.eventType.getEventTypes.useQuery(
-    userData?.memberships[0]
-      ? { organizationId: userData.memberships[0].organizationId }
-      : skipToken,
+  const { data: userData, isError } = trpc.user.getUser.useQuery(
+    userId ? { userId } : skipToken,
   );
 
   const handleCreateSetSubmit = async (formValues: CreateSetFormFields) => {
@@ -113,6 +100,10 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({
   } = createSetForm;
 
   const shouldSubmitBeDisabled = !isDirty || !isValid || isSubmitting;
+
+  if (!userId) {
+    return null;
+  }
 
   return (
     <FormProvider {...createSetForm}>

--- a/src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialogHeader.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialogHeader.tsx
@@ -41,17 +41,15 @@ export const AddSongToSetDialogHeader: React.FC<
               <CaretLeft weight="bold" className="h-5 w-5" />
             </Button>
           )}
-          <DialogTitle asChild>
-            <h2
-              id="modal-title"
-              className={cn("text-lg font-semibold", {
-                "ml-3":
-                  step === AddSongToSetDialogStep.SELECT_SET &&
-                  !isCreatingNewSet,
-              })}
-            >
-              {title}
-            </h2>
+          <DialogTitle
+            id="modal-title"
+            className={cn("text-lg font-semibold", {
+              "ml-3":
+                step === AddSongToSetDialogStep.SELECT_SET &&
+                !isCreatingNewSet,
+            })}
+          >
+            {title}
           </DialogTitle>
         </HStack>
         <DialogClose asChild>

--- a/src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx
@@ -165,6 +165,7 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
         <VStack className="gap-1">
           <Text className="font-medium text-slate-700">Song notes</Text>
           <Textarea
+            aria-label="Song notes"
             value={notes}
             onChange={(changeEvent) => {
               setNotes(changeEvent.target.value);

--- a/src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSelectionAllUpcomingSets.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Plus } from "@phosphor-icons/react/dist/ssr";
+import { skipToken } from "@tanstack/react-query";
 import { differenceInCalendarWeeks } from "date-fns";
 import { toast } from "sonner";
 
@@ -39,22 +40,8 @@ export const SetSelectionAllUpcomingSets: React.FC<
 > = ({ eventTypeFilters, dateFilter, onCreateSetClick, onSetSelect }) => {
   const {
     data: userData,
-    error: userQueryError,
-    isLoading: userQueryLoading,
-    isAuthLoaded,
   } = useUserQuery();
   const userMembership = userData?.memberships[0];
-
-  if (!userMembership) {
-    return (
-      <SetSelectionSection title="All upcoming sets">
-        <div className="p-4 text-center text-muted-foreground">
-          Unable to load sets. Looks like we can&apos;t verify which team
-          you&apos;re a part of
-        </div>
-      </SetSelectionSection>
-    );
-  }
 
   const {
     data: setsData,
@@ -64,16 +51,18 @@ export const SetSelectionAllUpcomingSets: React.FC<
     isLoading,
     error: getInfiniteSetsQueryError,
   } = trpc.set.getInfinite.useInfiniteQuery(
-    {
-      organizationId: userMembership.organizationId,
-      dateRange: dateFilter?.from
-        ? {
-            from: dateFilter.from,
-            to: dateFilter.to ? dateFilter.to : null,
-          }
-        : null,
-      eventTypeFilters: eventTypeFilters.map((filter) => filter.id),
-    },
+    userMembership
+      ? {
+          organizationId: userMembership.organizationId,
+          dateRange: dateFilter?.from
+            ? {
+                from: dateFilter.from,
+                to: dateFilter.to ?? null,
+              }
+            : null,
+          eventTypeFilters: eventTypeFilters.map((filter) => filter.id),
+        }
+      : skipToken,
     {
       getNextPageParam: (last) => {
         const cursor = last.nextCursor;
@@ -89,6 +78,17 @@ export const SetSelectionAllUpcomingSets: React.FC<
       },
     },
   );
+
+  if (!userMembership) {
+    return (
+      <SetSelectionSection title="All upcoming sets">
+        <div className="p-4 text-center text-muted-foreground">
+          Unable to load sets. Looks like we can&apos;t verify which team
+          you&apos;re a part of
+        </div>
+      </SetSelectionSection>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/modules/songs/forms/AddSongToSet/components/SetSelectionSetItem.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSelectionSetItem.tsx
@@ -26,6 +26,7 @@ export const SetSelectionSetItem: React.FC<SetSelectionSetItemProps> = ({
 }) => {
   return (
     <HStack
+      data-testid="set-selection-set-item"
       className={cn(
         "cursor-pointer items-center justify-between rounded-lg px-3 py-2 hover:bg-slate-100",
         className,

--- a/tests/e2e/organizations/home.authenticated.spec.ts
+++ b/tests/e2e/organizations/home.authenticated.spec.ts
@@ -9,7 +9,9 @@ test("organization home renders seeded upcoming sets", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "Upcoming sets" }),
   ).toBeVisible();
-  await expect(page.getByText(e2eData.eventType.name)).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: e2eData.eventType.name }).first(),
+  ).toBeVisible();
   await expect(page.getByText(e2eData.songs.first.name)).toBeVisible();
 
   await expectNoA11yViolations(page, {

--- a/tests/e2e/songs/add-song-to-new-set.authenticated.spec.ts
+++ b/tests/e2e/songs/add-song-to-new-set.authenticated.spec.ts
@@ -124,7 +124,12 @@ test("adds a song to a newly created set with a newly created section", async ({
     page,
     config,
   ).first();
-  if (await existingPlayHistoryLink.isVisible()) {
+  const hasExistingPlayHistory = await existingPlayHistoryLink
+    .waitFor({ state: "visible", timeout: 3_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (hasExistingPlayHistory) {
     await openPersistedSetFromSongHistory(page, config);
     return;
   }

--- a/tests/e2e/songs/add-song-to-new-set.authenticated.spec.ts
+++ b/tests/e2e/songs/add-song-to-new-set.authenticated.spec.ts
@@ -78,7 +78,11 @@ const expectAddedSongOnNewSetPage = async (
 ) => {
   await expect(
     page.getByRole("heading", {
-      name: formatDate(config.setDate, { month: "long" }),
+      name: formatDate(config.setDate, {
+        locale: "en-US",
+        month: "long",
+        day: "2-digit",
+      }),
     }),
   ).toBeVisible();
   await expect(

--- a/tests/e2e/songs/add-song-to-new-set.authenticated.spec.ts
+++ b/tests/e2e/songs/add-song-to-new-set.authenticated.spec.ts
@@ -1,0 +1,207 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { e2eData, e2eIds } from "@testUtils/e2e/fixtures";
+import { addWeeks, nextSunday } from "date-fns";
+
+import { type SongKey } from "@lib/constants";
+import { formatDate } from "@lib/date";
+import { getFirstSundayOfNextMonth } from "@lib/date/getFirstSundayOfNextMonth";
+import { formatSongKey } from "@lib/string/formatSongKey";
+
+test.setTimeout(90_000);
+
+type AddSongToNewSetSong =
+  | typeof e2eData.set.addSongToSet.desktopSong
+  | typeof e2eData.set.addSongToSet.mobileSong;
+
+type AddSongToNewSetConfig = {
+  datePresetLabel: "Sunday After Next" | "First Sunday of Next Month";
+  setDate: string;
+  setNotes: string;
+  song: AddSongToNewSetSong;
+  songId: string;
+  songKey: SongKey;
+  songNotes: string;
+  sectionName: string;
+};
+
+const toDateInputValue = (date: Date) => date.toLocaleDateString("en-CA");
+
+const getAddSongToNewSetConfig = (
+  projectName: string,
+): AddSongToNewSetConfig => {
+  const upcomingSunday = nextSunday(new Date());
+
+  if (projectName.includes("mobile")) {
+    return {
+      datePresetLabel: "First Sunday of Next Month",
+      setDate: toDateInputValue(getFirstSundayOfNextMonth(new Date())),
+      setNotes: "E2E mobile add-to-new-set workflow notes.",
+      song: e2eData.set.addSongToSet.mobileSong,
+      songId: e2eIds.addSongToSetMobileSongId,
+      songKey: "b_flat",
+      songNotes: "Mobile adds this song after creating the set and section.",
+      sectionName: e2eData.sectionTypes.prayer,
+    };
+  }
+
+  return {
+    datePresetLabel: "Sunday After Next",
+    setDate: toDateInputValue(addWeeks(upcomingSunday, 1)),
+    setNotes: "E2E desktop add-to-new-set workflow notes.",
+    song: e2eData.set.addSongToSet.desktopSong,
+    songId: e2eIds.addSongToSetDesktopSongId,
+    songKey: "f_sharp",
+    songNotes: "Desktop adds this song after creating the set and section.",
+    sectionName: e2eData.sectionTypes.prayer,
+  };
+};
+
+const getSetSectionCard = (page: Page, sectionName: string) =>
+  page
+    .getByTestId("set-section-card")
+    .filter({ has: page.getByRole("heading", { name: sectionName }) });
+
+const getPersistedPlayHistoryLink = (
+  page: Page,
+  config: AddSongToNewSetConfig,
+): Locator =>
+  page
+    .getByRole("link")
+    .filter({ hasText: formatDate(config.setDate, { format: "long" }) })
+    .filter({ hasText: e2eData.eventType.name })
+    .filter({ hasText: formatSongKey(config.songKey) })
+    .filter({ hasText: new RegExp(config.sectionName, "i") });
+
+const expectAddedSongOnNewSetPage = async (
+  page: Page,
+  config: AddSongToNewSetConfig,
+) => {
+  await expect(
+    page.getByRole("heading", {
+      name: formatDate(config.setDate, { month: "long" }),
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: e2eData.eventType.name }),
+  ).toBeVisible();
+  await expect(page.getByText(config.setNotes)).toBeVisible();
+
+  const sectionCard = getSetSectionCard(page, config.sectionName);
+  await expect(sectionCard).toBeVisible();
+  await expect(sectionCard).toContainText(config.song.name);
+  await expect(sectionCard).toContainText(formatSongKey(config.songKey));
+  await expect(sectionCard).toContainText(config.songNotes);
+};
+
+const openPersistedSetFromSongHistory = async (
+  page: Page,
+  config: AddSongToNewSetConfig,
+) => {
+  const playHistoryLink = getPersistedPlayHistoryLink(page, config).first();
+
+  await expect(playHistoryLink).toBeVisible({ timeout: 20_000 });
+  await playHistoryLink.click();
+  await expect(page).toHaveURL(/\/sets\//);
+  await expectAddedSongOnNewSetPage(page, config);
+};
+
+test("adds a song to a newly created set with a newly created section", async ({
+  page,
+}, testInfo) => {
+  const config = getAddSongToNewSetConfig(testInfo.project.name);
+
+  await page.goto(`/${e2eIds.organizationId}/songs/${config.songId}`);
+  await expect(
+    page.getByRole("heading", { name: config.song.name }),
+  ).toBeVisible();
+  await expect(page.getByText("Song added to library")).toBeVisible();
+
+  const existingPlayHistoryLink = getPersistedPlayHistoryLink(
+    page,
+    config,
+  ).first();
+  if (await existingPlayHistoryLink.isVisible()) {
+    await openPersistedSetFromSongHistory(page, config);
+    return;
+  }
+
+  await page.getByRole("button", { name: "Add to a set" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(
+    dialog.getByRole("heading", { name: "Add to which set?" }),
+  ).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Create set" }).click();
+  await expect(
+    dialog.getByRole("heading", { name: "Create new set" }),
+  ).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Pick a date" }).click();
+  await page
+    .getByRole("combobox", { name: "Quick select date" })
+    .click();
+  await page.getByRole("option", { name: config.datePresetLabel }).click();
+
+  await dialog
+    .getByRole("combobox", { name: "Select event type" })
+    .click();
+  await page
+    .getByRole("option", { name: e2eData.eventType.name })
+    .click();
+
+  await dialog.getByLabel("Set notes").fill(config.setNotes);
+
+  const createSetButton = dialog.getByRole("button", { name: "Create set" });
+  await expect(createSetButton).toBeEnabled();
+  await createSetButton.click();
+
+  await expect(
+    dialog.getByRole("heading", { name: "Which section?" }),
+  ).toBeVisible({ timeout: 20_000 });
+  await dialog.getByRole("button", { name: "Add section" }).click();
+  await dialog.getByRole("combobox", { name: "Select section type" }).click();
+  await page.getByRole("option", { name: config.sectionName }).click();
+
+  const addSectionButton = dialog.getByRole("button", {
+    name: "Add section to set",
+  });
+  await expect(addSectionButton).toBeEnabled();
+  await addSectionButton.click();
+
+  await expect(
+    dialog.getByRole("heading", { name: "When will you play it?" }),
+  ).toBeVisible({ timeout: 20_000 });
+  await dialog
+    .getByRole("button", { name: "Confirm song position" })
+    .click();
+
+  await expect(
+    dialog.getByRole("heading", { name: "What key will you play in?" }),
+  ).toBeVisible();
+  await dialog
+    .getByRole("button", {
+      name: formatSongKey(config.songKey),
+      exact: true,
+    })
+    .click();
+
+  await expect(dialog.getByRole("heading", { name: "Review" })).toBeVisible();
+  await dialog.getByLabel("Song notes").fill(config.songNotes);
+
+  const addSongButton = dialog.getByRole("button", {
+    name: "Add song to set",
+  });
+  await expect(addSongButton).toBeEnabled();
+  await addSongButton.click();
+
+  await expect(page.getByText("Song added to set!")).toBeVisible();
+  await expect(dialog).toBeHidden();
+
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: config.song.name }),
+  ).toBeVisible();
+  await openPersistedSetFromSongHistory(page, config);
+});

--- a/tests/e2e/songs/add-song-to-set.authenticated.spec.ts
+++ b/tests/e2e/songs/add-song-to-set.authenticated.spec.ts
@@ -59,6 +59,13 @@ const getDialogCardByHeading = (root: Page | Locator, headingName: string) =>
     .getByTestId("set-section-selection-card")
     .filter({ hasText: headingName });
 
+const getSeededSetSelectionItem = (dialog: Locator) =>
+  dialog
+    .getByTestId("set-selection-set-item")
+    .filter({ hasText: formatFriendlyDate(e2eData.set.date) })
+    .filter({ hasText: e2eData.eventType.name })
+    .first();
+
 const getDialogSummaryGroup = (dialog: Locator, label: string) =>
   dialog
     .getByTestId("add-song-review-summary-group")
@@ -153,7 +160,7 @@ test("song detail workflow adds a song to an existing set section", async ({
   const dialog = page.getByRole("dialog");
   await expectDialogStep(dialog, 1, "Add to which set?");
 
-  await dialog.getByText(e2eData.eventType.name).first().click();
+  await getSeededSetSelectionItem(dialog).click();
   await expectDialogStep(dialog, 2, "Which section?");
 
   const selectedSection = getDialogCardByHeading(dialog, song.sectionName);


### PR DESCRIPTION
## Background
- Linear ticket: https://linear.app/paranoid-android/issue/SWY-170/e2e-add-song-to-newly-created-set-with-newly-created-section
- This adds coverage for the song-detail flow where a user creates a new set, creates a section on that set, and then adds the song into the new section.
- The flow was previously untested beyond adding a song to an already-seeded set section, leaving several chained mutations and cache updates uncovered.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced accessibility with aria-labels across form controls and dialogs for improved screen reader support.

* **Bug Fixes**
  * Improved form handling logic in set creation and event type selection workflows.
  * Updated component rendering for better UI compatibility.

* **Tests**
  * Added comprehensive end-to-end test for adding songs to newly created sets.
  * Enhanced test reliability with improved selection strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Adds an authenticated Playwright spec that runs on desktop and mobile Chromium, uses separate seeded songs per project, creates new sets/sections through the UI, and verifies persisted play history after reload/navigation.
- Stabilizes the add-to-set path by avoiding hook-order crashes while Clerk/user membership data loads.
- Adds accessible names to the date preset, event type, shared combobox, and review notes controls so the browser workflow can use durable role and label locators.
- Handles duplicate date preset offsets when two preset labels resolve to the same calendar date.

## How to test
- In the web app, open a seeded song detail page and click **Add to a set**.
- Choose **Create set**, pick a preset date, select an event type, add notes, then create the set.
- Add a section to the new set, choose the song position and key, fill review notes, and submit.
- Reload the song page, open the new set from play history, and confirm the new section contains the song, key, and notes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new authenticated Playwright E2E spec covering the full "create set → create section → add song" flow, and stabilizes several UI components to make durable ARIA/role locators available to the test runner.

- **`CreateSetForm.tsx`**: Fixes a React Rules of Hooks violation by moving the `!userId` early-return guard to after all hook calls and replacing the conditional return with `skipToken`; also removes a now-redundant `getEventTypes` fetch that `EventTypeSelect` owns internally.
- **Accessibility additions**: `aria-label` props added to the `Combobox` trigger, `SelectTrigger` in `DatePicker` and `EventTypeSelect`, and a `Textarea` in `ReviewStep`; `DialogTitle` no longer uses `asChild+h2` and gains a stable `id`.
- **Duplicate preset fix in `DatePicker`**: Composite `\"value:index\"` is used as the `SelectItem` value to prevent two presets that resolve to the same day from colliding; the `parseInt` in `onValueChange` still relies on the implicit stop-at-colon behaviour rather than explicitly splitting the composite string.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the hooks-ordering fix is correct, accessibility additions are additive, and the new E2E spec is well-isolated with separate per-project seed data.

All production-code changes are either bug fixes (hooks ordering, duplicate preset keys) or purely additive (aria labels, data-testid). No data mutations, auth paths, or API contracts are altered.

src/components/ui/datePicker.tsx — the composite SelectItem value introduced to fix duplicate preset keys is not yet reflected in the parseInt call that consumes it.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/ui/datePicker.tsx | Adds aria-label to SelectTrigger and fixes duplicate-preset key collision by making SelectItem value a composite "value:index" string; implicit parseInt colon-stop is still present. |
| src/modules/sets/components/CreateSetForm/CreateSetForm.tsx | Fixes hooks-ordering violation by moving the early !userId guard after all hook calls and using skipToken for the user query; removes the now-redundant eventTypeData fetch that EventTypeSelect owns internally. |
| tests/e2e/songs/add-song-to-new-set.authenticated.spec.ts | New E2E spec covering the full create-set → create-section → add-song flow; uses separate desktop/mobile song fixtures, durable ARIA/role locators, and an idempotent early-exit if play history already exists from a prior run. |
| src/modules/eventTypes/components/EventTypeSelect.tsx | Removes the stale latestValueRef pattern in favour of comparing eventType.id directly against the rendered value prop; adds aria-label to SelectTrigger. |
| src/components/ui/combobox.tsx | Adds aria-label to the combobox trigger button and simplifies the check-mark opacity guard with optional chaining. |
| tests/e2e/songs/add-song-to-set.authenticated.spec.ts | Replaces fragile getByText selector with the new getSeededSetSelectionItem helper that filters by data-testid + date/event-type text, making the set-selection click more robust. |
| tests/e2e/organizations/home.authenticated.spec.ts | Tightens event-type assertion to getByRole("heading") + .first() to avoid false positives from other text nodes on the page. |
| src/modules/songs/forms/AddSongToSet/components/AddSongToSetDialogHeader.tsx | Removes the asChild+h2 wrapper so DialogTitle renders its own element directly, and adds a stable id="modal-title" attribute for aria-labelledby references. |
| src/modules/songs/forms/AddSongToSet/components/ReviewStep/ReviewStep.tsx | Adds aria-label="Song notes" to the Textarea so Playwright (and screen readers) can locate it by label. |
| src/modules/songs/forms/AddSongToSet/components/SetSelectionSetItem.tsx | Adds data-testid="set-selection-set-item" so the new getSeededSetSelectionItem test helper can target specific set items without relying on text content alone. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as E2E Test
    participant SongPage as Song Detail Page
    participant Dialog as Add-to-Set Dialog
    participant CreateSetForm
    participant DB as Backend / DB

    Test->>SongPage: navigate to song detail
    SongPage-->>Test: heading visible
    Test->>SongPage: click "Add to a set"
    SongPage->>Dialog: open (step: Select Set)
    Test->>Dialog: click "Create set"
    Dialog->>CreateSetForm: render (step: Create new set)
    Test->>CreateSetForm: pick date preset
    Test->>CreateSetForm: select event type
    Test->>CreateSetForm: fill set notes
    Test->>CreateSetForm: click "Create set"
    CreateSetForm->>DB: set.create mutation
    DB-->>CreateSetForm: new set returned
    CreateSetForm->>Dialog: advance (step: Which section?)
    Test->>Dialog: click "Add section", choose type
    Dialog->>DB: section.create mutation
    DB-->>Dialog: new section returned
    Dialog->>Dialog: advance (step: song position)
    Test->>Dialog: confirm position → pick key → fill notes
    Test->>Dialog: click "Add song to set"
    Dialog->>DB: songInSet.create mutation
    DB-->>Dialog: success
    Dialog-->>SongPage: close, toast "Song added to set!"
    Test->>SongPage: reload
    Test->>SongPage: click play-history link
    SongPage->>Test: navigate to set detail
    Test->>Test: assert section card contains song/key/notes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as E2E Test
    participant SongPage as Song Detail Page
    participant Dialog as Add-to-Set Dialog
    participant CreateSetForm
    participant DB as Backend / DB

    Test->>SongPage: navigate to song detail
    SongPage-->>Test: heading visible
    Test->>SongPage: click "Add to a set"
    SongPage->>Dialog: open (step: Select Set)
    Test->>Dialog: click "Create set"
    Dialog->>CreateSetForm: render (step: Create new set)
    Test->>CreateSetForm: pick date preset
    Test->>CreateSetForm: select event type
    Test->>CreateSetForm: fill set notes
    Test->>CreateSetForm: click "Create set"
    CreateSetForm->>DB: set.create mutation
    DB-->>CreateSetForm: new set returned
    CreateSetForm->>Dialog: advance (step: Which section?)
    Test->>Dialog: click "Add section", choose type
    Dialog->>DB: section.create mutation
    DB-->>Dialog: new section returned
    Dialog->>Dialog: advance (step: song position)
    Test->>Dialog: confirm position → pick key → fill notes
    Test->>Dialog: click "Add song to set"
    Dialog->>DB: songInSet.create mutation
    DB-->>Dialog: success
    Dialog-->>SongPage: close, toast "Song added to set!"
    Test->>SongPage: reload
    Test->>SongPage: click play-history link
    SongPage->>Test: navigate to set detail
    Test->>Test: assert section card contains song/key/notes
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/ui/datePicker.tsx`, line 250-256 ([link](https://github.com/justaddcl/sanbi/blob/bbcf0fd3a3a2cca48edf0d3cb5e0fc3d564ba6f7/src/components/ui/datePicker.tsx#L250-L256)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Implicit `parseInt` stop-at-colon on new composite value**

   The `onValueChange` handler calls `parseInt(value)` where `value` is now `"${preset.value}:${presetIndex}"`. This works because `parseInt` stops parsing at the non-numeric `:` character, but the behavior is non-obvious and will silently produce `NaN` (→ `addDays(new Date(), NaN)` → Invalid Date) if `preset.value` ever starts with non-numeric content. Explicitly splitting on `:` before parsing would make the intent clear and be more defensive: `parseInt(value.split(":")[0], 10)`. Including the radix `10` also prevents any hex-parsing edge case.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/ui/datePicker.tsx
   Line: 250-256

   Comment:
   **Implicit `parseInt` stop-at-colon on new composite value**

   The `onValueChange` handler calls `parseInt(value)` where `value` is now `"${preset.value}:${presetIndex}"`. This works because `parseInt` stops parsing at the non-numeric `:` character, but the behavior is non-obvious and will silently produce `NaN` (→ `addDays(new Date(), NaN)` → Invalid Date) if `preset.value` ever starts with non-numeric content. Explicitly splitting on `:` before parsing would make the intent clear and be more defensive: `parseInt(value.split(":")[0], 10)`. Including the radix `10` also prevents any hex-parsing edge case.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Address CodeRabbit review comments"](https://github.com/justaddcl/sanbi/commit/38c105d50a7d43d2f608c287cd313cd489475ca5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39139197)</sub>

<!-- /greptile_comment -->