### PR TITLE
[SWY-194] Document Sanbi API standard and service testing pattern

### DIFF
--- a/docs/adr/0002-api-standard-and-service-testing.md
+++ b/docs/adr/0002-api-standard-and-service-testing.md
@@ -26,8 +26,9 @@ New internal Sanbi APIs use tRPC by default.
 Use `createTRPCRouter` and the procedure helpers from `src/server/api/trpc.ts`.
 For organization-owned data, start with `organizationProcedure` or
 `adminProcedure` instead of repeating auth, user lookup, organization lookup, or
-membership checks inside each endpoint. Use `publicProcedure` only for behavior
-that is intentionally unauthenticated.
+membership checks inside each endpoint. Use `authedProcedure` for signed-in
+behavior that does not need organization scoping. Use `publicProcedure` only for
+behavior that is intentionally unauthenticated.
 
 Input validation belongs at the procedure boundary with Zod. Prefer named,
 exported schemas when an input shape is shared across callers, services, or

--- a/docs/adr/0002-api-standard-and-service-testing.md
+++ b/docs/adr/0002-api-standard-and-service-testing.md
@@ -1,0 +1,106 @@
+# ADR 0002: API Standard and Service Testing
+
+Status: Accepted
+
+Date: June 25, 2026
+
+## Context
+
+Sanbi currently has two backend API surfaces:
+
+- tRPC routers under `src/server/api/routers`, used by the Next.js app through
+  the shared tRPC client and server caller helpers.
+- oRPC resource routes under `src/server/orpc`, which expose RPC/OpenAPI-style
+  handlers for the existing resource work.
+
+Most Sanbi features are internal application workflows scoped to the signed-in
+user's organization. New feature work should not re-decide between tRPC, oRPC,
+and OpenAPI for each endpoint. The default should match the app's current
+internal client/server model while preserving a path for future public API
+contracts if Sanbi accepts that requirement.
+
+## Decision
+
+New internal Sanbi APIs use tRPC by default.
+
+Use `createTRPCRouter` and the procedure helpers from `src/server/api/trpc.ts`.
+For organization-owned data, start with `organizationProcedure` or
+`adminProcedure` instead of repeating auth, user lookup, organization lookup, or
+membership checks inside each endpoint. Use `publicProcedure` only for behavior
+that is intentionally unauthenticated.
+
+Input validation belongs at the procedure boundary with Zod. Prefer named,
+exported schemas when an input shape is shared across callers, services, or
+tests. Keep normalization either in the schema when it is pure input shaping or
+in the service when it depends on existing data, permissions, or external work.
+
+Keep simple reads and thin writes in the router when the procedure is only
+validating input, applying the existing organization procedure guard, and making
+a direct query. Extract non-trivial behavior into a focused service function
+when a mutation has branching, normalization, conflict handling, side effects,
+or data-access orchestration. Service functions should accept explicit injected
+dependencies, such as a `resourceDataAccess`-style object, so tests can exercise
+business behavior without a real database.
+
+Reserve OpenAPI, oRPC-style contracts, and public documentation routes for a
+future accepted public API requirement. Existing oRPC resource work should be
+migrated separately rather than copied as the pattern for new internal features.
+
+Chord chart API work should follow this decision: add organization-scoped tRPC
+procedures for internal app workflows, extract complex chart behavior into
+injectable services, and defer public/OpenAPI contract design until there is a
+specific accepted public API need.
+
+## Endpoint Shape
+
+New internal endpoints should generally use this shape:
+
+- Define Zod input and output shapes close to the domain, reusing existing
+  schema helpers when available.
+- Add procedures to a domain router under `src/server/api/routers`, then export
+  and register that router through `src/server/api/routers/index.ts` and
+  `src/server/api/root.ts`.
+- Use `organizationProcedure` for organization-scoped reads and writes so the
+  caller must provide a valid `organizationId` and the context includes the
+  authenticated user, membership, and organization.
+- Use shared auth and membership helpers instead of duplicating membership
+  lookups or trusting organization IDs from client state.
+- For complex mutations, call a service function from the procedure and pass
+  only the dependencies that service needs: data access functions, clocks,
+  metadata resolvers, loggers, or other hard boundaries.
+- Map expected domain failures to tRPC errors at the boundary or inside the
+  service, keeping error codes stable for callers and tests.
+
+## Testing
+
+Do not use Postman, generated OpenAPI clients, or browser UI tests as the
+default way to verify internal procedures.
+
+Test pure domain rules and complex mutations with service tests. Inject narrow
+data-access fixtures from `src/testUtils` and assert authorization, missing
+data, cross-organization access, no-op updates, changed-field writes,
+validation/normalization, and expected conflict or error mappings. These tests
+should not make real database calls unless the database contract itself is the
+behavior under test.
+
+Test router wiring and procedure behavior with tRPC callers. Create callers from
+the domain router or app router with a test context, then call the procedure
+directly. This covers Zod validation, procedure middleware, auth context,
+membership handling, and response mapping without going through HTTP or UI.
+
+Use Playwright only for user-visible workflows where browser behavior,
+navigation, Clerk integration, rendering, or accessibility is the subject of the
+test. Backend authorization, validation, and mutation branching should be
+covered by service or tRPC caller tests first.
+
+## Consequences
+
+- Internal API work has one default: tRPC.
+- Public API decisions are explicit product and architecture decisions, not a
+  side effect of endpoint implementation.
+- Services remain reusable and testable when behavior is too complex to live
+  directly in a router.
+- Procedure tests stay fast because they call services or tRPC callers without
+  Postman, OpenAPI generation, a browser, or real database access by default.
+- Existing oRPC resource routes remain in place until a separate migration moves
+  that surface to tRPC.


