### PR TITLE
[SWY-191] Reuse global song search UI in pickers

### DIFF
--- a/src/modules/search/components/Search.tsx
+++ b/src/modules/search/components/Search.tsx
@@ -1,42 +1,26 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { XIcon } from "@phosphor-icons/react/dist/ssr";
-import { useDebounceValue } from "usehooks-ts";
 
 import { Button } from "@components/ui/button";
 import { CommandDialog, CommandInput } from "@components/ui/command";
 import { HStack } from "@components/HStack";
-import { getGlobalSearchResultGroups } from "@modules/search/utils/getGlobalSearchResultGroups";
-import {
-  getVisibleGlobalSearchResults,
-  GLOBAL_SEARCH_RESULT_COUNT_LIMIT,
-  type SearchFilter,
-} from "@modules/search/utils/getVisibleGlobalSearchResults";
+import { useSongSearchResults } from "@modules/search/hooks/useSongSearchResults";
 import { AddSongToSetDialog } from "@modules/songs/forms/AddSongToSet/components/AddSongToSetDialog";
-import { trpc } from "@lib/trpc";
 import { cn } from "@lib/utils";
 
 import { SearchFilterControls } from "./SearchFilterControls";
 import { SearchResultsList } from "./SearchResultsList";
 import { SearchShortcutLegend } from "./SearchShortcutLegend";
 import { SearchTrigger } from "./SearchTrigger";
-import { type SearchSongResult, type SearchToggleFilter } from "./types";
+import { type SearchSongResult } from "./types";
 
 type SearchProps = {
   className?: string;
 };
 
-const MIN_SEARCH_LENGTH = 2;
-const SEARCH_DEBOUNCE_DELAY = 300;
 const DIALOG_EXIT_ANIMATION_DELAY = 200;
 
 export const Search: React.FC<SearchProps> = ({ className }) => {
@@ -44,17 +28,6 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
   const router = useRouter();
   const searchDescriptionId = useId();
   const [open, setOpen] = useState(false);
-  const [searchInput, setSearchInput] = useState("");
-  const [debouncedSearchInput, setDebouncedSearchInput] = useDebounceValue(
-    searchInput,
-    SEARCH_DEBOUNCE_DELAY,
-  );
-  const [selectedFilters, setSelectedFilters] = useState<
-    Record<SearchToggleFilter, boolean>
-  >({
-    songs: false,
-    tags: false,
-  });
   const [songToAddToSet, setSongToAddToSet] = useState<SearchSongResult | null>(
     null,
   );
@@ -67,114 +40,26 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
 
   const organizationId = params.organization;
   const currentSetId = params.setId;
-  const normalizedSearchInput = debouncedSearchInput.trim();
-  const normalizedSearchQuery = normalizedSearchInput.toLowerCase();
-  const hasSearchableInput = searchInput.trim().length >= MIN_SEARCH_LENGTH;
-  const canSearch =
-    !!organizationId && normalizedSearchInput.length >= MIN_SEARCH_LENGTH;
-  const isWaitingForDebounce =
-    hasSearchableInput && searchInput.trim() !== normalizedSearchInput;
-  const closeOrClearLabel = searchInput ? "Clear search" : "Close search";
-  const escapeShortcutLabel = searchInput.trim().length > 0 ? "Clear" : "Close";
-  const activeFilter: SearchFilter = useMemo(() => {
-    if (selectedFilters.songs === selectedFilters.tags) {
-      return "all";
-    }
-
-    return selectedFilters.songs ? "songs" : "tags";
-  }, [selectedFilters]);
-
   const {
-    data: searchResults,
-    isFetching: isSearchFetching,
-    isError: isSearchError,
-  } = trpc.song.search.useQuery(
-    {
-      organizationId: organizationId ?? "",
-      searchInput: normalizedSearchInput,
-      limit: GLOBAL_SEARCH_RESULT_COUNT_LIMIT,
-    },
-    {
-      enabled: canSearch,
-    },
-  );
-
-  const { songResults, tagResults } = useMemo(
-    () =>
-      getGlobalSearchResultGroups({
-        normalizedSearchQuery,
-        searchResults: searchResults ?? [],
-      }),
-    [normalizedSearchQuery, searchResults],
-  );
-
-  const songResultIds = useMemo(
-    () => new Set(songResults.map((result) => result.songId)),
-    [songResults],
-  );
-
-  const visibleTagCandidateResults = useMemo(() => {
-    if (activeFilter !== "all") {
-      return tagResults;
-    }
-
-    return tagResults.filter((result) => !songResultIds.has(result.songId));
-  }, [activeFilter, songResultIds, tagResults]);
-
-  const {
+    activeFilter,
+    emptyResultsMessage,
+    handleFilterToggle,
+    handleInputChange,
+    hasSearchResultOverflow,
+    hasSearchableInput,
+    isSearchError,
+    normalizedSearchInput,
+    resetSearchInput,
+    searchInput,
+    searchResultCountLabel,
+    selectedFilters,
+    shouldShowLoading,
+    visibleResultCount,
     visibleSongResults,
     visibleTagResults,
-    hasOverflow: hasSearchResultOverflow,
-  } = useMemo(
-    () =>
-      getVisibleGlobalSearchResults({
-        activeFilter,
-        songResults,
-        tagResults: visibleTagCandidateResults,
-      }),
-    [activeFilter, songResults, visibleTagCandidateResults],
-  );
-  const visibleResultCount =
-    visibleSongResults.length + visibleTagResults.length;
-  const totalResultCount = useMemo(() => {
-    if (activeFilter === "songs") {
-      return songResults.length;
-    }
-
-    if (activeFilter === "tags") {
-      return tagResults.length;
-    }
-
-    return songResults.length + visibleTagCandidateResults.length;
-  }, [activeFilter, songResults, tagResults, visibleTagCandidateResults]);
-  const searchResultCountLabel =
-    searchResults && searchResults.length >= GLOBAL_SEARCH_RESULT_COUNT_LIMIT
-      ? `${totalResultCount}+`
-      : totalResultCount.toString();
-  const shouldShowLoading =
-    hasSearchableInput && (isWaitingForDebounce || isSearchFetching);
-
-  const emptyResultsMessage = useMemo(() => {
-    if (!organizationId) {
-      return "Search is available inside an organization.";
-    }
-
-    if (activeFilter === "songs") {
-      return `No songs found for "${normalizedSearchInput}".`;
-    }
-
-    if (activeFilter === "tags") {
-      return `No songs found with matching tags for "${normalizedSearchInput}".`;
-    }
-
-    return `No results found for "${normalizedSearchInput}".`;
-  }, [activeFilter, normalizedSearchInput, organizationId]);
-
-  const resetSearchInput = useCallback(() => {
-    setSearchInput("");
-    setDebouncedSearchInput("");
-    setSelectedFilters({ songs: false, tags: false });
-  }, [setDebouncedSearchInput]);
+  } = useSongSearchResults({ organizationId });
+  const closeOrClearLabel = searchInput ? "Clear search" : "Close search";
+  const escapeShortcutLabel = searchInput.trim().length > 0 ? "Clear" : "Close";
 
   useEffect(() => {
     openRef.current = open;
@@ -221,10 +106,6 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
     }
   };
 
