### PR TITLE
[SWY-199] Add default button type and UI semantics audit

### DIFF
--- a/src/app/[organization]/page.tsx
+++ b/src/app/[organization]/page.tsx
@@ -63,7 +63,17 @@ export default async function Dashboard({
         <select aria-label="Filter sets by date range">
           <option value="This week">This week</option>
         </select>
-        <a className="text-xs text-slate-900">See all</a>
+        <button
+          type="button"
+          className="text-xs text-slate-400"
+          disabled
+          aria-describedby="upcoming-sets-see-all-description"
+        >
+          See all
+        </button>
+        <span id="upcoming-sets-see-all-description" className="sr-only">
+          All sets are already shown
+        </span>
       </section>
       {/* FIXME: update set list styling */}
       <VStack className="gap-8">

--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,50 @@
+import type React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { Button } from "../button";
+
+describe("Button", () => {
+  it("defaults to non-submit behavior inside forms", () => {
+    const onSubmit = jest.fn((event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+
+    render(
+      <form onSubmit={onSubmit}>
+        <Button>Open menu</Button>
+      </form>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit submit behavior", () => {
+    const onSubmit = jest.fn((event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+
+    render(
+      <form onSubmit={onSubmit}>
+        <Button type="submit">Save</Button>
+      </form>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not add button-only attributes to slotted links", () => {
+    render(
+      <Button asChild>
+        <a href="https://example.com/sets">View sets</a>
+      </Button>,
+    );
+
+    expect(screen.getByRole("link", { name: "View sets" })).not.toHaveAttribute(
+      "type",
+    );
+  });
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -61,11 +61,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const buttonClassName = cn(buttonVariants({ variant, size, className }));
 
     if (asChild) {
-      return (
-        <Slot className={buttonClassName} ref={ref} {...props}>
-          {props.children}
-        </Slot>
-      );
+      return <Slot className={buttonClassName} ref={ref} {...props} />;
     }
 
     return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -52,16 +52,28 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       isLoading = false,
       leftIcon,
       rightIcon,
+      disabled,
+      type,
       ...props
     },
     ref,
   ) => {
-    const Comp = asChild ? Slot : "button";
+    const buttonClassName = cn(buttonVariants({ variant, size, className }));
+
+    if (asChild) {
+      return (
+        <Slot className={buttonClassName} ref={ref} {...props}>
+          {props.children}
+        </Slot>
+      );
+    }
+
     return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+      <button
+        className={buttonClassName}
         ref={ref}
-        {...(isLoading && { disabled: true })}
+        type={type ?? "button"}
+        disabled={isLoading ? true : disabled}
         {...props}
       >
         {isLoading && (
@@ -70,7 +82,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {!isLoading && leftIcon}
         {props.children}
         {rightIcon}
-      </Comp>
+      </button>
     );
   },
 );

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -278,160 +278,171 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
     <CommandList className="max-h-[calc(100dvh_-_24px)] md:max-h-[calc(100dvh_-_12dvh_-_5dvh)]">
       <CommandGroup>
         <div className="grid grid-cols-[40px_1fr_40px] items-center">
-          <Button size="icon" variant="ghost" onClick={goBackToSearch}>
-            <CaretLeft />
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label="Back to song search"
+            onClick={goBackToSearch}
+          >
+            <CaretLeft aria-hidden />
           </Button>
           <DialogTitle className="text-center">Add song to set</DialogTitle>
         </div>
         <DialogDescription asChild>
           <div className="mt-6 flex flex-col gap-6">
-          <div
-            className="hover:bg-accent cursor-pointer rounded-lg border px-3 py-2 text-slate-900 transition-colors"
-            onClick={goBackToSearch}
-          >
-            <SongListItem
-              song={{
-                id: selectedSong.songId,
-                name: selectedSong.name,
-                preferredKey: selectedSong.preferredKey,
-                isArchived: selectedSong.isArchived,
-              }}
-              lastPlayed={selectedSong?.lastPlayedDate}
-              tags={selectedSong?.tags}
-              hidePreferredKey
-              size={isDesktop ? "md" : "sm"}
-            />
-          </div>
-          <Form {...addSongToSetForm}>
-            <form
-              onSubmit={addSongToSetForm.handleSubmit(handleAddSongToSetSubmit)}
-              className="flex flex-col gap-6"
+            <div
+              className="hover:bg-accent cursor-pointer rounded-lg border px-3 py-2 text-slate-900 transition-colors"
+              onClick={goBackToSearch}
             >
-              <section className="flex flex-col gap-2 text-slate-700">
-                <FormField
-                  control={addSongToSetForm.control}
-                  name="key"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel
-                        className={cn("font-normal text-slate-900", textSize)}
-                      >
-                        Song key
-                      </FormLabel>
-                      <FormControl>
-                        <Select
-                          onValueChange={field.onChange}
-                          defaultValue={field.value as string}
-                        >
-                          <SelectTrigger
-                            aria-label="Song key"
-                            className={cn(textSize)}
-                          >
-                            <SelectValue placeholder="Select song key" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {songKeys.map((key) => {
-                              const appendedText = [];
-                              if (key === selectedSong.preferredKey) {
-                                appendedText.push("preferred key");
-                              }
-                              if (key === lastPlayInstance?.song.key) {
-                                appendedText.push("last played in");
-                              }
-                              return (
-                                <SelectItem
-                                  key={key}
-                                  value={key}
-                                  className={cn(textSize)}
-                                >
-                                  {formatSongKey(key)}
-                                  {appendedText.length > 0 &&
-                                    ` (${appendedText.join(", ")})`}
-                                </SelectItem>
-                              );
-                            })}
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-                <div className="flex gap-2 text-slate-500">
-                  <div className="flex items-center gap-1">
-                    <Heart />
-                    <Text style={isDesktop ? "body-small" : "small"}>
-                      Preferred key: {formatSongKey(selectedSong.preferredKey!)}
-                      {/* used the non-null assertion since all songs should have a selected key */}
-                    </Text>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <ClockCounterClockwise />
-                    <HStack className="items-center">
-                      <Text style={isDesktop ? "body-small" : "small"}>
-                        Last played:
-                      </Text>
-                      {isLastPlayInstanceQueryLoading && (
-                        <>
-                          <CircleNotch
-                            size={12}
-                            className="mr-2 h-4 w-4 animate-spin"
-                          />
-                          <Text style={isDesktop ? "body-small" : "small"}>
-                            Looking up last time {selectedSong.name} was
-                            played...
-                          </Text>
-                        </>
-                      )}
-                      {!isLastPlayInstanceQueryLoading &&
-                        lastPlayInstance?.song.key && (
-                          <Text
-                            style={isDesktop ? "body-small" : "small"}
-                            className="ml-1"
-                          >
-                            {formatSongKey(lastPlayInstance.song.key)}
-                          </Text>
-                        )}
-                    </HStack>
-                  </div>
-                </div>
-              </section>
-              <section className="flex flex-col text-slate-700">
-                {sectionsForSetData.length > 0 && (
+              <SongListItem
+                song={{
+                  id: selectedSong.songId,
+                  name: selectedSong.name,
+                  preferredKey: selectedSong.preferredKey,
+                  isArchived: selectedSong.isArchived,
+                }}
+                lastPlayed={selectedSong?.lastPlayedDate}
+                tags={selectedSong?.tags}
+                hidePreferredKey
+                size={isDesktop ? "md" : "sm"}
+              />
+            </div>
+            <Form {...addSongToSetForm}>
+              <form
+                onSubmit={addSongToSetForm.handleSubmit(
+                  handleAddSongToSetSubmit,
+                )}
+                className="flex flex-col gap-6"
+              >
+                <section className="flex flex-col gap-2 text-slate-700">
                   <FormField
                     control={addSongToSetForm.control}
-                    name="setSectionId"
+                    name="key"
                     render={({ field }) => (
-                      <FormItem className="mb-2">
+                      <FormItem>
                         <FormLabel
                           className={cn("font-normal text-slate-900", textSize)}
                         >
-                          Which part of the set?
+                          Song key
                         </FormLabel>
                         <FormControl>
-                          <RadioGroup
+                          <Select
                             onValueChange={field.onChange}
-                            defaultValue={field.value}
-                            value={field.value}
+                            defaultValue={field.value as string}
                           >
-                            {sectionsForSetData.map((setSection) => (
-                              <FormItem
-                                key={setSection.id}
-                                className="flex items-center space-y-0 rounded border border-slate-200"
-                              >
-                                <div className="flex w-full items-center gap-2 py-2 pl-4">
-                                  <FormControl>
-                                    <RadioGroupItem
-                                      value={setSection.id}
-                                      className="size-3"
-                                    />
-                                  </FormControl>
-                                  <FormLabel className="flex-1 cursor-pointer">
-                                    <Text className={cn(textSize)}>
-                                      {setSection.type.name}
-                                    </Text>
-                                  </FormLabel>
-                                </div>
-                                {/* {isClearable(setSection) &&
+                            <SelectTrigger
+                              aria-label="Song key"
+                              className={cn(textSize)}
+                            >
+                              <SelectValue placeholder="Select song key" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {songKeys.map((key) => {
+                                const appendedText = [];
+                                if (key === selectedSong.preferredKey) {
+                                  appendedText.push("preferred key");
+                                }
+                                if (key === lastPlayInstance?.song.key) {
+                                  appendedText.push("last played in");
+                                }
+                                return (
+                                  <SelectItem
+                                    key={key}
+                                    value={key}
+                                    className={cn(textSize)}
+                                  >
+                                    {formatSongKey(key)}
+                                    {appendedText.length > 0 &&
+                                      ` (${appendedText.join(", ")})`}
+                                  </SelectItem>
+                                );
+                              })}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <div className="flex gap-2 text-slate-500">
+                    <div className="flex items-center gap-1">
+                      <Heart />
+                      <Text style={isDesktop ? "body-small" : "small"}>
+                        Preferred key:{" "}
+                        {formatSongKey(selectedSong.preferredKey!)}
+                        {/* used the non-null assertion since all songs should have a selected key */}
+                      </Text>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <ClockCounterClockwise />
+                      <HStack className="items-center">
+                        <Text style={isDesktop ? "body-small" : "small"}>
+                          Last played:
+                        </Text>
+                        {isLastPlayInstanceQueryLoading && (
+                          <>
+                            <CircleNotch
+                              size={12}
+                              className="mr-2 h-4 w-4 animate-spin"
+                            />
+                            <Text style={isDesktop ? "body-small" : "small"}>
+                              Looking up last time {selectedSong.name} was
+                              played...
+                            </Text>
+                          </>
+                        )}
+                        {!isLastPlayInstanceQueryLoading &&
+                          lastPlayInstance?.song.key && (
+                            <Text
+                              style={isDesktop ? "body-small" : "small"}
+                              className="ml-1"
+                            >
+                              {formatSongKey(lastPlayInstance.song.key)}
+                            </Text>
+                          )}
+                      </HStack>
+                    </div>
+                  </div>
+                </section>
+                <section className="flex flex-col text-slate-700">
+                  {sectionsForSetData.length > 0 && (
+                    <FormField
+                      control={addSongToSetForm.control}
+                      name="setSectionId"
+                      render={({ field }) => (
+                        <FormItem className="mb-2">
+                          <FormLabel
+                            className={cn(
+                              "font-normal text-slate-900",
+                              textSize,
+                            )}
+                          >
+                            Which part of the set?
+                          </FormLabel>
+                          <FormControl>
+                            <RadioGroup
+                              onValueChange={field.onChange}
+                              defaultValue={field.value}
+                              value={field.value}
+                            >
+                              {sectionsForSetData.map((setSection) => (
+                                <FormItem
+                                  key={setSection.id}
+                                  className="flex items-center space-y-0 rounded border border-slate-200"
+                                >
+                                  <div className="flex w-full items-center gap-2 py-2 pl-4">
+                                    <FormControl>
+                                      <RadioGroupItem
+                                        value={setSection.id}
+                                        className="size-3"
+                                      />
+                                    </FormControl>
+                                    <FormLabel className="flex-1 cursor-pointer">
+                                      <Text className={cn(textSize)}>
+                                        {setSection.type.name}
+                                      </Text>
+                                    </FormLabel>
+                                  </div>
+                                  {/* {isClearable(setSection) &&
                                   setSection.clearable && (
                                     <Button
                                       variant="ghost"
@@ -446,143 +457,143 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                                       <X />
                                     </Button>
                                   )} */}
-                              </FormItem>
-                            ))}
-                          </RadioGroup>
+                                </FormItem>
+                              ))}
+                            </RadioGroup>
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
+                  {sectionsForSetData.length === 0 && (
+                    <VStack className="gap-2">
+                      <Text
+                        className={cn("font-normal text-slate-900", textSize)}
+                      >
+                        Which part of the set?
+                      </Text>
+                      <div className="mb-4 flex w-full flex-col items-center rounded border border-dashed border-slate-200 py-3">
+                        <Text
+                          style="header-small-semibold"
+                          align="center"
+                          className="text-slate-900"
+                        >
+                          No sections yet
+                        </Text>
+                        <Text align="center" className="">
+                          Add one below to get started.
+                        </Text>
+                      </div>
+                    </VStack>
+                  )}
+                  {!isAddingSection && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className={cn("border border-dashed", [
+                        !isDesktop && "h-8",
+                      ])}
+                      onClick={() => setIsAddingSection(true)}
+                    >
+                      <Plus />
+                      <Text className={cn(textSize)}>Add another section</Text>
+                    </Button>
+                  )}
+                  {isAddingSection && (
+                    <>
+                      <SetSectionTypeCombobox
+                        placeholder="Add a set section"
+                        value={newSetSectionType}
+                        onChange={setNewSetSectionType}
+                        textStyles={cn("text-slate-700", textSize)}
+                        organizationId={userMembership.organizationId}
+                      />
+                      <div className="mt-2 flex justify-end gap-2">
+                        {sectionsForSetData.length > 0 && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                              setIsAddingSection(false);
+                              clearErrors("setSectionId");
+                              setNewSetSectionType(null);
+                            }}
+                            className={cn(textSize)}
+                          >
+                            Cancel
+                          </Button>
+                        )}
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={(clickEvent) =>
+                            handleAddSetSection(clickEvent)
+                          }
+                          disabled={
+                            !newSetSectionType ||
+                            newSetSectionType.id === "" ||
+                            createSetSectionMutation.isPending
+                          }
+                          isLoading={createSetSectionMutation.isPending}
+                          className={cn(textSize)}
+                        >
+                          Add section to set
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </section>
+                <section>
+                  <FormField
+                    control={addSongToSetForm.control}
+                    name="notes"
+                    render={({ field }) => (
+                      <FormItem className="">
+                        <FormLabel
+                          className={cn("font-normal text-slate-900", textSize)}
+                        >
+                          Song notes
+                        </FormLabel>
+                        <FormControl>
+                          <Textarea {...field} value={field.value ?? ""} />
                         </FormControl>
-                        <FormMessage />
                       </FormItem>
                     )}
                   />
-                )}
-                {sectionsForSetData.length === 0 && (
-                  <VStack className="gap-2">
-                    <Text
-                      className={cn("font-normal text-slate-900", textSize)}
-                    >
-                      Which part of the set?
-                    </Text>
-                    <div className="mb-4 flex w-full flex-col items-center rounded border border-dashed border-slate-200 py-3">
-                      <Text
-                        style="header-small-semibold"
-                        align="center"
-                        className="text-slate-900"
-                      >
-                        No sections yet
-                      </Text>
-                      <Text align="center" className="">
-                        Add one below to get started.
-                      </Text>
-                    </div>
-                  </VStack>
-                )}
-                {!isAddingSection && (
+                </section>
+                <div className="flex flex-col gap-4 sm:flex-row sm:justify-end">
+                  <FormField
+                    control={addSongToSetForm.control}
+                    name="addAnotherSong"
+                    render={({ field }) => (
+                      <FormItem className="flex items-center gap-1 space-y-0 self-end md:self-center">
+                        <FormControl>
+                          <Switch
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                        <FormLabel
+                          className={cn("font-normal text-slate-700", textSize)}
+                        >
+                          Add another song
+                        </FormLabel>
+                      </FormItem>
+                    )}
+                  />
                   <Button
                     size="sm"
-                    variant="ghost"
-                    className={cn("border border-dashed", [
-                      !isDesktop && "h-8",
-                    ])}
-                    onClick={() => setIsAddingSection(true)}
+                    type="submit"
+                    disabled={shouldAddSongBeDisabled}
+                    isLoading={isSubmitting}
                   >
-                    <Plus />
-                    <Text className={cn(textSize)}>Add another section</Text>
+                    Add song
                   </Button>
-                )}
-                {isAddingSection && (
-                  <>
-                    <SetSectionTypeCombobox
-                      placeholder="Add a set section"
-                      value={newSetSectionType}
-                      onChange={setNewSetSectionType}
-                      textStyles={cn("text-slate-700", textSize)}
-                      organizationId={userMembership.organizationId}
-                    />
-                    <div className="mt-2 flex justify-end gap-2">
-                      {sectionsForSetData.length > 0 && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => {
-                            setIsAddingSection(false);
-                            clearErrors("setSectionId");
-                            setNewSetSectionType(null);
-                          }}
-                          className={cn(textSize)}
-                        >
-                          Cancel
-                        </Button>
-                      )}
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={(clickEvent) =>
-                          handleAddSetSection(clickEvent)
-                        }
-                        disabled={
-                          !newSetSectionType ||
-                          newSetSectionType.id === "" ||
-                          createSetSectionMutation.isPending
-                        }
-                        isLoading={createSetSectionMutation.isPending}
-                        className={cn(textSize)}
-                      >
-                        Add section to set
-                      </Button>
-                    </div>
-                  </>
-                )}
-              </section>
-              <section>
-                <FormField
-                  control={addSongToSetForm.control}
-                  name="notes"
-                  render={({ field }) => (
-                    <FormItem className="">
-                      <FormLabel
-                        className={cn("font-normal text-slate-900", textSize)}
-                      >
-                        Song notes
-                      </FormLabel>
-                      <FormControl>
-                        <Textarea {...field} value={field.value ?? ""} />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </section>
-              <div className="flex flex-col gap-4 sm:flex-row sm:justify-end">
-                <FormField
-                  control={addSongToSetForm.control}
-                  name="addAnotherSong"
-                  render={({ field }) => (
-                    <FormItem className="flex items-center gap-1 space-y-0 self-end md:self-center">
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                      <FormLabel
-                        className={cn("font-normal text-slate-700", textSize)}
-                      >
-                        Add another song
-                      </FormLabel>
-                    </FormItem>
-                  )}
-                />
-                <Button
-                  size="sm"
-                  type="submit"
-                  disabled={shouldAddSongBeDisabled}
-                  isLoading={isSubmitting}
-                >
-                  Add song
-                </Button>
-              </div>
-              <DevTool control={addSongToSetForm.control} />
-            </form>
-          </Form>
+                </div>
+                <DevTool control={addSongToSetForm.control} />
+              </form>
+            </Form>
           </div>
         </DialogDescription>
       </CommandGroup>

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -160,9 +160,10 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
               <Button
                 size="icon"
                 variant="ghost"
+                aria-label="Back to song search"
                 onClick={() => setDialogStep("search")}
               >
-                <CaretLeft />
+                <CaretLeft aria-hidden />
               </Button>
               <DialogTitle className="text-center">Replace song</DialogTitle>
             </div>

--- a/src/modules/songs/forms/AddSongToSet/components/SetSelectionFilters.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSelectionFilters.tsx
@@ -105,8 +105,9 @@ export const SetSelectionFilters: React.FC<SetSelectionFiltersProps> = ({
                   size="icon"
                   variant="secondary"
                   className="rounded-full"
+                  aria-label="Close filters"
                 >
-                  <X />
+                  <X aria-hidden />
                 </Button>
               </DrawerClose>
             </HStack>


### PR DESCRIPTION
## Background
- Linear: https://linear.app/paranoid-android/issue/SWY-199/add-default-button-type-and-ui-semantics-audit
- This reduces accidental form submits and UI semantics regressions by making the shared `Button` safe-by-default and auditing touched dashboard and song/set controls for clearer button/link behavior and accessible names.

## What's changed
@coderabbitai summary
- The shared `Button` now defaults native buttons to `type="button"`, preserves explicit submit behavior, keeps loading buttons disabled, and avoids applying button-only props to `asChild` slots.
- Added component coverage for the default non-submit behavior, explicit submit behavior, and slotted link behavior.
- Updated touched UI controls so icon-only buttons have accessible labels, decorative icons are hidden, and the dashboard `See all` affordance is represented as a disabled button instead of an anchor without an `href`.

## How to test
- Open a form that uses secondary or utility buttons, such as adding a song to a set, and confirm clicking non-submit controls does not submit the form.
- Submit a form with an explicit submit button and confirm it still submits normally.
- Navigate the add/replace song dialogs and mobile set filters with a screen reader or accessibility inspector and confirm the back/close icon buttons have readable names.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the shared `Button` component safer by defaulting native buttons to `type="button"`, preventing accidental form submissions from non-submit controls. It also audits touched UI components for accessibility, adding `aria-label` to icon-only buttons, marking decorative icons with `aria-hidden`, and converting the dashboard "See all" affordance to a properly described disabled button.

- **`button.tsx`**: Splits `asChild` and native-button rendering paths; the native path sets `type={type ?? "button"}` and merges `disabled` with `isLoading`. Button-only props (`type`, `disabled`, `isLoading`, `leftIcon`, `rightIcon`) are not forwarded to the slotted element.
- **Accessibility audit** across `ConfigureSongForSet`, `ReplaceSongDialog`, and `SetSelectionFilters`: back/close icon buttons gain `aria-label`, their icons gain `aria-hidden`.
- **Tests** cover the three new `Button` behaviors: default non-submit, explicit submit, and clean `asChild` slot.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive safety and accessibility improvements with no logic regressions.

The core change (defaulting to `type="button"`) is low-risk and well-tested. The asChild split is correct: button-only props are intentionally withheld from slotted elements, and the new tests validate the three key behaviors. Accessibility additions are confined to `aria-label` and `aria-hidden` attributes; no functional logic was altered in the consumer components beyond the back button in the add/replace song dialogs.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/ui/button.tsx | Adds default `type="button"`, merges disabled/isLoading state, and splits asChild vs native-button paths to prevent button-only props leaking to slots. Logic is correct. |
| src/components/ui/__tests__/button.test.tsx | New test file covering default non-submit, explicit submit, and clean asChild slot behaviors. Tests are well-structured and use real component rendering. |
| src/modules/sets/components/OrganizationDashboardSets/OrganizationDashboardSets.tsx | Converts "See all" from a misleading anchor-like element to a properly disabled button with `aria-describedby` explaining why it's inactive. Color updated to match disabled visual state. |
| src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx | Adds `aria-label="Back to song search"` and `aria-hidden` to the back icon button; remaining diff is indentation cleanup with no logic changes. |
| src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx | Adds `aria-label="Back to song search"` and `aria-hidden` to the back icon button, consistent with ConfigureSongForSet changes. |
| src/modules/songs/forms/AddSongToSet/components/SetSelectionFilters.tsx | Adds `aria-label="Close filters"` and `aria-hidden` to the drawer close icon button. Correct usage within `DrawerClose asChild` context. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Button render called] --> B{asChild?}
    B -- yes --> C[Return Slot with className + props\ntype, disabled, isLoading, leftIcon, rightIcon excluded]
    B -- no --> D[Resolve type: type ?? 'button']
    D --> E[Resolve disabled: isLoading ? true : disabled]
    E --> F{isLoading?}
    F -- yes --> G[Render spinner + children + rightIcon\ndisabled=true]
    F -- no --> H[Render leftIcon + children + rightIcon]
    G --> I[native button element]
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Button render called] --> B{asChild?}
    B -- yes --> C[Return Slot with className + props\ntype, disabled, isLoading, leftIcon, rightIcon excluded]
    B -- no --> D[Resolve type: type ?? 'button']
    D --> E[Resolve disabled: isLoading ? true : disabled]
    E --> F{isLoading?}
    F -- yes --> G[Render spinner + children + rightIcon\ndisabled=true]
    F -- no --> H[Render leftIcon + children + rightIcon]
    G --> I[native button element]
    H --> I
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/justaddcl/sanbi/commit/c6a2d657233c35904d1113a9ea8bd31ab4dd21c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39944281)</sub>

<!-- /greptile_comment -->