### PR DESCRIPTION
## Background
- Linear ticket: https://linear.app/sanbi/issue/SWY-194
- This documents the API standard and service testing pattern for Sanbi so new internal feature work has a clear default instead of re-deciding between tRPC, oRPC, and OpenAPI for each endpoint.
- The ADR also captures when to keep logic in routers, when to extract injectable services, and how chord chart API work should follow the internal tRPC path until a public API requirement is accepted.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new architecture decision record outlining the recommended internal API and testing approach.
  * Clarified guidance for choosing API patterns, validating inputs, handling errors consistently, and separating business logic into testable services.
  * Documented the preferred testing mix for service logic, API behavior, and end-to-end user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Added ADR 0002 defining tRPC as the default API surface for new internal Sanbi APIs.
- Documented expected procedure shape, organization-scoped middleware usage, Zod validation placement, service extraction criteria, and dependency-injected service testing.
- Clarified that existing oRPC resource routes remain in place until a separate migration and that Playwright should be reserved for user-visible workflows.

## How to test
- No web app behavior changed; verify by reviewing the new ADR in the GitHub Files changed view and confirming the documented API/testing guidance matches current Sanbi development expectations.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds ADR 0002, which establishes tRPC as the default internal API surface for Sanbi and documents service extraction criteria and the preferred testing pyramid. No application code changes.

- **API standard**: Mandates `createTRPCRouter` with the existing procedure hierarchy (`publicProcedure` → `authedProcedure` → `organizationProcedure` → `adminProcedure`) for new internal endpoints, deferring oRPC/OpenAPI to a future explicit public-API decision.
- **Service extraction rule**: Keeps thin reads and writes in the router; extracts to injectable service functions only when a mutation has branching, conflict handling, side effects, or data-access orchestration.
- **Testing pyramid**: Service tests (injected fixtures) → tRPC caller tests (in-process context) → Playwright only for user-visible browser workflows.

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no production code is modified.

The PR adds a single ADR markdown file. All referenced source paths and procedure names were verified to exist in the codebase. The guidance is internally consistent and aligns with existing sanbi-rules conventions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/adr/0002-api-standard-and-service-testing.md | New ADR documenting tRPC as the default API surface, service extraction criteria, and the testing pyramid; all referenced file paths and procedure names were verified to exist in the codebase. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New backend endpoint needed?] --> B{Internal app workflow?}
    B -- Yes --> C[Use tRPC\ncreateTRPCRouter]
    B -- No --> D[Future public API requirement\naccept explicitly first]
    C --> E{Auth scope?}
    E -- Unauthenticated --> F[publicProcedure]
    E -- Signed-in, no org --> G[authedProcedure]
    E -- Org-owned data --> H[organizationProcedure]
    E -- Admin action --> I[adminProcedure]
    H & I --> J{Complexity?}
    J -- Simple read / thin write --> K[Keep logic in router]
    J -- Branching / side effects\n/ conflict handling --> L[Extract to service function\nwith injected dependencies]
    L --> M[Test with injected fixtures\nfrom src/testUtils]
    K --> N[Test with tRPC caller\nin test context]
    D --> O[OpenAPI / oRPC contract\ndesigned separately]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[New backend endpoint needed?] --> B{Internal app workflow?}
    B -- Yes --> C[Use tRPC\ncreateTRPCRouter]
    B -- No --> D[Future public API requirement\naccept explicitly first]
    C --> E{Auth scope?}
    E -- Unauthenticated --> F[publicProcedure]
    E -- Signed-in, no org --> G[authedProcedure]
    E -- Org-owned data --> H[organizationProcedure]
    E -- Admin action --> I[adminProcedure]
    H & I --> J{Complexity?}
    J -- Simple read / thin write --> K[Keep logic in router]
    J -- Branching / side effects\n/ conflict handling --> L[Extract to service function\nwith injected dependencies]
    L --> M[Test with injected fixtures\nfrom src/testUtils]
    K --> N[Test with tRPC caller\nin test context]
    D --> O[OpenAPI / oRPC contract\ndesigned separately]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Add authenticated procedure guidance"](https://github.com/justaddcl/sanbi/commit/e67a0a77f4acf87e34d03d7a678c3ee5061d3f09) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39845433)</sub>

<!-- /greptile_comment -->