-  const handleInputChange = (newValue: string) => {
-    setSearchInput(newValue);
-  };
-
   const handleSearchControlClick = () => {
     if (searchInput.trim().length > 0) {
       handleInputChange("");
@@ -232,13 +113,6 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
     }
 
     handleOpenChange(false);
-  };
-
-  const handleFilterToggle = (filter: SearchToggleFilter) => {
-    setSelectedFilters((currentFilters) => ({
-      ...currentFilters,
-      [filter]: !currentFilters[filter],
-    }));
   };
 
   const openSong = (songId: string) => {
@@ -360,17 +234,20 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
 
         {hasSearchableInput && (
           <SearchResultsList
+            actions={{
+              onAddSongToCurrentSet: currentSetId
+                ? addSongToCurrentSet
+                : undefined,
+              onAddSongToSet: addSongToSet,
+              onOpenSong: openSong,
+            }}
             activeFilter={activeFilter}
             emptyResultsMessage={emptyResultsMessage}
             hasOverflow={hasSearchResultOverflow}
             isError={isSearchError}
             isLoading={shouldShowLoading}
             normalizedSearchInput={normalizedSearchInput}
-            onAddSongToCurrentSet={
-              currentSetId ? addSongToCurrentSet : undefined
-            }
-            onAddSongToSet={addSongToSet}
-            onSongSelect={openSong}
+            onSongSelect={(result) => openSong(result.songId)}
             resultCountLabel={searchResultCountLabel}
             visibleResultCount={visibleResultCount}
             visibleSongResults={visibleSongResults}

--- a/src/modules/search/components/Search.tsx
+++ b/src/modules/search/components/Search.tsx
@@ -45,6 +45,7 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
     emptyResultsMessage,
     handleFilterToggle,
     handleInputChange,
+    handleSearchEscapeKeyDown,
     hasSearchResultOverflow,
     hasSearchableInput,
     isSearchError,
@@ -57,9 +58,9 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
     visibleResultCount,
     visibleSongResults,
     visibleTagResults,
+    escapeShortcutLabel,
   } = useSongSearchResults({ organizationId });
   const closeOrClearLabel = searchInput ? "Clear search" : "Close search";
-  const escapeShortcutLabel = searchInput.trim().length > 0 ? "Clear" : "Close";
 
   useEffect(() => {
     openRef.current = open;
@@ -191,14 +192,7 @@ export const Search: React.FC<SearchProps> = ({ className }) => {
         shouldFilter={false}
         autoFocusInput={open}
         closeButton={null}
-        onEscapeKeyDown={(event) => {
-          if (searchInput.trim().length === 0) {
-            return;
-          }
-
-          event.preventDefault();
-          handleInputChange("");
-        }}
+        onEscapeKeyDown={handleSearchEscapeKeyDown}
         className={cn(
           "max-h-[calc(100dvh_-_24px)] overflow-hidden pb-0!",
           hasSearchableInput && "sm:pb-3!",

--- a/src/modules/search/components/SearchResultsList.tsx
+++ b/src/modules/search/components/SearchResultsList.tsx
@@ -15,16 +15,26 @@ import { SearchResultsErrorState } from "./SearchResultsErrorState";
 import { SearchResultsLoadingState } from "./SearchResultsLoadingState";
 import { type SearchSongResult, type TagSearchResult } from "./types";
 
+export type SearchResultMatchType = "song" | "tag";
+
+type SearchResultActionsConfig = {
+  onAddSongToCurrentSet?: (result: SearchSongResult) => void;
+  onAddSongToSet: (result: SearchSongResult) => void;
+  onOpenSong: (songId: string) => void;
+};
+
 type SearchResultsListProps = {
+  actions?: SearchResultActionsConfig;
   activeFilter: SearchFilter;
   emptyResultsMessage: string;
   hasOverflow: boolean;
   isError: boolean;
   isLoading: boolean;
   normalizedSearchInput: string;
-  onAddSongToCurrentSet?: (result: SearchSongResult) => void;
-  onAddSongToSet: (result: SearchSongResult) => void;
-  onSongSelect: (songId: string) => void;
+  onSongSelect: (
+    result: SearchSongResult,
+    matchType: SearchResultMatchType,
+  ) => void;
   resultCountLabel: string;
   visibleResultCount: number;
   visibleSongResults: SearchSongResult[];
@@ -37,14 +47,13 @@ const resultItemClassName =
 const SEARCH_RESULT_GROUP_HEADING_ICON_SIZE = 15;
 
 export const SearchResultsList = ({
+  actions,
   activeFilter,
   emptyResultsMessage,
   hasOverflow,
   isError,
   isLoading,
   normalizedSearchInput,
-  onAddSongToCurrentSet,
-  onAddSongToSet,
   onSongSelect,
   resultCountLabel,
   visibleResultCount,
@@ -52,7 +61,8 @@ export const SearchResultsList = ({
   visibleTagResults,
 }: SearchResultsListProps) => {
   const shouldShowResultGroupHeadings = activeFilter === "all";
-  const canAddToCurrentSet = !!onAddSongToCurrentSet;
+  const canAddToCurrentSet = !!actions?.onAddSongToCurrentSet;
+  const hasResultActions = !!actions;
   const [openActionsSongId, setOpenActionsSongId] = useState<string | null>(
     null,
   );
@@ -60,6 +70,10 @@ export const SearchResultsList = ({
   const suppressNextSongSelectRef = useRef(false);
 
   useEffect(() => {
+    if (!hasResultActions) {
+      return;
+    }
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (openActionsSongId && event.key === "Enter" && !event.shiftKey) {
         const target = event.target;
@@ -103,7 +117,7 @@ export const SearchResultsList = ({
       document.removeEventListener("keydown", handleKeyDown, {
         capture: true,
       });
-  }, [openActionsSongId]);
+  }, [hasResultActions, openActionsSongId]);
 
   const suppressNextSongSelect = () => {
     suppressNextSongSelectRef.current = true;
@@ -113,7 +127,7 @@ export const SearchResultsList = ({
   };
 
   useEffect(() => {
-    if (!openActionsSongId) {
+    if (!hasResultActions || !openActionsSongId) {
       return;
     }
 
@@ -130,15 +144,22 @@ export const SearchResultsList = ({
     }, 0);
 
     return () => window.clearTimeout(clearStaleOpenActions);
-  }, [openActionsSongId, visibleSongResults, visibleTagResults]);
+  }, [
+    hasResultActions,
+    openActionsSongId,
+    visibleSongResults,
+    visibleTagResults,
+  ]);
 
   const renderSongResultItem = ({
     keyPrefix,
+    matchType,
     result,
     row,
     valuePrefix,
   }: {
     keyPrefix: string;
+    matchType: SearchResultMatchType;
     result: SearchSongResult;
     row: ReactNode;
     valuePrefix: string;
@@ -147,29 +168,37 @@ export const SearchResultsList = ({
       key={`${keyPrefix}-${result.songId}`}
       value={`${valuePrefix}-${result.songId}`}
       data-song-id={result.songId}
+      data-search-match-type={matchType}
       className={resultItemClassName}
       onSelect={() => {
-        if (openActionsSongId || suppressNextSongSelectRef.current) {
+        if (
+          hasResultActions &&
+          (openActionsSongId || suppressNextSongSelectRef.current)
+        ) {
           suppressNextSongSelectRef.current = false;
           return;
         }
 
-        onSongSelect(result.songId);
+        onSongSelect(result, matchType);
       }}
     >
       {row}
-      <SearchResultActions
-        canAddToCurrentSet={canAddToCurrentSet}
-        open={openActionsSongId === result.songId}
-        result={result}
-        onAddToCurrentSet={onAddSongToCurrentSet ?? onAddSongToSet}
-        onAddToSet={onAddSongToSet}
-        onActionSelect={suppressNextSongSelect}
-        onOpenChange={(open) => {
-          setOpenActionsSongId(open ? result.songId : null);
-        }}
-        onOpenSong={onSongSelect}
-      />
+      {actions && (
+        <SearchResultActions
+          canAddToCurrentSet={canAddToCurrentSet}
+          open={openActionsSongId === result.songId}
+          result={result}
+          onAddToCurrentSet={
+            actions.onAddSongToCurrentSet ?? actions.onAddSongToSet
+          }
+          onAddToSet={actions.onAddSongToSet}
+          onActionSelect={suppressNextSongSelect}
+          onOpenChange={(open) => {
+            setOpenActionsSongId(open ? result.songId : null);
+          }}
+          onOpenSong={actions.onOpenSong}
+        />
+      )}
     </CommandItem>
   );
 
@@ -209,6 +238,7 @@ export const SearchResultsList = ({
           {visibleSongResults.map((result) =>
             renderSongResultItem({
               keyPrefix: "song",
+              matchType: "song",
               result,
               row: (
                 <SearchSongRow query={normalizedSearchInput} result={result} />
@@ -243,6 +273,7 @@ export const SearchResultsList = ({
           {visibleTagResults.map((result) =>
             renderSongResultItem({
               keyPrefix: "tag-song",
+              matchType: "tag",
               result,
               row: (
                 <SearchTagMatchedSongRow

--- a/src/modules/search/components/SearchShortcutLegend.tsx
+++ b/src/modules/search/components/SearchShortcutLegend.tsx
@@ -34,11 +34,15 @@ const SearchShortcutHint = ({ keys, label }: SearchShortcutHintProps) => (
 );
 
 type SearchShortcutLegendProps = {
+  enterShortcutLabel?: string;
   escapeShortcutLabel: string;
+  showActionsShortcut?: boolean;
 };
 
 export const SearchShortcutLegend = ({
+  enterShortcutLabel = "Open",
   escapeShortcutLabel,
+  showActionsShortcut = true,
 }: SearchShortcutLegendProps) => (
   <HStack className="hidden items-center justify-between gap-4 border-t border-slate-100 px-4 py-2.5 text-xs text-slate-500 sm:flex">
     <HStack className="items-center gap-4">
@@ -71,23 +75,25 @@ export const SearchShortcutLegend = ({
             label: "Enter",
           },
         ]}
-        label="Open"
+        label={enterShortcutLabel}
       />
-      <SearchShortcutHint
-        keys={[
-          { content: "Shift", label: "Shift" },
-          {
-            content: (
-              <ArrowElbowDownLeftIcon
-                aria-hidden
-                size={SHORTCUT_ENTER_ICON_SIZE}
-              />
-            ),
-            label: "Enter",
-          },
-        ]}
-        label="Actions"
-      />
+      {showActionsShortcut && (
+        <SearchShortcutHint
+          keys={[
+            { content: "Shift", label: "Shift" },
+            {
+              content: (
+                <ArrowElbowDownLeftIcon
+                  aria-hidden
+                  size={SHORTCUT_ENTER_ICON_SIZE}
+                />
+              ),
+              label: "Enter",
+            },
+          ]}
+          label="Actions"
+        />
+      )}
     </HStack>
     <SearchShortcutHint
       keys={[{ content: "Esc", label: "Escape" }]}

--- a/src/modules/search/components/__tests__/SearchResultsList.test.tsx
+++ b/src/modules/search/components/__tests__/SearchResultsList.test.tsx
@@ -165,7 +165,9 @@ describe("SearchResultsList", () => {
 
     expect(onSongSelect).toHaveBeenCalledWith(songResult, "song");
     expect(
-      screen.queryByRole("menuitem", { name: /add to a set/i }),
+      screen.queryByRole("button", {
+        name: `Open actions for ${songResult.name}`,
+      }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/modules/search/components/__tests__/SearchResultsList.test.tsx
+++ b/src/modules/search/components/__tests__/SearchResultsList.test.tsx
@@ -1,3 +1,4 @@
+import { type ComponentProps } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createSearchSongResultFixture } from "@testUtils/models/search/fixtures";
 
@@ -15,25 +16,34 @@ class ResizeObserverMock {
 const songResult = createSearchSongResultFixture();
 
 const renderSearchResultsList = ({
+  includeActions = true,
   onAddSongToCurrentSet,
   onAddSongToSet = jest.fn(),
   onSongSelect = jest.fn(),
 }: {
+  includeActions?: boolean;
   onAddSongToCurrentSet?: (result: SearchSongResult) => void;
   onAddSongToSet?: (result: SearchSongResult) => void;
-  onSongSelect?: (songId: string) => void;
+  onSongSelect?: ComponentProps<typeof SearchResultsList>["onSongSelect"];
 } = {}) => {
   render(
     <Command shouldFilter={false}>
       <SearchResultsList
+        actions={
+          includeActions
+            ? {
+                onAddSongToCurrentSet,
+                onAddSongToSet,
+                onOpenSong: (_songId) => onSongSelect(songResult, "song"),
+              }
+            : undefined
+        }
         activeFilter="songs"
         emptyResultsMessage="No results"
         hasOverflow={false}
         isError={false}
         isLoading={false}
         normalizedSearchInput="grace"
-        onAddSongToCurrentSet={onAddSongToCurrentSet}
-        onAddSongToSet={onAddSongToSet}
         onSongSelect={onSongSelect}
         resultCountLabel="1"
         visibleResultCount={1}
@@ -142,5 +152,20 @@ describe("SearchResultsList", () => {
         screen.queryByRole("menuitem", { name: /add to a set/i }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("selects the result directly when action menus are disabled", () => {
+    const onSongSelect = jest.fn();
+    const { resultItem } = renderSearchResultsList({
+      includeActions: false,
+      onSongSelect,
+    });
+
+    fireEvent.click(resultItem);
+
+    expect(onSongSelect).toHaveBeenCalledWith(songResult, "song");
+    expect(
+      screen.queryByRole("menuitem", { name: /add to a set/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/modules/search/hooks/__tests__/useSongSearchResults.test.tsx
+++ b/src/modules/search/hooks/__tests__/useSongSearchResults.test.tsx
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { trpc } from "@lib/trpc";
+
+import { useSongSearchResults } from "../useSongSearchResults";
+
+jest.mock("@lib/trpc", () => ({
+  trpc: {
+    song: {
+      search: {
+        useQuery: jest.fn(),
+      },
+    },
+  },
+}));
+
+const mockSongSearchUseQuery = trpc.song.search.useQuery as jest.Mock;
+
+describe("useSongSearchResults", () => {
+  beforeEach(() => {
+    mockSongSearchUseQuery.mockReturnValue({
+      data: [],
+      isFetching: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("clears search input on Escape before allowing the dialog to close", () => {
+    const { result } = renderHook(() =>
+      useSongSearchResults({ organizationId: "organization-1" }),
+    );
+    const escapeEvent = { preventDefault: jest.fn() };
+
+    let handledEscape = true;
+    act(() => {
+      handledEscape = result.current.handleSearchEscapeKeyDown(escapeEvent);
+    });
+
+    expect(handledEscape).toBe(false);
+    expect(escapeEvent.preventDefault).not.toHaveBeenCalled();
+    expect(result.current.escapeShortcutLabel).toBe("Close");
+
+    act(() => {
+      result.current.handleInputChange("communion");
+    });
+
+    expect(result.current.searchInput).toBe("communion");
+    expect(result.current.escapeShortcutLabel).toBe("Clear");
+
+    act(() => {
+      handledEscape = result.current.handleSearchEscapeKeyDown(escapeEvent);
+    });
+
+    expect(handledEscape).toBe(true);
+    expect(escapeEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(result.current.searchInput).toBe("");
+    expect(result.current.escapeShortcutLabel).toBe("Close");
+  });
+});

--- a/src/modules/search/hooks/useSongSearchResults.ts
+++ b/src/modules/search/hooks/useSongSearchResults.ts
@@ -1,0 +1,182 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useDebounceValue } from "usehooks-ts";
+
+import {
+  type SearchToggleFilter,
+  type TagSearchResult,
+} from "@modules/search/components/types";
+import { getGlobalSearchResultGroups } from "@modules/search/utils/getGlobalSearchResultGroups";
+import {
+  getVisibleGlobalSearchResults,
+  GLOBAL_SEARCH_RESULT_COUNT_LIMIT,
+  type SearchFilter,
+} from "@modules/search/utils/getVisibleGlobalSearchResults";
+import { trpc } from "@lib/trpc";
+
+type UseSongSearchResultsInput = {
+  organizationId?: string;
+};
+
+export const MIN_SONG_SEARCH_LENGTH = 2;
+export const SONG_SEARCH_DEBOUNCE_DELAY = 300;
+
+export const useSongSearchResults = ({
+  organizationId,
+}: UseSongSearchResultsInput) => {
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedSearchInput, setDebouncedSearchInput] = useDebounceValue(
+    searchInput,
+    SONG_SEARCH_DEBOUNCE_DELAY,
+  );
+  const [selectedFilters, setSelectedFilters] = useState<
+    Record<SearchToggleFilter, boolean>
+  >({
+    songs: false,
+    tags: false,
+  });
+
+  const normalizedSearchInput = debouncedSearchInput.trim();
+  const normalizedSearchQuery = normalizedSearchInput.toLowerCase();
+  const hasSearchableInput =
+    searchInput.trim().length >= MIN_SONG_SEARCH_LENGTH;
+  const canSearch =
+    !!organizationId &&
+    normalizedSearchInput.length >= MIN_SONG_SEARCH_LENGTH;
+  const isWaitingForDebounce =
+    hasSearchableInput && searchInput.trim() !== normalizedSearchInput;
+  const activeFilter: SearchFilter = useMemo(() => {
+    if (selectedFilters.songs === selectedFilters.tags) {
+      return "all";
+    }
+
+    return selectedFilters.songs ? "songs" : "tags";
+  }, [selectedFilters]);
+
+  const {
+    data: searchResults,
+    isFetching: isSearchFetching,
+    isError: isSearchError,
+  } = trpc.song.search.useQuery(
+    {
+      organizationId: organizationId ?? "",
+      searchInput: normalizedSearchInput,
+      limit: GLOBAL_SEARCH_RESULT_COUNT_LIMIT,
+    },
+    {
+      enabled: canSearch,
+    },
+  );
+
+  const { songResults, tagResults } = useMemo(
+    () =>
+      getGlobalSearchResultGroups({
+        normalizedSearchQuery,
+        searchResults: searchResults ?? [],
+      }),
+    [normalizedSearchQuery, searchResults],
+  );
+
+  const songResultIds = useMemo(
+    () => new Set(songResults.map((result) => result.songId)),
+    [songResults],
+  );
+
+  const visibleTagCandidateResults: TagSearchResult[] = useMemo(() => {
+    if (activeFilter !== "all") {
+      return tagResults;
+    }
+
+    return tagResults.filter((result) => !songResultIds.has(result.songId));
+  }, [activeFilter, songResultIds, tagResults]);
+
+  const {
+    visibleSongResults,
+    visibleTagResults,
+    hasOverflow: hasSearchResultOverflow,
+  } = useMemo(
+    () =>
+      getVisibleGlobalSearchResults({
+        activeFilter,
+        songResults,
+        tagResults: visibleTagCandidateResults,
+      }),
+    [activeFilter, songResults, visibleTagCandidateResults],
+  );
+
+  const visibleResultCount =
+    visibleSongResults.length + visibleTagResults.length;
+  const totalResultCount = useMemo(() => {
+    if (activeFilter === "songs") {
+      return songResults.length;
+    }
+
+    if (activeFilter === "tags") {
+      return tagResults.length;
+    }
+
+    return songResults.length + visibleTagCandidateResults.length;
+  }, [activeFilter, songResults, tagResults, visibleTagCandidateResults]);
+  const searchResultCountLabel =
+    searchResults && searchResults.length >= GLOBAL_SEARCH_RESULT_COUNT_LIMIT
+      ? `${totalResultCount}+`
+      : totalResultCount.toString();
+  const shouldShowLoading =
+    hasSearchableInput && (isWaitingForDebounce || isSearchFetching);
+
+  const emptyResultsMessage = useMemo(() => {
+    if (!organizationId) {
+      return "Search is available inside an organization.";
+    }
+
+    if (activeFilter === "songs") {
+      return `No songs found for "${normalizedSearchInput}".`;
+    }
+
+    if (activeFilter === "tags") {
+      return `No songs found with matching tags for "${normalizedSearchInput}".`;
+    }
+
+    return `No results found for "${normalizedSearchInput}".`;
+  }, [activeFilter, normalizedSearchInput, organizationId]);
+
+  const handleInputChange = useCallback(
+    (newValue: string) => {
+      setSearchInput(newValue);
+    },
+    [setSearchInput],
+  );
+
+  const handleFilterToggle = useCallback((filter: SearchToggleFilter) => {
+    setSelectedFilters((currentFilters) => ({
+      ...currentFilters,
+      [filter]: !currentFilters[filter],
+    }));
+  }, []);
+
+  const resetSearchInput = useCallback(() => {
+    setSearchInput("");
+    setDebouncedSearchInput("");
+    setSelectedFilters({ songs: false, tags: false });
+  }, [setDebouncedSearchInput]);
+
+  return {
+    activeFilter,
+    emptyResultsMessage,
+    handleFilterToggle,
+    handleInputChange,
+    hasSearchResultOverflow,
+    hasSearchableInput,
+    isSearchError,
+    normalizedSearchInput,
+    resetSearchInput,
+    searchInput,
+    searchResultCountLabel,
+    selectedFilters,
+    shouldShowLoading,
+    visibleResultCount,
+    visibleSongResults,
+    visibleTagResults,
+  };
+};

--- a/src/modules/search/hooks/useSongSearchResults.ts
+++ b/src/modules/search/hooks/useSongSearchResults.ts
@@ -19,6 +19,10 @@ type UseSongSearchResultsInput = {
   organizationId?: string;
 };
 
+type SearchEscapeEvent = {
+  preventDefault: () => void;
+};
+
 export const MIN_SONG_SEARCH_LENGTH = 2;
 export const SONG_SEARCH_DEBOUNCE_DELAY = 300;
 
@@ -124,6 +128,7 @@ export const useSongSearchResults = ({
       : totalResultCount.toString();
   const shouldShowLoading =
     hasSearchableInput && (isWaitingForDebounce || isSearchFetching);
+  const escapeShortcutLabel = searchInput.trim().length > 0 ? "Clear" : "Close";
 
   const emptyResultsMessage = useMemo(() => {
     if (!organizationId) {
@@ -148,6 +153,23 @@ export const useSongSearchResults = ({
     [setSearchInput],
   );
 
+  const clearSearchInput = useCallback(() => {
+    setSearchInput("");
+  }, []);
+
+  const handleSearchEscapeKeyDown = useCallback(
+    (event: SearchEscapeEvent) => {
+      if (searchInput.trim().length === 0) {
+        return false;
+      }
+
+      event.preventDefault();
+      clearSearchInput();
+      return true;
+    },
+    [clearSearchInput, searchInput],
+  );
+
   const handleFilterToggle = useCallback((filter: SearchToggleFilter) => {
     setSelectedFilters((currentFilters) => ({
       ...currentFilters,
@@ -164,8 +186,11 @@ export const useSongSearchResults = ({
   return {
     activeFilter,
     emptyResultsMessage,
+    escapeShortcutLabel,
+    clearSearchInput,
     handleFilterToggle,
     handleInputChange,
+    handleSearchEscapeKeyDown,
     hasSearchResultOverflow,
     hasSearchableInput,
     isSearchError,

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -68,7 +68,7 @@ export type AddSongToSetFormFields = z.infer<
 
 export type ConfigureSongForSetProps = {
   existingSetSections: SetSectionWithSongs[];
-  selectedSong: NonNullable<SongSearchResult>;
+  selectedSong: SongSearchResult;
   setDialogStep: Dispatch<SetStateAction<SongSearchDialogSteps>>;
   onSubmit?: () => void;
   setId: string;

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -59,9 +59,8 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
 
   const [dialogStep, setDialogStep] =
     useState<ReplaceSongDialogSteps>("search");
-  const [selectedSong, setSelectedSong] = useState<SongSearchResult | null>(
-    null,
-  );
+  const [selectedSong, setSelectedSong] =
+    useState<SongSearchResult | null>(null);
 
   const replaceSongMutation =
     trpc.setSectionSong.replaceSong.useMutation<Error>();
@@ -151,7 +150,10 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
       className={cn([dialogStep === "confirm" && "max-w-lg"])}
     >
       {dialogStep === "search" && (
-        <SongSearch onSongSelect={handleSongSelect} />
+        <SongSearch
+          organizationId={userMembership.organizationId}
+          onSongSelect={handleSongSelect}
+        />
       )}
       {dialogStep === "confirm" && !!selectedSong && (
         <CommandList className="max-h-[calc(100dvh_-_24px)] text-center md:max-h-[calc(100dvh_-_12dvh_-_5dvh)]">

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -14,8 +14,9 @@ import { DialogDescription, DialogTitle } from "@components/ui/dialog";
 import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
+import { useSongSearchResults } from "@modules/search/hooks/useSongSearchResults";
 import {
-  SongSearch,
+  SongSearchContent,
   type SongSearchResult,
 } from "@modules/songs/components/SongSearch";
 import { useUserQuery } from "@modules/users/api/queries";
@@ -56,6 +57,9 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
     isAuthLoaded,
   } = useUserQuery();
   const userMembership = userData?.memberships[0];
+  const songSearchState = useSongSearchResults({
+    organizationId: userMembership?.organizationId,
+  });
 
   const [dialogStep, setDialogStep] =
     useState<ReplaceSongDialogSteps>("search");
@@ -148,10 +152,17 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
       minimalPadding
       autoFocusInput={open && dialogStep === "search"}
       className={cn([dialogStep === "confirm" && "max-w-lg"])}
+      onEscapeKeyDown={(event) => {
+        if (dialogStep !== "search") {
+          return;
+        }
+
+        songSearchState.handleSearchEscapeKeyDown(event);
+      }}
     >
       {dialogStep === "search" && (
-        <SongSearch
-          organizationId={userMembership.organizationId}
+        <SongSearchContent
+          searchState={songSearchState}
           onSongSelect={handleSongSelect}
         />
       )}

--- a/src/modules/songs/components/SongSearch/SongSearch.tsx
+++ b/src/modules/songs/components/SongSearch/SongSearch.tsx
@@ -6,12 +6,14 @@ import {
   type SearchResultMatchType,
   SearchResultsList,
 } from "@modules/search/components/SearchResultsList";
+import { SearchShortcutLegend } from "@modules/search/components/SearchShortcutLegend";
 import { type SearchSongResult } from "@modules/search/components/types";
 import { useSongSearchResults } from "@modules/search/hooks/useSongSearchResults";
 
 export type SongSearchMatchType = SearchResultMatchType;
 
 export type SongSearchResult = SearchSongResult;
+export type SongSearchState = ReturnType<typeof useSongSearchResults>;
 
 type SongSearchProps = {
   organizationId?: string;
@@ -22,14 +24,19 @@ type SongSearchProps = {
   searchPlaceholder?: string;
 };
 
-export const SongSearch: React.FC<SongSearchProps> = ({
-  organizationId,
+type SongSearchContentProps = Omit<SongSearchProps, "organizationId"> & {
+  searchState: SongSearchState;
+};
+
+export const SongSearchContent: React.FC<SongSearchContentProps> = ({
   onSongSelect,
+  searchState,
   searchPlaceholder = "Search songs or tags",
 }) => {
   const {
     activeFilter,
     emptyResultsMessage,
+    escapeShortcutLabel,
     handleFilterToggle,
     handleInputChange,
     hasSearchResultOverflow,
@@ -43,7 +50,7 @@ export const SongSearch: React.FC<SongSearchProps> = ({
     visibleResultCount,
     visibleSongResults,
     visibleTagResults,
-  } = useSongSearchResults({ organizationId });
+  } = searchState;
 
   return (
     <>
@@ -76,6 +83,27 @@ export const SongSearch: React.FC<SongSearchProps> = ({
           visibleTagResults={visibleTagResults}
         />
       )}
+      {hasSearchableInput && (
+        <SearchShortcutLegend
+          enterShortcutLabel="Select"
+          escapeShortcutLabel={escapeShortcutLabel}
+          showActionsShortcut={false}
+        />
+      )}
     </>
+  );
+};
+
+export const SongSearch: React.FC<SongSearchProps> = ({
+  organizationId,
+  ...songSearchContentProps
+}) => {
+  const searchState = useSongSearchResults({ organizationId });
+
+  return (
+    <SongSearchContent
+      {...songSearchContentProps}
+      searchState={searchState}
+    />
   );
 };

--- a/src/modules/songs/components/SongSearch/SongSearch.tsx
+++ b/src/modules/songs/components/SongSearch/SongSearch.tsx
@@ -1,163 +1,81 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { redirect } from "next/navigation";
-import { useAuth } from "@clerk/nextjs";
-import { CaretRight } from "@phosphor-icons/react/dist/ssr";
-import { CommandLoading } from "cmdk";
-import { useDebounceValue } from "usehooks-ts";
-
-import { Text } from "@components/Text";
+import { CommandInput } from "@components/ui/command";
+import { SearchFilterControls } from "@modules/search/components/SearchFilterControls";
 import {
-  SongListItem,
-  type SongListItemProps,
-} from "@modules/songs/components/SongListItem";
-import { useUserQuery } from "@modules/users/api/queries";
-import { trpc } from "@lib/trpc";
-import { type Song, type Tag } from "@lib/types";
-import {
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
+  type SearchResultMatchType,
+  SearchResultsList,
+} from "@modules/search/components/SearchResultsList";
+import { type SearchSongResult } from "@modules/search/components/types";
+import { useSongSearchResults } from "@modules/search/hooks/useSongSearchResults";
 
-export type SongSearchResult =
-  | (Pick<Song, "name" | "preferredKey" | "isArchived"> & {
-      songId: Song["id"];
-      similarityScore: number;
-      lastPlayedDate: SongListItemProps["lastPlayed"];
-      tags?: Tag["tag"][];
-    })
-  | undefined;
+export type SongSearchMatchType = SearchResultMatchType;
+
+export type SongSearchResult = SearchSongResult;
 
 type SongSearchProps = {
-  onSongSelect?: (selectedSong?: SongSearchResult) => void;
+  organizationId?: string;
+  onSongSelect?: (
+    selectedSong: SongSearchResult,
+    matchType: SongSearchMatchType,
+  ) => void;
   searchPlaceholder?: string;
 };
 
-const SEARCH_DEBOUNCE_DELAY = 350;
-
 export const SongSearch: React.FC<SongSearchProps> = ({
+  organizationId,
   onSongSelect,
-  searchPlaceholder = "Search for a song...",
+  searchPlaceholder = "Search songs or tags",
 }) => {
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  const defaultSearchQuery = "";
-  const [searchInput, setSearchInput] = useState<string>(defaultSearchQuery);
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useDebounceValue(
+  const {
+    activeFilter,
+    emptyResultsMessage,
+    handleFilterToggle,
+    handleInputChange,
+    hasSearchResultOverflow,
+    hasSearchableInput,
+    isSearchError,
+    normalizedSearchInput,
     searchInput,
-    SEARCH_DEBOUNCE_DELAY,
-  );
-
-  const {
-    data: userData,
-    error: userQueryError,
-    isLoading: userQueryLoading,
-    isAuthLoaded,
-  } = useUserQuery();
-  const userMembership = userData?.memberships[0];
-
-  const {
-    data: songSearchData,
-    error: songSearchError,
-    isLoading: songSearchLoading,
-  } = trpc.song.search.useQuery(
-    {
-      organizationId: userMembership!.organizationId, // we use a type assertion here since if this isn't true, the query will be disabled
-      searchInput: debouncedSearchQuery,
-    },
-    {
-      enabled:
-        !!userMembership?.organizationId &&
-        !!debouncedSearchQuery &&
-        debouncedSearchQuery.length > 2,
-    },
-  );
-
-  const canRenderSearchInput =
-    !!userData?.id && isAuthLoaded && !userQueryLoading;
-
-  useEffect(() => {
-    if (!canRenderSearchInput) {
-      return;
-    }
-
-    searchInputRef.current?.focus();
-  }, [canRenderSearchInput]);
-
-  if (!userData?.id) {
-    redirect("/");
-  }
-
-  if (!isAuthLoaded) {
-    return <Text>Loading auth...</Text>;
-  }
-
-  if (userQueryLoading) {
-    return <Text>Getting user...</Text>;
-  }
-
-  if (!songSearchData || songSearchError) {
-    // TODO: handle the error
-  }
-
-  const handleSearchInputChange = (newValue: string) => {
-    setSearchInput(newValue);
-    setDebouncedSearchQuery(newValue);
-  };
-
-  const handleSongSelect = (selectedSongId: string) => {
-    const selectedSong = songSearchData?.find(
-      (songData) => songData.songId === selectedSongId,
-    );
-    onSongSelect?.(selectedSong);
-  };
+    searchResultCountLabel,
+    selectedFilters,
+    shouldShowLoading,
+    visibleResultCount,
+    visibleSongResults,
+    visibleTagResults,
+  } = useSongSearchResults({ organizationId });
 
   return (
     <>
-      <CommandInput
-        ref={searchInputRef}
-        placeholder={searchPlaceholder}
-        value={searchInput}
-        onValueChange={(newValue) => handleSearchInputChange(newValue)}
-        autoFocus
-      />
-      <CommandList>
-        {songSearchLoading && (
-          <CommandLoading>Searching songs...</CommandLoading>
-        )}
-        {!songSearchLoading &&
-          debouncedSearchQuery &&
-          debouncedSearchQuery.length > 0 && (
-            <CommandEmpty>
-              No songs found for &quot;{debouncedSearchQuery}&quot;.
-            </CommandEmpty>
-          )}
-        <CommandGroup heading="Songs">
-          <div className="flex flex-col gap-2">
-            {songSearchData?.map((searchResult) => {
-              const { lastPlayedDate, tags, ...songData } = searchResult;
-              return (
-                <CommandItem
-                  key={searchResult.songId}
-                  value={searchResult.songId}
-                  className="flex items-center justify-between"
-                  onSelect={handleSongSelect}
-                >
-                  <SongListItem
-                    song={{ id: songData.songId, ...songData }}
-                    lastPlayed={lastPlayedDate}
-                    tags={tags}
-                  />
-                  <CaretRight size="12px" className="text-slate-500" />
-                </CommandItem>
-              );
-            })}
-          </div>
-        </CommandGroup>
-      </CommandList>
+      <div className={hasSearchableInput ? "border-b border-slate-100" : ""}>
+        <CommandInput
+          value={searchInput}
+          onValueChange={handleInputChange}
+          placeholder={searchPlaceholder}
+          className="h-14 text-base md:text-base"
+        />
+        <SearchFilterControls
+          selectedFilters={selectedFilters}
+          onFilterToggle={handleFilterToggle}
+        />
+      </div>
+      {hasSearchableInput && (
+        <SearchResultsList
+          activeFilter={activeFilter}
+          emptyResultsMessage={emptyResultsMessage}
+          hasOverflow={hasSearchResultOverflow}
+          isError={isSearchError}
+          isLoading={shouldShowLoading}
+          normalizedSearchInput={normalizedSearchInput}
+          onSongSelect={(result, matchType) =>
+            onSongSelect?.(result, matchType)
+          }
+          resultCountLabel={searchResultCountLabel}
+          visibleResultCount={visibleResultCount}
+          visibleSongResults={visibleSongResults}
+          visibleTagResults={visibleTagResults}
+        />
+      )}
     </>
   );
 };

--- a/src/modules/songs/components/SongSearch/__tests__/SongSearch.test.tsx
+++ b/src/modules/songs/components/SongSearch/__tests__/SongSearch.test.tsx
@@ -1,4 +1,8 @@
-import { type ComponentProps } from "react";
+import {
+  type ComponentProps,
+  type useEffect,
+  type useState,
+} from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createSearchSongResultFixture } from "@testUtils/models/search/fixtures";
 
@@ -18,7 +22,10 @@ jest.mock("@lib/trpc", () => ({
 }));
 
 jest.mock("usehooks-ts", () => {
-  const React = jest.requireActual<typeof import("react")>("react");
+  const React = jest.requireActual<{
+    useEffect: typeof useEffect;
+    useState: typeof useState;
+  }>("react");
 
   return {
     useDebounceValue: <Value,>(value: Value, delay: number) => {
@@ -164,6 +171,21 @@ describe("SongSearch", () => {
     expect(screen.getAllByText("Songs")).toHaveLength(2);
     expect(screen.getAllByText("Tags")).toHaveLength(2);
     expect(screen.getByText("Search results (2)")).toBeInTheDocument();
+  });
+
+  it("renders picker keyboard shortcuts without action menu shortcuts", async () => {
+    renderSongSearch();
+
+    enterSearchInput("comm");
+
+    await waitFor(() => {
+      expect(screen.getByText("Search results (2)")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Navigate")).toBeInTheDocument();
+    expect(screen.getByText("Select")).toBeInTheDocument();
+    expect(screen.getByText("Clear")).toBeInTheDocument();
+    expect(screen.queryByText("Actions")).not.toBeInTheDocument();
   });
 
   it("filters picker results by song and tag result groups", async () => {

--- a/src/modules/songs/components/SongSearch/__tests__/SongSearch.test.tsx
+++ b/src/modules/songs/components/SongSearch/__tests__/SongSearch.test.tsx
@@ -1,0 +1,253 @@
+import { type ComponentProps } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createSearchSongResultFixture } from "@testUtils/models/search/fixtures";
+
+import { Command } from "@components/ui/command";
+import { trpc } from "@lib/trpc";
+
+import { SongSearch } from "../SongSearch";
+
+jest.mock("@lib/trpc", () => ({
+  trpc: {
+    song: {
+      search: {
+        useQuery: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock("usehooks-ts", () => {
+  return {
+    useDebounceValue: <Value,>(initialValue: Value) =>
+      [initialValue, jest.fn()] as const,
+  };
+});
+
+class ResizeObserverMock {
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+}
+
+const titleMatchedSong = createSearchSongResultFixture({
+  songId: "title-song",
+  name: "Communion Hymn",
+  matchedTags: [],
+  tags: ["Classic"],
+});
+
+const tagMatchedSong = createSearchSongResultFixture({
+  songId: "tag-song",
+  name: "Amazing Grace",
+  matchedTags: ["Communion"],
+  tags: ["Communion"],
+});
+
+const mockSongSearchUseQuery = trpc.song.search.useQuery as jest.Mock;
+
+const renderSongSearch = ({
+  onSongSelect = jest.fn(),
+  organizationId = "organization-1",
+}: {
+  onSongSelect?: ComponentProps<typeof SongSearch>["onSongSelect"];
+  organizationId?: string;
+} = {}) => {
+  render(
+    <Command shouldFilter={false}>
+      <SongSearch organizationId={organizationId} onSongSelect={onSongSelect} />
+    </Command>,
+  );
+
+  return { onSongSelect };
+};
+
+const enterSearchInput = (searchInput: string) => {
+  fireEvent.change(screen.getByPlaceholderText("Search songs or tags"), {
+    target: { value: searchInput },
+  });
+};
+
+const getResultItem = (matchType: "song" | "tag") => {
+  const resultItem = document.querySelector(
+    `[data-search-match-type='${matchType}']`,
+  );
+
+  if (!(resultItem instanceof HTMLElement)) {
+    throw new Error(`Could not find ${matchType}-matched result item`);
+  }
+
+  return resultItem;
+};
+
+describe("SongSearch", () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+      writable: true,
+    });
+
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: jest.fn(),
+      writable: true,
+    });
+  });
+
+  beforeEach(() => {
+    mockSongSearchUseQuery.mockReturnValue({
+      data: [titleMatchedSong, tagMatchedSong],
+      isFetching: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses song.search with the debounced query after the minimum search length", async () => {
+    renderSongSearch();
+
+    enterSearchInput("c");
+
+    expect(mockSongSearchUseQuery).toHaveBeenLastCalledWith(
+      {
+        organizationId: "organization-1",
+        searchInput: "c",
+        limit: 50,
+      },
+      {
+        enabled: false,
+      },
+    );
+
+    enterSearchInput("comm");
+
+    await waitFor(() => {
+      expect(mockSongSearchUseQuery).toHaveBeenLastCalledWith(
+        {
+          organizationId: "organization-1",
+          searchInput: "comm",
+          limit: 50,
+        },
+        {
+          enabled: true,
+        },
+      );
+    });
+  });
+
+  it("groups title matches and tag matches with highlighted result rows", async () => {
+    renderSongSearch();
+
+    enterSearchInput("comm");
+
+    await waitFor(() => {
+      expect(getResultItem("song")).toHaveTextContent("Communion Hymn");
+      expect(getResultItem("tag")).toHaveTextContent("Amazing Grace");
+    });
+    expect(screen.getAllByText("Songs")).toHaveLength(2);
+    expect(screen.getAllByText("Tags")).toHaveLength(2);
+    expect(screen.getByText("Search results (2)")).toBeInTheDocument();
+  });
+
+  it("filters picker results by song and tag result groups", async () => {
+    renderSongSearch();
+
+    enterSearchInput("comm");
+    await waitFor(() => {
+      expect(getResultItem("song")).toHaveTextContent("Communion Hymn");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /tags/i }));
+
+    expect(
+      document.querySelector("[data-search-match-type='song']"),
+    ).not.toBeInTheDocument();
+    expect(getResultItem("tag")).toHaveTextContent("Amazing Grace");
+    expect(screen.getByText("Search results (1)")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /songs/i }));
+
+    expect(getResultItem("song")).toHaveTextContent("Communion Hymn");
+    expect(getResultItem("tag")).toHaveTextContent("Amazing Grace");
+    expect(screen.getByText("Search results (2)")).toBeInTheDocument();
+  });
+
+  it("calls selection callbacks with the selected song and match type", async () => {
+    const onSongSelect = jest.fn();
+    renderSongSearch({ onSongSelect });
+
+    enterSearchInput("comm");
+
+    await waitFor(() => {
+      expect(getResultItem("song")).toBeInTheDocument();
+    });
+
+    fireEvent.click(getResultItem("song"));
+    fireEvent.click(getResultItem("tag"));
+
+    expect(onSongSelect).toHaveBeenNthCalledWith(
+      1,
+      titleMatchedSong,
+      "song",
+    );
+    expect(onSongSelect).toHaveBeenNthCalledWith(2, tagMatchedSong, "tag");
+  });
+
+  it("renders loading, error, and empty states", async () => {
+    mockSongSearchUseQuery.mockReturnValue({
+      data: [],
+      isFetching: true,
+      isError: false,
+    });
+
+    const { rerender } = render(
+      <Command shouldFilter={false}>
+        <SongSearch organizationId="organization-1" onSongSelect={jest.fn()} />
+      </Command>,
+    );
+
+    enterSearchInput("missing");
+
+    expect(
+      await screen.findByLabelText("Searching songs and tags"),
+    ).toBeInTheDocument();
+
+    mockSongSearchUseQuery.mockReturnValue({
+      data: [],
+      isFetching: false,
+      isError: true,
+    });
+
+    rerender(
+      <Command shouldFilter={false}>
+        <SongSearch organizationId="organization-1" onSongSelect={jest.fn()} />
+      </Command>,
+    );
+
+    expect(
+      await screen.findByText(
+        "Search is unavailable. Please try again in a moment.",
+      ),
+    ).toBeInTheDocument();
+
+    mockSongSearchUseQuery.mockReturnValue({
+      data: [],
+      isFetching: false,
+      isError: false,
+    });
+
+    rerender(
+      <Command shouldFilter={false}>
+        <SongSearch organizationId="organization-1" onSongSelect={jest.fn()} />
+      </Command>,
+    );
+
+    expect(
+      await screen.findByText('No results found for "missing".'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/modules/songs/components/SongSearch/__tests__/SongSearch.test.tsx
+++ b/src/modules/songs/components/SongSearch/__tests__/SongSearch.test.tsx
@@ -18,9 +18,22 @@ jest.mock("@lib/trpc", () => ({
 }));
 
 jest.mock("usehooks-ts", () => {
+  const React = jest.requireActual<typeof import("react")>("react");
+
   return {
-    useDebounceValue: <Value,>(initialValue: Value) =>
-      [initialValue, jest.fn()] as const,
+    useDebounceValue: <Value,>(value: Value, delay: number) => {
+      const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+      React.useEffect(() => {
+        const timeoutId = window.setTimeout(() => {
+          setDebouncedValue(value);
+        }, delay);
+
+        return () => window.clearTimeout(timeoutId);
+      }, [delay, value]);
+
+      return [debouncedValue, setDebouncedValue] as const;
+    },
   };
 });
 
@@ -115,7 +128,7 @@ describe("SongSearch", () => {
     expect(mockSongSearchUseQuery).toHaveBeenLastCalledWith(
       {
         organizationId: "organization-1",
-        searchInput: "c",
+        searchInput: "",
         limit: 50,
       },
       {

--- a/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
+++ b/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
@@ -45,9 +45,8 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
   const router = useRouter();
 
   const [dialogStep, setDialogStep] = useState<SongSearchDialogSteps>("search");
-  const [selectedSong, setSelectedSong] = useState<SongSearchResult | null>(
-    null,
-  );
+  const [selectedSong, setSelectedSong] =
+    useState<SongSearchResult | null>(null);
   const [dismissedPreSelectedSongId, setDismissedPreSelectedSongId] = useState<
     string | null
   >(null);
@@ -70,6 +69,8 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
           preferredKey: preSelectedSong.preferredKey,
           isArchived: preSelectedSong.isArchived,
           similarityScore: 0,
+          tags: [],
+          matchedTags: [],
           lastPlayedDate: null,
         }
       : null;
@@ -113,7 +114,7 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
   };
 
   const handleSongSelect = (song?: SongSearchResult) => {
-    if (!!song) {
+    if (song) {
       setSelectedSong(song);
       setDialogStep("configure");
     }
@@ -160,7 +161,10 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
         <Text>Loading song...</Text>
       )}
       {activeDialogStep === "search" && !isPreSelectedSongLoading && (
-        <SongSearch onSongSelect={handleSongSelect} />
+        <SongSearch
+          organizationId={params.organization}
+          onSongSelect={handleSongSelect}
+        />
       )}
       {activeDialogStep === "configure" && !!activeSelectedSong && (
         <ConfigureSongForSet

--- a/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
+++ b/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
@@ -6,8 +6,9 @@ import { useAuth } from "@clerk/nextjs";
 
 import { CommandDialog } from "@components/ui/command";
 import { Text } from "@components/Text";
+import { useSongSearchResults } from "@modules/search/hooks/useSongSearchResults";
 import {
-  SongSearch,
+  SongSearchContent,
   type SongSearchResult,
 } from "@modules/songs/components/SongSearch";
 import { trpc } from "@lib/trpc";
@@ -50,6 +51,9 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
   const [dismissedPreSelectedSongId, setDismissedPreSelectedSongId] = useState<
     string | null
   >(null);
+  const songSearchState = useSongSearchResults({
+    organizationId: params.organization,
+  });
   const { data: preSelectedSong, isLoading: isPreSelectedSongLoading } =
     trpc.song.get.useQuery(
       {
@@ -156,13 +160,20 @@ export const SongSearchDialog: React.FC<SongSearchDialogProps> = ({
       animated={activeDialogStep !== "configure"}
       minimalPadding
       autoFocusInput={open && activeDialogStep === "search"}
+      onEscapeKeyDown={(event) => {
+        if (activeDialogStep !== "search") {
+          return;
+        }
+
+        songSearchState.handleSearchEscapeKeyDown(event);
+      }}
     >
       {activeDialogStep === "search" && isPreSelectedSongLoading && (
         <Text>Loading song...</Text>
       )}
       {activeDialogStep === "search" && !isPreSelectedSongLoading && (
-        <SongSearch
-          organizationId={params.organization}
+        <SongSearchContent
+          searchState={songSearchState}
           onSongSelect={handleSongSelect}
         />
       )}

--- a/tests/e2e/sets/set-detail.authenticated.spec.ts
+++ b/tests/e2e/sets/set-detail.authenticated.spec.ts
@@ -106,7 +106,7 @@ test("adds a song to a section from set detail", async ({ page }, testInfo) => {
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
   await dialog
-    .getByPlaceholder("Search for a song...")
+    .getByPlaceholder("Search songs or tags")
     .fill(songToAdd.name);
   await expect(dialog.getByText(songToAdd.name, { exact: true })).toBeVisible();
   await dialog.getByText(songToAdd.name, { exact: true }).click();


### PR DESCRIPTION
## Background
- Linear: https://linear.app/paranoid-android/issue/SWY-191/extract-reusable-song-picker-search-ui-from-global-search
- This extracts the reusable song/tag search state and result rendering from global search so modal song picker workflows can use the same search experience without global navigation or quick actions.
- It preserves the global search UX while letting picker consumers handle selected songs directly.

## What's changed
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now supports both songs and tags, with separate filters and clearer result counts.
  * Search results can be opened or added directly from the results list, with improved selection behavior.

* **Bug Fixes**
  * Search loading, empty, and error states now update more consistently.
  * Result selection now correctly distinguishes between song and tag matches.
  * Search is now scoped more reliably to the current organization where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- Added `useSongSearchResults` to centralize debounced query state, song/tag grouping, filters, loading, error, empty states, overflow labels, and reset behavior around the existing `song.search` procedure.
- Updated `SearchResultsList` so global search can still provide action menus while picker flows can render selectable results without quick actions.
- Rebuilt `SongSearch` on the shared hook and result list, threaded organization IDs from add/replace song dialogs, and added picker tests for grouping, filters, states, and selection callbacks.

## How to test
- Open a set, use the add-song dialog, and search for at least two characters that match both song names and tags.
- Toggle the Songs and Tags filters, select a title match and a tag match, and confirm each advances to the configure step with the expected song.
- Open the replace-song dialog from an existing set song, search/select a replacement, and confirm the replacement confirmation step shows the selected song.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a reusable `useSongSearchResults` hook from the global `Search` component so that modal song-picker workflows (`SongSearchDialog`, `ReplaceSongDialog`) can share the same debounced query, filter, loading/error/empty-state, and keyboard behaviour without re-implementing it. `SearchResultsList` gains an optional `actions` prop to distinguish "open/add" menus (global search) from direct selection (picker mode), and `SearchShortcutLegend` gains props to customise the Enter label and hide the Shift+Enter shortcut for pickers.

- **New `useSongSearchResults` hook** centralises debounce, filter toggle, overflow labelling, escape handling, and reset, and is consumed by all three search surfaces.
- **`SearchResultsList`** is split into `actions`-driven (global search) and action-free (picker) modes, with `matchType` forwarded to selection callbacks so callers can distinguish title vs. tag matches.
- **`SongSearch` / `SongSearchContent`** replaces a bespoke, auth-fetching implementation with a thin wrapper over the shared hook and result list, and new unit tests cover grouping, filters, states, and selection callbacks.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: both picker dialogs need to call resetSearchInput() when they close.

The core extraction is well-structured and Search.tsx already shows the correct close/reset pattern. The two dialog components hoist the hook but omit the matching teardown call, so users who close and reopen a picker dialog will see their previous search query and filters still active.

SongSearchDialog.tsx and ReplaceSongDialog.tsx — both onOpenChange handlers need a resetSearchInput() call in the !open branch.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/modules/search/hooks/useSongSearchResults.ts | New hook correctly extracts debounce, filter, overflow, and escape logic from Search.tsx; exports resetSearchInput for callers to reset on dialog close. |
| src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx | Hoists useSongSearchResults but onOpenChange never calls resetSearchInput(), leaving stale search state on dialog reopen. |
| src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx | Same missing resetSearchInput() call in onOpenChange and handleCloseDialog as SongSearchDialog. |
| src/modules/search/components/SearchResultsList.tsx | Cleanly adds optional actions prop and matchType parameter; keyboard-event guards correctly short-circuit when actions are absent. |
| src/modules/songs/components/SongSearch/SongSearch.tsx | Old bespoke implementation replaced by SongSearchContent (renders shared hook results) and a thin SongSearch wrapper; removes auth-redirect logic that belonged in middleware. |
| src/modules/search/components/Search.tsx | Correctly migrated to useSongSearchResults; calls resetSearchInput() on close and on Cmd+K shortcut. |
| src/modules/songs/components/SongSearch/__tests__/SongSearch.test.tsx | New test suite covers debounce threshold, grouping, filter toggles, selection callbacks with matchType, and loading/error/empty states. |
| src/modules/search/hooks/__tests__/useSongSearchResults.test.tsx | Unit-tests the escape-key flow; correctly asserts both the preventDefault side-effect and the return value. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Dialog as SongSearchDialog / ReplaceSongDialog
    participant Hook as useSongSearchResults
    participant Content as SongSearchContent
    participant List as SearchResultsList

    User->>Dialog: opens dialog
    Dialog->>Hook: "useSongSearchResults({ organizationId })"
    Hook-->>Dialog: searchState

    Dialog->>Content: SongSearchContent searchState onSongSelect
    User->>Content: types query (≥2 chars)
    Content->>Hook: handleInputChange(value)
    Hook->>Hook: debounce → trpc.song.search.useQuery
    Hook-->>Content: visibleSongResults, visibleTagResults

    Content->>List: "SearchResultsList actions=undefined onSongSelect"
    User->>List: clicks result
    List->>Dialog: onSongSelect(result, matchType)
    Dialog->>Dialog: setDialogStep configure or confirm

    User->>Dialog: closes dialog
    Note over Dialog,Hook: resetSearchInput() NOT called — stale state persists
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Dialog as SongSearchDialog / ReplaceSongDialog
    participant Hook as useSongSearchResults
    participant Content as SongSearchContent
    participant List as SearchResultsList

    User->>Dialog: opens dialog
    Dialog->>Hook: "useSongSearchResults({ organizationId })"
    Hook-->>Dialog: searchState

    Dialog->>Content: SongSearchContent searchState onSongSelect
    User->>Content: types query (≥2 chars)
    Content->>Hook: handleInputChange(value)
    Hook->>Hook: debounce → trpc.song.search.useQuery
    Hook-->>Content: visibleSongResults, visibleTagResults

    Content->>List: "SearchResultsList actions=undefined onSongSelect"
    User->>List: clicks result
    List->>Dialog: onSongSelect(result, matchType)
    Dialog->>Dialog: setDialogStep configure or confirm

    User->>Dialog: closes dialog
    Note over Dialog,Hook: resetSearchInput() NOT called — stale state persists
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx`, line 116-121 ([link](https://github.com/justaddcl/sanbi/blob/b865dd6c1dd83ff1410823015b536d638e3afb4e/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx#L116-L121)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `song?` optional parameter is now semantically unreachable from `SongSearch`. The new `SongSearch.onSongSelect` always provides a non-null `SongSearchResult`, so the `if (song)` guard can never be false when called from `SongSearch`. Dropping the `?` makes the intent explicit and avoids a dead branch for future readers. The same pattern exists in `ReplaceSongDialog.tsx` at line 86.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
   Line: 116-121

   Comment:
   The `song?` optional parameter is now semantically unreachable from `SongSearch`. The new `SongSearch.onSongSelect` always provides a non-null `SongSearchResult`, so the `if (song)` guard can never be false when called from `SongSearch`. Dropping the `?` makes the intent explicit and avoids a dead branch for future readers. The same pattern exists in `ReplaceSongDialog.tsx` at line 86.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx`, line 86-92 ([link](https://github.com/justaddcl/sanbi/blob/b865dd6c1dd83ff1410823015b536d638e3afb4e/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx#L86-L92)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same optional-parameter issue as `SongSearchDialog`: `SongSearch` now always calls `onSongSelect` with a non-null result, so `song?` can never be `undefined` here and the `if (song)` guard is dead code on the `SongSearch` path.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
   Line: 86-92

   Comment:
   Same optional-parameter issue as `SongSearchDialog`: `SongSearch` now always calls `onSongSelect` with a non-null result, so `song?` can never be `undefined` here and the `if (song)` guard is dead code on the `SongSearch` path.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

3. `src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx`, line 147-156 ([link](https://github.com/justaddcl/sanbi/blob/6fd0593f73a5c514b6d87184aa51f327804120b0/src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx#L147-L156)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Search state not reset on dialog close**

   `songSearchState` is now hoisted to the `SongSearchDialog` component level, so it persists as long as the component is mounted. `Search.tsx` calls `resetSearchInput()` inside its `handleOpenChange(false)` for exactly this reason, but neither this `onOpenChange` handler nor `ReplaceSongDialog`'s does. When the dialog is closed and reopened (with the component staying mounted), the previous search input and selected filters will still be active, showing stale results immediately on reopen.

   Both `onOpenChange` handlers need a `songSearchState.resetSearchInput()` call in the `!open` branch, matching the pattern established in `Search.tsx` (line 106).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx
   Line: 147-156

   Comment:
   **Search state not reset on dialog close**

   `songSearchState` is now hoisted to the `SongSearchDialog` component level, so it persists as long as the component is mounted. `Search.tsx` calls `resetSearchInput()` inside its `handleOpenChange(false)` for exactly this reason, but neither this `onOpenChange` handler nor `ReplaceSongDialog`'s does. When the dialog is closed and reopened (with the component staying mounted), the previous search input and selected filters will still be active, showing stale results immediately on reopen.

   Both `onOpenChange` handlers need a `songSearchState.resetSearchInput()` call in the `!open` branch, matching the pattern established in `Search.tsx` (line 106).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


4. `src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx`, line 138-147 ([link](https://github.com/justaddcl/sanbi/blob/6fd0593f73a5c514b6d87184aa51f327804120b0/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx#L138-L147)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Search state not reset on dialog close**

   Same issue as `SongSearchDialog`: `songSearchState` is hoisted to the component level but its `resetSearchInput()` is never called when the dialog closes. `handleCloseDialog` (line 98) and the `onOpenChange` handler both clear `selectedSong` and reset `dialogStep`, but neither resets the search hook state. Reopening the dialog will show the previous search query and filters. Add `songSearchState.resetSearchInput()` in the `!open` branch of `onOpenChange` (and in `handleCloseDialog` if a confirm-step cancel should also reset it).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
   Line: 138-147

   Comment:
   **Search state not reset on dialog close**

   Same issue as `SongSearchDialog`: `songSearchState` is hoisted to the component level but its `resetSearchInput()` is never called when the dialog closes. `handleCloseDialog` (line 98) and the `onOpenChange` handler both clear `selectedSong` and reset `dialogStep`, but neither resets the search hook state. Reopening the dialog will show the previous search query and filters. Add `songSearchState.resetSearchInput()` in the `!open` branch of `onOpenChange` (and in `handleCloseDialog` if a confirm-step cancel should also reset it).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/modules/songs/components/SongSearchDialog/SongSearchDialog.tsx:147-156
**Search state not reset on dialog close**

`songSearchState` is now hoisted to the `SongSearchDialog` component level, so it persists as long as the component is mounted. `Search.tsx` calls `resetSearchInput()` inside its `handleOpenChange(false)` for exactly this reason, but neither this `onOpenChange` handler nor `ReplaceSongDialog`'s does. When the dialog is closed and reopened (with the component staying mounted), the previous search input and selected filters will still be active, showing stale results immediately on reopen.

Both `onOpenChange` handlers need a `songSearchState.resetSearchInput()` call in the `!open` branch, matching the pattern established in `Search.tsx` (line 106).

### Issue 2 of 2
src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx:138-147
**Search state not reset on dialog close**

Same issue as `SongSearchDialog`: `songSearchState` is hoisted to the component level but its `resetSearchInput()` is never called when the dialog closes. `handleCloseDialog` (line 98) and the `onOpenChange` handler both clear `selectedSong` and reset `dialogStep`, but neither resets the search hook state. Reopening the dialog will show the previous search query and filters. Add `songSearchState.resetSearchInput()` in the `!open` branch of `onOpenChange` (and in `handleCloseDialog` if a confirm-step cancel should also reset it).


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Share search dialog keyboard shortcuts"](https://github.com/justaddcl/sanbi/commit/6fd0593f73a5c514b6d87184aa51f327804120b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39956620)</sub>

<!-- /greptile_comment -->