### PR TITLE
[SWY-143] Add resource lifecycle E2E smoke test

### DIFF
--- a/src/testUtils/e2e/fixtures.ts
+++ b/src/testUtils/e2e/fixtures.ts
@@ -106,4 +106,17 @@ export const e2eData = {
     title: "E2E Chart",
     url: "https://example.com/e2e-chart",
   },
+  resourceLifecycle: {
+    host: "resource-lifecycle.invalid",
+    desktop: {
+      createTitle: "E2E Desktop Lifecycle Chart",
+      updatedTitle: "E2E Desktop Lifecycle Chart Updated",
+      url: "https://resource-lifecycle.invalid/desktop",
+    },
+    mobile: {
+      createTitle: "E2E Mobile Lifecycle Chart",
+      updatedTitle: "E2E Mobile Lifecycle Chart Updated",
+      url: "https://resource-lifecycle.invalid/mobile",
+    },
+  },
 } as const;

--- a/tests/e2e/songs/resource-lifecycle.authenticated.spec.ts
+++ b/tests/e2e/songs/resource-lifecycle.authenticated.spec.ts
@@ -1,0 +1,199 @@
+import {
+  expect,
+  type Locator,
+  type Page,
+  test,
+  type TestInfo,
+} from "@playwright/test";
+import { e2eData, e2eIds } from "@testUtils/e2e/fixtures";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { db } from "@server/db";
+import { resources, userPreferences } from "@server/db/schema";
+
+const sharedResourceLifecycle = {
+  host: "resource-lifecycle.invalid",
+  legacyUrl: "https://resource-lifecycle.invalid/create",
+} as const;
+
+const getResourceLifecycleFixture = (projectName: TestInfo["project"]["name"]) =>
+  projectName.includes("mobile")
+    ? {
+        createTitle: "E2E Mobile Lifecycle Chart",
+        updatedTitle: "E2E Mobile Lifecycle Chart Updated",
+        url: "https://resource-lifecycle.invalid/mobile",
+        host: sharedResourceLifecycle.host,
+      }
+    : {
+        createTitle: "E2E Desktop Lifecycle Chart",
+        updatedTitle: "E2E Desktop Lifecycle Chart Updated",
+        url: "https://resource-lifecycle.invalid/desktop",
+        host: sharedResourceLifecycle.host,
+      };
+
+type ResourceLifecycleFixture = ReturnType<typeof getResourceLifecycleFixture>;
+
+const getResourceItem = (
+  page: Page,
+  { title, host }: { title: string; host: string },
+) =>
+  page
+    .locator("li")
+    .filter({ has: page.getByText(title, { exact: true }) })
+    .filter({ hasText: host });
+
+const getCreatedResourceLink = (
+  page: Page,
+  fixture: ResourceLifecycleFixture,
+) =>
+  getResourceItem(page, {
+    title: fixture.createTitle,
+    host: fixture.host,
+  }).getByRole("link");
+
+const getUpdatedResourceLink = (
+  page: Page,
+  fixture: ResourceLifecycleFixture,
+) =>
+  getResourceItem(page, {
+    title: fixture.updatedTitle,
+    host: fixture.host,
+  }).getByRole("link");
+
+const getResourceActionMenu = (page: Page, title: string) =>
+  page.getByRole("button", {
+    name: `Open actions for ${title}`,
+  });
+
+const resetResourceLifecycleFixture = async (
+  fixture: ResourceLifecycleFixture,
+) => {
+  const e2eUserId = process.env.E2E_CLERK_USER_ID;
+
+  if (!e2eUserId) {
+    throw new Error("E2E_CLERK_USER_ID is required for Playwright E2E tests.");
+  }
+
+  await db.transaction(async (transaction) => {
+    await transaction
+      .delete(resources)
+      .where(
+        and(
+          eq(resources.songId, e2eIds.firstSongId),
+          inArray(resources.url, [
+            fixture.url,
+            sharedResourceLifecycle.legacyUrl,
+          ]),
+        ),
+      );
+
+    await transaction
+      .update(userPreferences)
+      .set({ confirmResourceDelete: true })
+      .where(eq(userPreferences.userId, e2eUserId));
+  });
+};
+
+const fillResourceForm = async (
+  dialog: Locator,
+  {
+    title,
+    url,
+  }: {
+    title?: string;
+    url?: string;
+  },
+) => {
+  if (url !== undefined) {
+    await dialog.getByLabel("URL *").fill(url);
+  }
+
+  if (title !== undefined) {
+    await dialog.getByLabel("Name").fill(title);
+  }
+};
+
+test("song detail resource lifecycle can link, update, and unlink a resource", async ({
+  page,
+}, testInfo) => {
+  const fixture = getResourceLifecycleFixture(testInfo.project.name);
+
+  await resetResourceLifecycleFixture(fixture);
+
+  // The CRUD path still uses the real tRPC resource procedures. The preview is
+  // best-effort UI decoration, so keep it out of this smoke's network surface.
+  await page.route("**/api/trpc/resource.previewMetadata**", (route) =>
+    route.abort(),
+  );
+
+  await page.goto(`/${e2eIds.organizationId}/songs/${e2eIds.firstSongId}`);
+  await expect(
+    page.getByRole("heading", { name: e2eData.songs.first.name }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Link resource" }).click();
+
+  const createDialog = page.getByRole("dialog");
+  await expect(
+    createDialog.getByRole("heading", { name: "Link a song resource" }),
+  ).toBeVisible();
+  await fillResourceForm(createDialog, {
+    url: fixture.url,
+    title: fixture.createTitle,
+  });
+
+  const linkResourceButton = createDialog.getByRole("button", {
+    name: "Link resource",
+  });
+  await expect(linkResourceButton).toBeEnabled({ timeout: 10_000 });
+  await linkResourceButton.click();
+
+  await expect(page.getByText("Resource was linked")).toBeVisible();
+  await expect(createDialog).toBeHidden({ timeout: 15_000 });
+
+  const createdResourceLink = getCreatedResourceLink(page, fixture);
+  await expect(createdResourceLink).toBeVisible();
+  await expect(createdResourceLink).toContainText(fixture.host);
+  await expect(createdResourceLink).toHaveAttribute("href", fixture.url);
+
+  await getResourceActionMenu(page, fixture.createTitle).click();
+  await page.getByRole("menuitem", { name: "Edit resource" }).click();
+
+  const editDialog = page.getByRole("dialog");
+  await expect(
+    editDialog.getByRole("heading", { name: "Edit resource" }),
+  ).toBeVisible();
+  await fillResourceForm(editDialog, {
+    title: fixture.updatedTitle,
+  });
+
+  const saveChangesButton = editDialog.getByRole("button", {
+    name: "Save changes",
+  });
+  await expect(saveChangesButton).toBeEnabled();
+  await saveChangesButton.click();
+
+  await expect(page.getByText("Resource was updated")).toBeVisible();
+  await expect(editDialog).toBeHidden({ timeout: 15_000 });
+  await expect(getCreatedResourceLink(page, fixture)).toBeHidden();
+
+  const updatedResourceLink = getUpdatedResourceLink(page, fixture);
+  await expect(updatedResourceLink).toBeVisible();
+  await expect(updatedResourceLink).toContainText(fixture.host);
+
+  await getResourceActionMenu(page, fixture.updatedTitle).click();
+  await page.getByRole("menuitem", { name: "Unlink resource" }).click();
+
+  const confirmationDialog = page.getByRole("alertdialog");
+  await expect(
+    confirmationDialog.getByRole("heading", {
+      name: `Unlink ${fixture.updatedTitle}`,
+    }),
+  ).toBeVisible();
+  await confirmationDialog
+    .getByRole("button", { name: "Unlink resource" })
+    .click();
+
+  await expect(page.getByText("Resource was unlinked")).toBeVisible();
+  await expect(getUpdatedResourceLink(page, fixture)).toBeHidden();
+});

--- a/tests/e2e/songs/resource-lifecycle.authenticated.spec.ts
+++ b/tests/e2e/songs/resource-lifecycle.authenticated.spec.ts
@@ -6,29 +6,20 @@ import {
   type TestInfo,
 } from "@playwright/test";
 import { e2eData, e2eIds } from "@testUtils/e2e/fixtures";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { db } from "@server/db";
 import { resources, userPreferences } from "@server/db/schema";
 
-const sharedResourceLifecycle = {
-  host: "resource-lifecycle.invalid",
-  legacyUrl: "https://resource-lifecycle.invalid/create",
-} as const;
-
 const getResourceLifecycleFixture = (projectName: TestInfo["project"]["name"]) =>
   projectName.includes("mobile")
     ? {
-        createTitle: "E2E Mobile Lifecycle Chart",
-        updatedTitle: "E2E Mobile Lifecycle Chart Updated",
-        url: "https://resource-lifecycle.invalid/mobile",
-        host: sharedResourceLifecycle.host,
+        ...e2eData.resourceLifecycle.mobile,
+        host: e2eData.resourceLifecycle.host,
       }
     : {
-        createTitle: "E2E Desktop Lifecycle Chart",
-        updatedTitle: "E2E Desktop Lifecycle Chart Updated",
-        url: "https://resource-lifecycle.invalid/desktop",
-        host: sharedResourceLifecycle.host,
+        ...e2eData.resourceLifecycle.desktop,
+        host: e2eData.resourceLifecycle.host,
       };
 
 type ResourceLifecycleFixture = ReturnType<typeof getResourceLifecycleFixture>;
@@ -80,10 +71,7 @@ const resetResourceLifecycleFixture = async (
       .where(
         and(
           eq(resources.songId, e2eIds.firstSongId),
-          inArray(resources.url, [
-            fixture.url,
-            sharedResourceLifecycle.legacyUrl,
-          ]),
+          eq(resources.url, fixture.url),
         ),
       );
 
@@ -180,6 +168,7 @@ test("song detail resource lifecycle can link, update, and unlink a resource", a
   const updatedResourceLink = getUpdatedResourceLink(page, fixture);
   await expect(updatedResourceLink).toBeVisible();
   await expect(updatedResourceLink).toContainText(fixture.host);
+  await expect(updatedResourceLink).toHaveAttribute("href", fixture.url);
 
   await getResourceActionMenu(page, fixture.updatedTitle).click();
   await page.getByRole("menuitem", { name: "Unlink resource" }).click();


### PR DESCRIPTION
## Background
- [SWY-143](https://linear.app/sanbi/issue/SWY-143) adds smoke coverage for the song resource lifecycle so linking, editing, and unlinking a resource are exercised through the authenticated app flow.

## What's changed
@coderabbitai summary
- Added an authenticated Playwright spec for the song detail resource lifecycle.
- The spec uses desktop/mobile-specific resource URLs and titles, resets the seeded resource fixture before each run, and restores the delete confirmation preference.
- The preview metadata request is aborted so the smoke test stays focused on the real resource CRUD procedures and visible UI state.

## How to test
- In the web app, open the seeded organization, go to the first song detail page, link a resource, edit its display name, then unlink it and confirm that each success state appears.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an authenticated Playwright E2E smoke test for the song detail resource lifecycle (link → edit → unlink). Fixture data is correctly extracted to the shared `fixtures.ts` file, and the test resets database state before each run. The PR addresses prior review feedback: fixture values now live in the shared file, and `href` attributes are verified at every assertion point.

- Adds `e2eData.resourceLifecycle` to `src/testUtils/e2e/fixtures.ts` with desktop/mobile variants for titles, URLs, and the shared hostname.
- Adds a single parameterised Playwright spec that exercises create, edit, and unlink flows using real tRPC procedures, aborting only the `previewMetadata` request to keep the network surface narrow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive test-only code with no impact on production paths.

Both files are purely test infrastructure. The spec correctly resets DB state before the test, aborts the non-critical preview route, and asserts href at every step. No production code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/testUtils/e2e/fixtures.ts | Adds resourceLifecycle block to e2eData with host, desktop, and mobile variants (titles + URLs). Clean additive change, consistent with existing fixture structure. |
| tests/e2e/songs/resource-lifecycle.authenticated.spec.ts | New authenticated Playwright spec for resource lifecycle. Well-structured with modular helpers. Minor concern: userPreferences reset uses update which silently no-ops if no row exists for the e2e user. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test Runner
    participant DB as Database
    participant P as Browser (Playwright)
    participant APP as App (tRPC)

    T->>DB: "resetResourceLifecycleFixture()<br/>DELETE resource by songId+url<br/>UPDATE userPreferences.confirmResourceDelete=true"
    T->>P: page.route abort previewMetadata
    P->>APP: goto /org/songs/firstSong
    P->>APP: click Link resource
    P->>APP: fill URL + title, click Link resource
    APP->>DB: resource.create (tRPC)
    APP-->>P: toast Resource was linked
    P->>P: assert href + host visible (createdResourceLink)
    P->>APP: open action menu Edit resource
    P->>APP: fill updatedTitle, click Save changes
    APP->>DB: resource.update (tRPC)
    APP-->>P: toast Resource was updated
    P->>P: assert href + host visible (updatedResourceLink)
    P->>APP: open action menu Unlink resource
    APP-->>P: alertdialog confirmation
    P->>APP: click Unlink resource
    APP->>DB: resource.delete (tRPC)
    APP-->>P: toast Resource was unlinked
    P->>P: assert updatedResourceLink hidden
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test Runner
    participant DB as Database
    participant P as Browser (Playwright)
    participant APP as App (tRPC)

    T->>DB: "resetResourceLifecycleFixture()<br/>DELETE resource by songId+url<br/>UPDATE userPreferences.confirmResourceDelete=true"
    T->>P: page.route abort previewMetadata
    P->>APP: goto /org/songs/firstSong
    P->>APP: click Link resource
    P->>APP: fill URL + title, click Link resource
    APP->>DB: resource.create (tRPC)
    APP-->>P: toast Resource was linked
    P->>P: assert href + host visible (createdResourceLink)
    P->>APP: open action menu Edit resource
    P->>APP: fill updatedTitle, click Save changes
    APP->>DB: resource.update (tRPC)
    APP-->>P: toast Resource was updated
    P->>P: assert href + host visible (updatedResourceLink)
    P->>APP: open action menu Unlink resource
    APP-->>P: alertdialog confirmation
    P->>APP: click Unlink resource
    APP->>DB: resource.delete (tRPC)
    APP-->>P: toast Resource was unlinked
    P->>P: assert updatedResourceLink hidden
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address resource lifecycle review feedba..."](https://github.com/justaddcl/sanbi/commit/30afa8bd9e3730bcbc905bf0d11bfa11193fcc31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40090058)</sub>

<!-- /greptile_comment -->