### PR TITLE
[SWY-169] Add song tag component coverage

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -28,6 +28,7 @@ const badgeVariants = cva(
 export type BadgeProps = React.HTMLAttributes<HTMLDivElement> &
   VariantProps<typeof badgeVariants> & {
     dismissable?: boolean;
+    dismissLabel?: string;
     onDismiss?: () => void;
     onDismissPending?: boolean;
   };
@@ -36,6 +37,7 @@ function Badge({
   className,
   variant,
   dismissable,
+  dismissLabel,
   onDismiss,
   onDismissPending,
   children,
@@ -51,6 +53,7 @@ function Badge({
             closeEvent.stopPropagation();
             onDismiss();
           }}
+          aria-label={dismissLabel}
           disabled={onDismissPending}
           className="ring-offset-background focus:ring-ring ml-2 rounded-full outline-hidden focus:ring-2 focus:ring-offset-2"
         >

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -53,7 +53,7 @@ function Badge({
             closeEvent.stopPropagation();
             onDismiss();
           }}
-          aria-label={dismissLabel}
+          aria-label={dismissLabel ?? "Remove"}
           disabled={onDismissPending}
           className="ring-offset-background focus:ring-ring ml-2 rounded-full outline-hidden focus:ring-2 focus:ring-offset-2"
         >

--- a/src/modules/songs/components/SongTagSelector/SongTagSelector.tsx
+++ b/src/modules/songs/components/SongTagSelector/SongTagSelector.tsx
@@ -182,7 +182,9 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
     const validationResult = tagNameSchema.safeParse(trimmedTag);
 
     if (!validationResult.success) {
-      const [formattedError] = z.flattenError(validationResult.error).formErrors;
+      const [formattedError] = z.flattenError(
+        validationResult.error,
+      ).formErrors;
       toast.error(formattedError);
       return;
     }
@@ -374,7 +376,11 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
               </HStack>
 
               {isLoading ? (
-                <VStack className="gap-6 p-5">
+                <VStack
+                  aria-label="Loading tags"
+                  className="gap-6 p-5"
+                  role="status"
+                >
                   <HStack className="h-5 justify-between">
                     <HStack className="gap-3">
                       <Skeleton className="w-4" />
@@ -395,17 +401,25 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
                   </HStack>
                 </VStack>
               ) : (
-                <ScrollArea className="max-h-[600px] flex-1 px-1 py-2">
+                <ScrollArea
+                  aria-label="Available tags"
+                  className="max-h-[600px] flex-1 px-1 py-2"
+                  role="group"
+                >
                   {filteredTags.length > 0 &&
                     filteredTags.map((tag, index: number) => {
                       const isSelected = isTagSelected(tag.id);
 
                       return (
                         <HStack
+                          as="button"
                           key={tag.id}
+                          type="button"
+                          aria-label={`${isSelected ? "Remove" : "Add"} ${tag.tag} tag`}
+                          aria-pressed={isSelected}
                           onClick={() => handleTagSelect(tag)}
                           className={cn(
-                            "items-center justify-between rounded-lg px-3 py-3 text-sm transition-colors",
+                            "w-full items-center justify-between rounded-lg px-3 py-3 text-left text-sm transition-colors",
                             "cursor-pointer",
                             "hover:bg-slate-100",
                           )}
@@ -426,9 +440,12 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
                     })}
                   {showCreateOption && (
                     <HStack
+                      as="button"
+                      type="button"
+                      aria-label={`Create ${search} tag`}
                       onClick={handleCreateTag}
                       className={cn(
-                        "items-center justify-between rounded-lg px-3 py-3 text-sm transition-colors",
+                        "w-full items-center justify-between rounded-lg px-3 py-3 text-left text-sm transition-colors",
                         "cursor-pointer",
                         "hover:bg-slate-100",
                       )}
@@ -538,7 +555,11 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
               </div>
             )} */}
             {isLoading ? (
-              <VStack className="gap-4 p-5">
+              <VStack
+                aria-label="Loading tags"
+                className="gap-4 p-5"
+                role="status"
+              >
                 <HStack className="h-5 justify-between">
                   <HStack className="gap-3">
                     <Skeleton className="w-4" />
@@ -560,17 +581,21 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
               </VStack>
             ) : (
               <ScrollArea className="h-full px-3">
-                <div className="py-2">
+                <div aria-label="Available tags" className="py-2" role="group">
                   {filteredTags.length > 0 &&
                     filteredTags.map((tag, index) => {
                       const isSelected = isTagSelected(tag.id);
 
                       return (
                         <HStack
+                          as="button"
                           key={tag.id}
+                          type="button"
+                          aria-label={`${isSelected ? "Remove" : "Add"} ${tag.tag} tag`}
+                          aria-pressed={isSelected}
                           onClick={() => handleTagSelect(tag)}
                           className={cn(
-                            "mx-1 items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors",
+                            "mx-1 w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors",
                             "cursor-pointer",
                             "hover:bg-slate-100",
                             highlightedIndex === index && "bg-slate-100",
@@ -592,9 +617,12 @@ export const SongTagSelector: React.FC<SongTagSelectorProps> = ({
                     })}
                   {showCreateOption && (
                     <HStack
+                      as="button"
+                      type="button"
+                      aria-label={`Create ${search} tag`}
                       onClick={handleCreateTag}
                       className={cn(
-                        "mx-1 items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors",
+                        "mx-1 w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors",
                         "cursor-pointer",
                         "hover:bg-slate-100",
                         highlightedIndex === filteredTags.length &&

--- a/src/modules/songs/components/SongTagSelector/__tests__/SongTagSelector.test.tsx
+++ b/src/modules/songs/components/SongTagSelector/__tests__/SongTagSelector.test.tsx
@@ -1,0 +1,279 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createTagFixture } from "@testUtils/fixtures/tags";
+import { createUuid } from "@testUtils/generators/createUuid";
+import {
+  mockCreateSongTagMutate,
+  mockCreateTagMutate,
+  mockDeleteSongTagMutate,
+  mockInvalidateOrganizationTags,
+  mockInvalidateSongTags,
+  mockTrpc,
+  resetMockTrpc,
+  setMockCreatedTag,
+  setMockOrganizationTagsQuery,
+  type SongTagResult,
+  type TrpcMockModule,
+} from "@testUtils/mocks/trpc";
+import { toast } from "sonner";
+
+import { type Tag } from "@lib/types";
+import { useResponsive } from "@/hooks/useResponsive";
+
+import { SongTagSelector } from "../SongTagSelector";
+
+jest.mock("@lib/trpc", () => {
+  const { mockTrpc } = jest.requireActual<TrpcMockModule>(
+    "@testUtils/mocks/trpc",
+  );
+
+  return { trpc: mockTrpc };
+});
+
+jest.mock("@/hooks/useResponsive", () => ({
+  useResponsive: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    loading: jest.fn(() => "toast-id"),
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const organizationId = createUuid();
+const songId = createUuid();
+const selectedTag = createTagFixture({
+  id: createUuid(),
+  organizationId,
+  tag: "Communion",
+});
+const unselectedTag = createTagFixture({
+  id: createUuid(),
+  organizationId,
+  tag: "Prayer",
+});
+const newTagName = "Blessing";
+
+const createSongTagResult = (tag: Tag): SongTagResult => ({
+  songId,
+  tagId: tag.id,
+  tag: {
+    id: tag.id,
+    tag: tag.tag,
+  },
+});
+
+const renderSongTagSelector = (songTags: SongTagResult[] = []) => {
+  render(
+    <SongTagSelector
+      songId={songId}
+      organizationId={organizationId}
+      songTags={songTags}
+    />,
+  );
+};
+
+const openSelector = async () => {
+  fireEvent.click(screen.getByRole("button", { name: "Add Tag" }));
+
+  return screen.findByPlaceholderText("Search tags...");
+};
+
+describe("SongTagSelector", () => {
+  beforeAll(() => {
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: jest.fn(),
+      writable: true,
+    });
+
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => window.setTimeout(callback, 0),
+      writable: true,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockTrpc();
+    setMockCreatedTag(
+      createTagFixture({
+        id: "created-tag-id",
+        organizationId,
+        tag: newTagName,
+      }),
+    );
+    setMockOrganizationTagsQuery({
+      data: [selectedTag, unselectedTag],
+      error: null,
+      isLoading: false,
+    });
+    (useResponsive as jest.Mock).mockReturnValue({ isDesktop: true });
+  });
+
+  it("filters organization tags by search text", async () => {
+    renderSongTagSelector();
+
+    const searchInput = await openSelector();
+    expect(
+      screen.getByRole("group", { name: "Available tags" }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: "pray" } });
+
+    expect(
+      screen.getByRole("button", { name: `Add ${unselectedTag.tag} tag` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: `Add ${selectedTag.tag} tag` }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("attaches an existing tag from the selector", async () => {
+    renderSongTagSelector();
+    await openSelector();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: `Add ${unselectedTag.tag} tag` }),
+    );
+
+    const lastCreateSongTagCall = mockCreateSongTagMutate.mock.calls.at(-1);
+
+    expect(lastCreateSongTagCall?.[0]).toEqual({
+      organizationId,
+      songId,
+      tagId: unselectedTag.id,
+    });
+    expect(typeof lastCreateSongTagCall?.[1]?.onError).toBe("function");
+    expect(typeof lastCreateSongTagCall?.[1]?.onSuccess).toBe("function");
+    await waitFor(() => {
+      expect(mockInvalidateSongTags).toHaveBeenCalledWith({
+        organizationId,
+        songId,
+      });
+    });
+  });
+
+  it("removes a selected tag from the selector", async () => {
+    renderSongTagSelector([createSongTagResult(selectedTag)]);
+    await openSelector();
+
+    const removeButton = screen.getByRole("button", {
+      name: `Remove ${selectedTag.tag} tag`,
+    });
+
+    expect(removeButton).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(removeButton);
+
+    const lastDeleteSongTagCall = mockDeleteSongTagMutate.mock.calls.at(-1);
+
+    expect(lastDeleteSongTagCall?.[0]).toEqual({
+      organizationId,
+      songId,
+      tagId: selectedTag.id,
+    });
+    expect(typeof lastDeleteSongTagCall?.[1]?.onError).toBe("function");
+    expect(typeof lastDeleteSongTagCall?.[1]?.onSuccess).toBe("function");
+  });
+
+  it("creates a new tag and attaches it to the song", async () => {
+    renderSongTagSelector();
+
+    const searchInput = await openSelector();
+    fireEvent.change(searchInput, { target: { value: newTagName } });
+    fireEvent.click(
+      screen.getByRole("button", { name: `Create ${newTagName} tag` }),
+    );
+
+    const lastCreateTagCall = mockCreateTagMutate.mock.calls.at(-1);
+
+    expect(lastCreateTagCall?.[0]).toEqual({
+      organizationId,
+      tag: newTagName,
+    });
+    expect(typeof lastCreateTagCall?.[1]?.onError).toBe("function");
+    expect(typeof lastCreateTagCall?.[1]?.onSuccess).toBe("function");
+    expect(mockCreateSongTagMutate).toHaveBeenCalledWith({
+      organizationId,
+      songId,
+      tagId: "created-tag-id",
+    });
+    await waitFor(() => {
+      expect(mockInvalidateOrganizationTags).toHaveBeenCalledWith({
+        organizationId,
+      });
+    });
+  });
+
+  it("selects the highlighted tag with keyboard navigation", async () => {
+    renderSongTagSelector();
+
+    const searchInput = await openSelector();
+    fireEvent.keyDown(searchInput, { key: "ArrowDown" });
+    fireEvent.keyDown(searchInput, { key: "Enter" });
+
+    const lastCreateSongTagCall = mockCreateSongTagMutate.mock.calls.at(-1);
+
+    expect(lastCreateSongTagCall?.[0]).toEqual({
+      organizationId,
+      songId,
+      tagId: selectedTag.id,
+    });
+    expect(typeof lastCreateSongTagCall?.[1]?.onError).toBe("function");
+    expect(typeof lastCreateSongTagCall?.[1]?.onSuccess).toBe("function");
+  });
+
+  it("shows the loading state while tags are loading", async () => {
+    setMockOrganizationTagsQuery({
+      data: undefined,
+      error: null,
+      isLoading: true,
+    });
+
+    renderSongTagSelector();
+    await openSelector();
+
+    expect(
+      screen.getByRole("status", { name: "Loading tags" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reports tag loading errors", async () => {
+    const queryError = new Error("Tag service unavailable");
+    setMockOrganizationTagsQuery({
+      data: undefined,
+      error: queryError,
+      isLoading: false,
+    });
+
+    renderSongTagSelector();
+
+    expect(
+      screen.queryByRole("button", { name: "Add Tag" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        `Could not get the tags for your team: ${queryError.message}`,
+      );
+    });
+  });
+
+  it("requests tags only when the selector is open", async () => {
+    renderSongTagSelector();
+
+    expect(mockTrpc.tag.getByOrganization.useQuery).toHaveBeenLastCalledWith(
+      { organizationId },
+      { enabled: false },
+    );
+
+    await openSelector();
+
+    expect(mockTrpc.tag.getByOrganization.useQuery).toHaveBeenLastCalledWith(
+      { organizationId },
+      { enabled: true },
+    );
+  });
+});

--- a/src/modules/songs/components/SongTagSelector/__tests__/SongTagSelector.test.tsx
+++ b/src/modules/songs/components/SongTagSelector/__tests__/SongTagSelector.test.tsx
@@ -251,9 +251,8 @@ describe("SongTagSelector", () => {
 
     renderSongTagSelector();
 
-    expect(
-      screen.queryByRole("button", { name: "Add Tag" }),
-    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Add Tag" }));
+
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
         `Could not get the tags for your team: ${queryError.message}`,

--- a/src/modules/songs/components/SongTags/SongTags.tsx
+++ b/src/modules/songs/components/SongTags/SongTags.tsx
@@ -91,11 +91,11 @@ export const SongTags: React.FC<SongTagsProps> = ({
   return (
     <HStack as="dd" className="flex-wrap items-start gap-2">
       {isSongTagsQueryLoading && (
-        <>
+        <HStack aria-label="Loading song tags" className="gap-2" role="status">
           <Skeleton className="h-5 w-20" />
           <Skeleton className="h-5 w-16" />
           <Skeleton className="h-5 w-24" />
-        </>
+        </HStack>
       )}
       {!isSongTagsQueryLoading &&
         songTags?.map((tag) => (
@@ -103,6 +103,7 @@ export const SongTags: React.FC<SongTagsProps> = ({
             variant="secondary"
             key={tag.tagId}
             dismissable
+            dismissLabel={`Remove ${tag.tag.tag} tag`}
             onDismiss={() => {
               deleteSongTag(tag.tagId);
             }}

--- a/src/modules/songs/components/SongTags/__tests__/SongTags.test.tsx
+++ b/src/modules/songs/components/SongTags/__tests__/SongTags.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createTagFixture } from "@testUtils/fixtures/tags";
+import { createUuid } from "@testUtils/generators/createUuid";
+import {
+  mockDeleteSongTagMutate,
+  mockInvalidateSong,
+  mockInvalidateSongTags,
+  resetMockTrpc,
+  setMockSongTagsQuery,
+  type SongTagResult,
+  type TrpcMockModule,
+} from "@testUtils/mocks/trpc";
+import { toast } from "sonner";
+
+import { type Tag } from "@lib/types";
+
+import { SongTags } from "../SongTags";
+
+jest.mock("@lib/trpc", () => {
+  const { mockTrpc } = jest.requireActual<TrpcMockModule>(
+    "@testUtils/mocks/trpc",
+  );
+
+  return { trpc: mockTrpc };
+});
+
+jest.mock("@/hooks/useResponsive", () => ({
+  useResponsive: jest.fn(() => ({ isDesktop: true })),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    loading: jest.fn(() => "toast-id"),
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const organizationId = createUuid();
+const songId = createUuid();
+const firstTag = createTagFixture({
+  id: createUuid(),
+  organizationId,
+  tag: "Communion",
+});
+const secondTag = createTagFixture({
+  id: createUuid(),
+  organizationId,
+  tag: "Prayer",
+});
+
+const createSongTagResult = (tag: Tag): SongTagResult => ({
+  songId,
+  tagId: tag.id,
+  tag: {
+    id: tag.id,
+    tag: tag.tag,
+  },
+});
+
+const renderSongTags = () => {
+  render(<SongTags songId={songId} organizationId={organizationId} />);
+};
+
+describe("SongTags", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockTrpc();
+    setMockSongTagsQuery({
+      data: [createSongTagResult(firstTag), createSongTagResult(secondTag)],
+      error: null,
+      isLoading: false,
+    });
+  });
+
+  it("renders the song tag list and named remove actions", () => {
+    renderSongTags();
+
+    expect(screen.getByText(firstTag.tag)).toBeInTheDocument();
+    expect(screen.getByText(secondTag.tag)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `Remove ${firstTag.tag} tag` }),
+    ).toBeInTheDocument();
+  });
+
+  it("removes a song tag and refreshes song tag data", async () => {
+    renderSongTags();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: `Remove ${firstTag.tag} tag` }),
+    );
+
+    const lastDeleteSongTagCall = mockDeleteSongTagMutate.mock.calls.at(-1);
+
+    expect(lastDeleteSongTagCall?.[0]).toEqual({
+      organizationId,
+      songId,
+      tagId: firstTag.id,
+    });
+    expect(typeof lastDeleteSongTagCall?.[1]?.onError).toBe("function");
+    expect(typeof lastDeleteSongTagCall?.[1]?.onSettled).toBe("function");
+    expect(typeof lastDeleteSongTagCall?.[1]?.onSuccess).toBe("function");
+    await waitFor(() => {
+      expect(mockInvalidateSongTags).toHaveBeenCalledWith({
+        organizationId,
+        songId,
+      });
+    });
+    expect(mockInvalidateSong).toHaveBeenCalledWith({
+      organizationId,
+      songId,
+    });
+  });
+
+  it("shows a loading state while song tags load", () => {
+    setMockSongTagsQuery({
+      data: undefined,
+      error: null,
+      isLoading: true,
+    });
+
+    renderSongTags();
+
+    expect(
+      screen.getByRole("status", { name: "Loading song tags" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reports song tag loading errors", async () => {
+    const queryError = new Error("Song tags unavailable");
+    setMockSongTagsQuery({
+      data: undefined,
+      error: queryError,
+      isLoading: false,
+    });
+
+    const { container } = render(
+      <SongTags songId={songId} organizationId={organizationId} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        `Could not get the tags for this song: ${queryError.message}`,
+      );
+    });
+  });
+});

--- a/src/testUtils/mocks/trpc.ts
+++ b/src/testUtils/mocks/trpc.ts
@@ -1,0 +1,152 @@
+import { createTagFixture } from "@testUtils/fixtures/tags";
+import { createUuid } from "@testUtils/generators/createUuid";
+
+import { type Tag } from "@lib/types";
+
+export type SongTagResult = {
+  songId: string;
+  tagId: string;
+  tag: {
+    id: string;
+    tag: string;
+  };
+};
+
+export type QueryResult<Data> = {
+  data: Data | undefined;
+  isLoading: boolean;
+  error: Error | null;
+};
+
+export type MutationCallbacks<Result = unknown> = {
+  onSuccess?: (result: Result) => void | Promise<void>;
+  onError?: (error: Error) => void;
+  onSettled?: () => void;
+};
+
+type CreateTagInput = {
+  organizationId: string;
+  tag: string;
+};
+
+const createQueryResult = <Data>(data: Data): QueryResult<Data> => ({
+  data,
+  error: null,
+  isLoading: false,
+});
+
+let mockOrganizationTagsQuery = createQueryResult<Tag[]>([]);
+let mockSongTagsQuery = createQueryResult<SongTagResult[]>([]);
+let mockCreatedTag: Tag | undefined;
+let mockCreateTagHookCallbacks: MutationCallbacks<Tag> | undefined;
+
+export const mockCreateSongTagMutate = jest.fn(
+  (_input: unknown, callbacks?: MutationCallbacks) => {
+    void callbacks?.onSuccess?.({});
+  },
+);
+
+export const mockDeleteSongTagMutate = jest.fn(
+  (_input: unknown, callbacks?: MutationCallbacks) => {
+    void callbacks?.onSuccess?.({});
+    callbacks?.onSettled?.();
+  },
+);
+
+export const mockCreateTagMutate = jest.fn(
+  (input: unknown, callbacks?: MutationCallbacks<Tag>) => {
+    const createInput = input as Partial<CreateTagInput>;
+    const createdTag =
+      mockCreatedTag ??
+      createTagFixture({
+        id: createUuid(),
+        ...(createInput.organizationId
+          ? { organizationId: createInput.organizationId }
+          : {}),
+        ...(createInput.tag ? { tag: createInput.tag } : {}),
+      });
+
+    void mockCreateTagHookCallbacks?.onSuccess?.(createdTag);
+    void callbacks?.onSuccess?.(createdTag);
+  },
+);
+
+export const mockInvalidateSongTags = jest.fn();
+export const mockInvalidateSong = jest.fn();
+export const mockInvalidateOrganizationTags = jest.fn();
+
+export const setMockOrganizationTagsQuery = (
+  queryResult: QueryResult<Tag[]>,
+) => {
+  mockOrganizationTagsQuery = queryResult;
+};
+
+export const setMockSongTagsQuery = (
+  queryResult: QueryResult<SongTagResult[]>,
+) => {
+  mockSongTagsQuery = queryResult;
+};
+
+export const setMockCreatedTag = (tag: Tag) => {
+  mockCreatedTag = tag;
+};
+
+export const resetMockTrpc = () => {
+  mockOrganizationTagsQuery = createQueryResult([]);
+  mockSongTagsQuery = createQueryResult([]);
+  mockCreatedTag = undefined;
+  mockCreateTagHookCallbacks = undefined;
+};
+
+export const mockTrpc = {
+  songTag: {
+    create: {
+      useMutation: jest.fn(() => ({
+        mutate: mockCreateSongTagMutate,
+      })),
+    },
+    delete: {
+      useMutation: jest.fn(() => ({
+        mutate: mockDeleteSongTagMutate,
+      })),
+    },
+    getBySongId: {
+      useQuery: jest.fn(() => mockSongTagsQuery),
+    },
+  },
+  tag: {
+    create: {
+      useMutation: jest.fn((callbacks?: MutationCallbacks<Tag>) => {
+        mockCreateTagHookCallbacks = callbacks;
+
+        return {
+          mutate: mockCreateTagMutate,
+        };
+      }),
+    },
+    getByOrganization: {
+      useQuery: jest.fn(() => mockOrganizationTagsQuery),
+    },
+  },
+  useUtils: jest.fn(() => ({
+    song: {
+      get: {
+        invalidate: mockInvalidateSong,
+      },
+    },
+    songTag: {
+      getBySongId: {
+        invalidate: mockInvalidateSongTags,
+      },
+    },
+    tag: {
+      getByOrganization: {
+        invalidate: mockInvalidateOrganizationTags,
+      },
+    },
+  })),
+};
+
+export type TrpcMockModule = {
+  mockTrpc: typeof mockTrpc;
+};

--- a/src/testUtils/mocks/trpc.ts
+++ b/src/testUtils/mocks/trpc.ts
@@ -24,6 +24,10 @@ export type MutationCallbacks<Result = unknown> = {
   onSettled?: () => void;
 };
 
+type QueryOptions = {
+  enabled?: boolean;
+};
+
 type CreateTagInput = {
   organizationId: string;
   tag: string;
@@ -125,7 +129,13 @@ export const mockTrpc = {
       }),
     },
     getByOrganization: {
-      useQuery: jest.fn(() => mockOrganizationTagsQuery),
+      useQuery: jest.fn((_input: unknown, options?: QueryOptions) => {
+        if (options?.enabled === false) {
+          return createQueryResult<Tag[] | undefined>(undefined);
+        }
+
+        return mockOrganizationTagsQuery;
+      }),
     },
   },
   useUtils: jest.fn(() => ({


### PR DESCRIPTION
## Background

- Linear ticket: [SWY-169](https://linear.app/paranoid-android/issue/SWY-169/component-tests-song-tag-selector-and-tag-list)
- This adds coverage for the song tag selector and tag list before the selector is refactored into smaller pieces. It also tightens the tag UI semantics so the tests can assert the accessible behavior users rely on.

## What's changed

@coderabbitai summary

- Added semantic button behavior, pressed state, accessible names, and loading/status labels for song tag selection and removal controls.
- Added `dismissLabel` support to `Badge` so dismissible badges can expose contextual remove actions.
- Added component tests for filtering, attaching, removing, creating tags, keyboard selection, loading states, error states, query enablement, and tag list removal behavior.
- Added a narrow shared tRPC test mock for these song tag component workflows.

## How to test

- Open a song details page with existing song tags.
- Use Add Tag to search for an existing tag, select it, create a new tag from search text, and remove an existing selected tag.
- Confirm the loading skeletons appear while tag data loads and that remove buttons are announced with the tag name by assistive technology.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the accessibility semantics of the song tag UI — converting clickable `HStack` rows to real `button` elements with `aria-pressed` and contextual `aria-label`, adding `role="status"` to loading skeletons, and fixing the unlabelled dismiss button in `Badge` — then adds component tests that verify those semantics alongside the core tag workflows. The new shared tRPC mock correctly gates `getByOrganization` data behind the `enabled` option, so the error-state test exercises the actual component code path rather than an unreachable state.

- **`badge.tsx`**: Adds `dismissLabel` prop; dismiss button now falls back to `"Remove"` when the prop is omitted, closing the previously-flagged unlabelled-button gap for all current and future call sites.
- **`SongTagSelector.tsx` / `SongTags.tsx`**: Tag-row items rendered as `button` with `aria-pressed` and descriptive labels; loading containers use `role="status"`; tag-list containers use `role="group"` — both components are now testable through accessible queries.
- **Test files + `trpc.ts` mock**: Seven new `SongTagSelector` tests and four `SongTags` tests covering filtering, attach, remove, create, keyboard navigation, loading, error, and query-enablement; the shared mock is narrow and correctly respects the `enabled` query option.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive accessibility improvements and new test coverage with no mutations to existing business logic.

The production changes are limited to ARIA attributes, role annotations, and the `dismissLabel` prop addition; no data-fetching, mutation, or routing logic is altered. The new tRPC mock correctly gates data behind the `enabled` option, eliminating the unreachable-state problem noted in the previous review thread. Test coverage is thorough for the desktop rendering path.

No files require special attention. The mobile Dialog rendering path in `SongTagSelector.tsx` received the same semantic button changes as the desktop path but has no dedicated test coverage — consistent with the PR's stated intent to defer mobile-path tests until the pending refactor.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/ui/badge.tsx | Adds optional `dismissLabel` prop; dismiss button falls back to "Remove" when omitted, resolving the previously-flagged unlabelled-button issue. |
| src/modules/songs/components/SongTagSelector/SongTagSelector.tsx | Converts tag-list items to real `button` elements with `aria-pressed` and contextual `aria-label`; adds `role="status"` / `role="group"` ARIA landmarks to loading and tag-list containers in both desktop and mobile rendering paths. |
| src/modules/songs/components/SongTagSelector/__tests__/SongTagSelector.test.tsx | New test file covering filtering, attach, remove, create, keyboard navigation, loading state, error state, and query-enablement—all on the desktop path. |
| src/modules/songs/components/SongTags/SongTags.tsx | Wraps loading skeletons in a `role="status"` HStack; passes contextual `dismissLabel` to each `Badge` so screen readers announce "Remove [tag name] tag". |
| src/modules/songs/components/SongTags/__tests__/SongTags.test.tsx | New test file covering tag-list render, remove-and-invalidate, loading state, and error state. |
| src/testUtils/mocks/trpc.ts | Introduces a shared, narrowly-scoped tRPC mock; correctly gates `getByOrganization` data behind `enabled` so the error-state test is reachable without the previously-flagged unreachable-state problem. |

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/kyu..."](https://github.com/justaddcl/sanbi/commit/5040e339aed789c231aa28782e7f4c858a8b1dab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40212628)</sub>

<!-- /greptile_comment -->