### PR TITLE
[SWY-193] Use unified song search in replace song picker

### DIFF
--- a/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
+++ b/src/modules/sets/components/CreateSetForm/CreateSetForm.tsx
@@ -61,38 +61,37 @@ export const CreateSetForm: React.FC<CreateSetFormProps> = ({
         return;
       }
 
-      await createSetMutation.mutateAsync(
-        {
+      try {
+        const data = await createSetMutation.mutateAsync({
           date,
           eventTypeId,
           notes: notes ? sanitizeInput(notes) : null,
           organizationId: organizationMembership.organizationId,
           isArchived: false,
-        },
-        {
-          onSuccess(data) {
-            logger.info("🤖 [createSetMutation/onSuccess] ~ data:", data);
-            const [newSet] = data;
+        });
 
-            toast.success("Set was created", { id: toastId });
+        logger.info("🤖 [createSetMutation/onSuccess] ~ data:", data);
+        const [newSet] = data;
 
-            if (newSet) {
-              onCreationSuccess?.(newSet);
-            } else {
-              toast.warning(
-                "Set was created, but the set data wasn't returned...",
-                { id: toastId },
-              );
-            }
-          },
-          onError(error) {
-            logger.info("🤖 [createSetMutation/onError] ~ error:", error);
-            toast.error(`Could not create set: ${error.message}`, {
-              id: toastId,
-            });
-          },
-        },
-      );
+        toast.success("Set was created", { id: toastId });
+
+        if (newSet) {
+          onCreationSuccess?.(newSet);
+        } else {
+          toast.warning("Set was created, but the set data wasn't returned...", {
+            id: toastId,
+          });
+        }
+      } catch (error) {
+        logger.info("🤖 [createSetMutation/onError] ~ error:", error);
+
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+
+        toast.error(`Could not create set: ${errorMessage}`, {
+          id: toastId,
+        });
+      }
     }
   };
 

--- a/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
+++ b/src/modules/sets/components/CreateSongForm/CreateSongForm.tsx
@@ -92,33 +92,34 @@ export const CreateSongForm: React.FC<CreateSongFormProps> = ({ onSubmit }) => {
         return;
       }
 
-      await createSongMutation.mutateAsync(
-        {
+      try {
+        const data = await createSongMutation.mutateAsync({
           name,
           preferredKey,
           notes: sanitizeInput(notes ?? "") || null,
           organizationId: organizationMembership.organizationId,
           createdBy: userData.id,
           isArchived: false,
-        },
-        {
-          onSuccess(data) {
-            logger.info("🤖 [createSongMutation/onSuccess] ~ data:", data);
-            const [newSong] = data;
+        });
 
-            toast.success("Song was created", { id: toastId });
-            router.push(
-              `/${organizationMembership.organizationId}/songs/${newSong?.id}`,
-            );
-          },
-          onError(error) {
-            logger.info("🤖 [createSongMutation/onError] ~ error:", error);
-            toast.error(`Could not create song: ${error.message}`, {
-              id: toastId,
-            });
-          },
-        },
-      );
+        logger.info("🤖 [createSongMutation/onSuccess] ~ data:", data);
+        const [newSong] = data;
+
+        toast.success("Song was created", { id: toastId });
+        router.push(
+          `/${organizationMembership.organizationId}/songs/${newSong?.id}`,
+        );
+      } catch (error) {
+        logger.info("🤖 [createSongMutation/onError] ~ error:", error);
+
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+
+        toast.error(`Could not create song: ${errorMessage}`, {
+          id: toastId,
+        });
+        return;
+      }
     }
 
     // close the dialog

--- a/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
+++ b/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
@@ -68,33 +68,30 @@ export const SetSectionTypeCombobox: React.FC<SetSectionTypeComboboxProps> = ({
 
     if (!trimmedInput) return;
 
-    await createSetSectionTypeMutation.mutateAsync(
-      { name: trimmedInput, organizationId },
-      {
-        async onSuccess(createSetSectionTypeMutationResult) {
-          const [newSetSectionType] = createSetSectionTypeMutationResult;
+    const [newSetSectionType] =
+      await createSetSectionTypeMutation.mutateAsync({
+        name: trimmedInput,
+        organizationId,
+      });
 
-          if (newSetSectionType) {
-            toast.success(`${newSetSectionType.name} set section type created`);
+    if (newSetSectionType) {
+      toast.success(`${newSetSectionType.name} set section type created`);
 
-            // If a callback was provided, call it with the new section type
-            if (onCreateSuccess) {
-              onCreateSuccess(newSetSectionType);
-            }
+      // If a callback was provided, call it with the new section type
+      if (onCreateSuccess) {
+        onCreateSuccess(newSetSectionType);
+      }
 
-            // Update the selected value
-            onChange({
-              id: newSetSectionType.id,
-              label: newSetSectionType.name,
-            });
+      // Update the selected value
+      onChange({
+        id: newSetSectionType.id,
+        label: newSetSectionType.name,
+      });
 
-            await apiUtils.setSectionType.getTypes.invalidate({
-              organizationId,
-            });
-          }
-        },
-      },
-    );
+      await apiUtils.setSectionType.getTypes.invalidate({
+        organizationId,
+      });
+    }
 
     setIsOpen(false);
     setNewSetSectionInputValue("");

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -187,41 +187,34 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
     if (!setAlreadyHasSelectedSection) {
       const positionForNewSetSection = sectionsForSetData.length;
 
-      await createSetSectionMutation.mutateAsync(
-        {
+      const [newSetSection] = await createSetSectionMutation.mutateAsync({
+        setId,
+        organizationId: userMembership.organizationId,
+        sectionTypeId: newSetSectionType.id,
+        position: positionForNewSetSection,
+      });
+
+      if (newSetSection) {
+        setValue("setSectionId", newSetSection.id, {
+          shouldValidate: true,
+          shouldDirty: true,
+          shouldTouch: true,
+        });
+
+        setNewSetSectionType(null);
+
+        toast.success(`Section added to set`);
+
+        await apiUtils.setSection.getSectionsForSet.refetch({
+          organizationId: userMembership.organizationId,
+          setId,
+        });
+
+        await apiUtils.set.get.invalidate({
           setId,
           organizationId: userMembership.organizationId,
-          sectionTypeId: newSetSectionType.id,
-          position: positionForNewSetSection,
-        },
-        {
-          async onSuccess(createSetSectionMutationResult) {
-            const [newSetSection] = createSetSectionMutationResult;
-
-            if (newSetSection) {
-              setValue("setSectionId", newSetSection.id, {
-                shouldValidate: true,
-                shouldDirty: true,
-                shouldTouch: true,
-              });
-
-              setNewSetSectionType(null);
-
-              toast.success(`Section added to set`);
-
-              await apiUtils.setSection.getSectionsForSet.refetch({
-                organizationId: userMembership.organizationId,
-                setId,
-              });
-
-              await apiUtils.set.get.invalidate({
-                setId,
-                organizationId: userMembership.organizationId,
-              });
-            }
-          },
-        },
-      );
+        });
+      }
     } else {
       setError("setSectionId", {
         type: "custom",
@@ -240,37 +233,29 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
     );
     const setSectionSongPosition = setSectionToAddTo!.songs.length; // using non-null assertion since in the happiest path where we don't add any new set sections to the set, this set section already exists
 
-    await addSetSectionSongMutation.mutateAsync(
-      {
-        organizationId: userMembership.organizationId,
-        songId,
-        setSectionId,
-        key: key!,
-        position: setSectionSongPosition,
-        notes: notes ?? null,
-      },
-      {
-        async onSuccess(data) {
-          logger.info(
-            "🤖 [createSetSectionSongMutation/onSuccess] ~ data:",
-            data,
-          );
+    const data = await addSetSectionSongMutation.mutateAsync({
+      organizationId: userMembership.organizationId,
+      songId,
+      setSectionId,
+      key: key!,
+      position: setSectionSongPosition,
+      notes: notes ?? null,
+    });
 
-          await apiUtils.set.get.invalidate({
-            setId,
-          });
+    logger.info("🤖 [createSetSectionSongMutation/onSuccess] ~ data:", data);
 
-          toast.success("Song added to the set!");
+    await apiUtils.set.get.invalidate({
+      setId,
+    });
 
-          setDialogStep("search");
+    toast.success("Song added to the set!");
 
-          if (!addAnotherSong) {
-            // close the dialog
-            onSubmit?.();
-          }
-        },
-      },
-    );
+    setDialogStep("search");
+
+    if (!addAnotherSong) {
+      // close the dialog
+      onSubmit?.();
+    }
   };
 
   const goBackToSearch = () => setDialogStep("search");

--- a/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
@@ -10,7 +10,7 @@ import {
   CommandGroup,
   CommandList,
 } from "@components/ui/command";
-import { DialogDescription, DialogTitle } from "@components/ui/dialog";
+import { DialogDescription } from "@components/ui/dialog";
 import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
@@ -63,8 +63,9 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
 
   const [dialogStep, setDialogStep] =
     useState<ReplaceSongDialogSteps>("search");
-  const [selectedSong, setSelectedSong] =
-    useState<SongSearchResult | null>(null);
+  const [selectedSong, setSelectedSong] = useState<SongSearchResult | null>(
+    null,
+  );
 
   const replaceSongMutation =
     trpc.setSectionSong.replaceSong.useMutation<Error>();
@@ -116,14 +117,14 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
           replacementSongId: selectedSong?.songId,
         },
         {
-          async onSuccess() {
+          onSuccess() {
             toast.dismiss();
             toast.success("Song replaced");
             handleCloseDialog();
-            await apiUtils.set.get.invalidate({ setId });
+            void apiUtils.set.get.invalidate({ setId });
           },
 
-          async onError() {
+          onError() {
             toast.dismiss();
             toast.error("Song could not be replaced");
           },
@@ -178,7 +179,13 @@ export const ReplaceSongDialog: React.FC<ReplaceSongDialogProps> = ({
               >
                 <CaretLeft aria-hidden />
               </Button>
-              <DialogTitle className="text-center">Replace song</DialogTitle>
+              <Text
+                asElement="h2"
+                align="center"
+                className="text-center text-lg font-semibold tracking-tight"
+              >
+                Replace song
+              </Text>
             </div>
             <DialogDescription className="mt-2" asChild>
               <VStack className="gap-8 px-4">

--- a/src/modules/songs/components/ReplaceSongDialog/__tests__/ReplaceSongDialog.test.tsx
+++ b/src/modules/songs/components/ReplaceSongDialog/__tests__/ReplaceSongDialog.test.tsx
@@ -1,0 +1,252 @@
+import { type ComponentProps, type useEffect, type useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createSetSectionSongWithSongDataFixture } from "@testUtils/fixtures/setSectionSongs";
+import { createSongFixture } from "@testUtils/fixtures/songs";
+import {
+  mockInvalidateSet,
+  mockReplaceSongMutate,
+  resetMockTrpc,
+  setMockSongSearchQuery,
+  type TrpcMockModule,
+} from "@testUtils/mocks/trpc";
+import { createSearchSongResultFixture } from "@testUtils/models/search/fixtures";
+import { toast } from "sonner";
+
+import { ReplaceSongDialog } from "../ReplaceSongDialog";
+
+const mockSetOpen = jest.fn();
+
+jest.mock("@modules/users/api/queries", () => ({
+  useUserQuery: jest.fn(() => ({
+    data: {
+      memberships: [{ organizationId: "organization-1" }],
+    },
+    isAuthLoaded: true,
+    isLoading: false,
+  })),
+}));
+
+jest.mock("@lib/trpc", () => {
+  const { mockTrpc } = jest.requireActual<TrpcMockModule>(
+    "@testUtils/mocks/trpc",
+  );
+
+  return { trpc: mockTrpc };
+});
+
+jest.mock("sonner", () => ({
+  toast: {
+    dismiss: jest.fn(),
+    error: jest.fn(),
+    loading: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock("usehooks-ts", () => {
+  const React = jest.requireActual<{
+    useEffect: typeof useEffect;
+    useState: typeof useState;
+  }>("react");
+
+  return {
+    useDebounceValue: <Value,>(value: Value) => {
+      const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+      React.useEffect(() => {
+        setDebouncedValue(value);
+      }, [value]);
+
+      return [debouncedValue, setDebouncedValue] as const;
+    },
+  };
+});
+
+class ResizeObserverMock {
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+}
+
+const currentSong = createSetSectionSongWithSongDataFixture({
+  id: "set-section-song-1",
+  setSectionId: "set-section-1",
+  songId: "current-song",
+  organizationId: "organization-1",
+  song: createSongFixture({
+    id: "current-song",
+    name: "Current Hymn",
+    organizationId: "organization-1",
+  }),
+});
+
+const titleMatchedSong = createSearchSongResultFixture({
+  songId: "title-song",
+  name: "Communion Hymn",
+  matchedTags: [],
+  tags: ["Classic"],
+});
+
+const tagMatchedSong = createSearchSongResultFixture({
+  songId: "tag-song",
+  name: "Amazing Grace",
+  matchedTags: ["Communion"],
+  tags: ["Communion"],
+});
+
+const selfMatchedSong = createSearchSongResultFixture({
+  songId: currentSong.songId,
+  name: currentSong.song.name,
+  matchedTags: [],
+  tags: ["Classic"],
+});
+
+const mockToast = jest.mocked(toast);
+
+const renderReplaceSongDialog = (
+  props: Partial<ComponentProps<typeof ReplaceSongDialog>> = {},
+) => {
+  render(
+    <ReplaceSongDialog
+      open
+      setOpen={mockSetOpen}
+      currentSong={currentSong}
+      setId="set-1"
+      {...props}
+    />,
+  );
+};
+
+const enterSearchInput = (searchInput: string) => {
+  fireEvent.change(screen.getByPlaceholderText("Search songs or tags"), {
+    target: { value: searchInput },
+  });
+};
+
+const getResultItem = async (matchType: "song" | "tag") => {
+  await waitFor(() => {
+    expect(
+      document.querySelector(`[data-search-match-type='${matchType}']`),
+    ).toBeInTheDocument();
+  });
+
+  const resultItem = document.querySelector(
+    `[data-search-match-type='${matchType}']`,
+  );
+
+  if (!(resultItem instanceof HTMLElement)) {
+    throw new Error(`Could not find ${matchType}-matched result item`);
+  }
+
+  return resultItem;
+};
+
+describe("ReplaceSongDialog", () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+      writable: true,
+    });
+
+    Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: jest.fn(),
+      writable: true,
+    });
+
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => window.setTimeout(callback, 0),
+      writable: true,
+    });
+
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: (handle: number) => window.clearTimeout(handle),
+      writable: true,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockTrpc();
+    setMockSongSearchQuery({
+      data: [titleMatchedSong, tagMatchedSong],
+      isFetching: false,
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("advances to confirmation when selecting a title result", async () => {
+    const onSongSelect = jest.fn();
+    renderReplaceSongDialog({ onSongSelect });
+
+    enterSearchInput("comm");
+    fireEvent.click(await getResultItem("song"));
+
+    expect(await screen.findByText("Current song")).toBeInTheDocument();
+    expect(screen.getByText("New song")).toBeInTheDocument();
+    expect(screen.getByText(currentSong.song.name)).toBeInTheDocument();
+    expect(screen.getByText(titleMatchedSong.name)).toBeInTheDocument();
+    expect(onSongSelect).toHaveBeenLastCalledWith(titleMatchedSong);
+  });
+
+  it("advances to confirmation when selecting a tag-matched result", async () => {
+    renderReplaceSongDialog();
+
+    enterSearchInput("comm");
+    fireEvent.click(await getResultItem("tag"));
+
+    expect(await screen.findByText("New song")).toBeInTheDocument();
+    expect(screen.getByText(tagMatchedSong.name)).toBeInTheDocument();
+  });
+
+  it("shows an error and does not mutate when replacing a song with itself", async () => {
+    setMockSongSearchQuery({
+      data: [selfMatchedSong],
+      isFetching: false,
+      isError: false,
+    });
+
+    renderReplaceSongDialog();
+
+    enterSearchInput("curr");
+    fireEvent.click(await getResultItem("song"));
+    fireEvent.click(screen.getByRole("button", { name: "Replace song" }));
+
+    expect(mockToast.error).toHaveBeenLastCalledWith(
+      "Cannot replace a song with itself",
+    );
+    expect(mockReplaceSongMutate).not.toHaveBeenCalled();
+  });
+
+  it("replaces the song, invalidates the set, and closes the dialog", async () => {
+    renderReplaceSongDialog();
+
+    enterSearchInput("comm");
+    fireEvent.click(await getResultItem("song"));
+    fireEvent.click(screen.getByRole("button", { name: "Replace song" }));
+
+    expect(mockToast.loading).toHaveBeenLastCalledWith("Replacing song...");
+    const [mutationInput, mutationOptions] =
+      mockReplaceSongMutate.mock.lastCall ?? [];
+    expect(mutationInput).toEqual({
+      organizationId: "organization-1",
+      setSectionSongId: currentSong.id,
+      replacementSongId: titleMatchedSong.songId,
+    });
+    expect(typeof mutationOptions?.onError).toBe("function");
+    expect(typeof mutationOptions?.onSuccess).toBe("function");
+    await waitFor(() => {
+      expect(mockInvalidateSet).toHaveBeenLastCalledWith({ setId: "set-1" });
+    });
+    expect(mockToast.dismiss).toHaveBeenCalled();
+    expect(mockToast.success).toHaveBeenLastCalledWith("Song replaced");
+    expect(mockSetOpen).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/testUtils/mocks/trpc.ts
+++ b/src/testUtils/mocks/trpc.ts
@@ -1,6 +1,7 @@
 import { createTagFixture } from "@testUtils/fixtures/tags";
 import { createUuid } from "@testUtils/generators/createUuid";
 
+import { type SearchSongResult } from "@modules/search/components/types";
 import { type Tag } from "@lib/types";
 
 export type SongTagResult = {
@@ -16,6 +17,12 @@ export type QueryResult<Data> = {
   data: Data | undefined;
   isLoading: boolean;
   error: Error | null;
+};
+
+export type SongSearchQueryResult = {
+  data: SearchSongResult[];
+  isFetching: boolean;
+  isError: boolean;
 };
 
 export type MutationCallbacks<Result = unknown> = {
@@ -39,8 +46,17 @@ const createQueryResult = <Data>(data: Data): QueryResult<Data> => ({
   isLoading: false,
 });
 
+const createSongSearchQueryResult = (
+  data: SearchSongResult[] = [],
+): SongSearchQueryResult => ({
+  data,
+  isError: false,
+  isFetching: false,
+});
+
 let mockOrganizationTagsQuery = createQueryResult<Tag[]>([]);
 let mockSongTagsQuery = createQueryResult<SongTagResult[]>([]);
+let mockSongSearchQuery = createSongSearchQueryResult();
 let mockCreatedTag: Tag | undefined;
 let mockCreateTagHookCallbacks: MutationCallbacks<Tag> | undefined;
 
@@ -75,9 +91,16 @@ export const mockCreateTagMutate = jest.fn(
   },
 );
 
+export const mockReplaceSongMutate = jest.fn(
+  (_input: unknown, callbacks?: MutationCallbacks) => {
+    void callbacks?.onSuccess?.({});
+  },
+);
+
 export const mockInvalidateSongTags = jest.fn();
 export const mockInvalidateSong = jest.fn();
 export const mockInvalidateOrganizationTags = jest.fn();
+export const mockInvalidateSet = jest.fn();
 
 export const setMockOrganizationTagsQuery = (
   queryResult: QueryResult<Tag[]>,
@@ -91,6 +114,12 @@ export const setMockSongTagsQuery = (
   mockSongTagsQuery = queryResult;
 };
 
+export const setMockSongSearchQuery = (
+  queryResult: SongSearchQueryResult,
+) => {
+  mockSongSearchQuery = queryResult;
+};
+
 export const setMockCreatedTag = (tag: Tag) => {
   mockCreatedTag = tag;
 };
@@ -98,11 +127,17 @@ export const setMockCreatedTag = (tag: Tag) => {
 export const resetMockTrpc = () => {
   mockOrganizationTagsQuery = createQueryResult([]);
   mockSongTagsQuery = createQueryResult([]);
+  mockSongSearchQuery = createSongSearchQueryResult();
   mockCreatedTag = undefined;
   mockCreateTagHookCallbacks = undefined;
 };
 
 export const mockTrpc = {
+  song: {
+    search: {
+      useQuery: jest.fn(() => mockSongSearchQuery),
+    },
+  },
   songTag: {
     create: {
       useMutation: jest.fn(() => ({
@@ -116,6 +151,13 @@ export const mockTrpc = {
     },
     getBySongId: {
       useQuery: jest.fn(() => mockSongTagsQuery),
+    },
+  },
+  setSectionSong: {
+    replaceSong: {
+      useMutation: jest.fn(() => ({
+        mutate: mockReplaceSongMutate,
+      })),
     },
   },
   tag: {
@@ -139,6 +181,11 @@ export const mockTrpc = {
     },
   },
   useUtils: jest.fn(() => ({
+    set: {
+      get: {
+        invalidate: mockInvalidateSet,
+      },
+    },
     song: {
       get: {
         invalidate: mockInvalidateSong,

--- a/tests/e2e/sets/set-detail.authenticated.spec.ts
+++ b/tests/e2e/sets/set-detail.authenticated.spec.ts
@@ -1,8 +1,11 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Page, test, type TestInfo } from "@playwright/test";
 import { e2eData, e2eIds } from "@testUtils/e2e/fixtures";
+import { eq } from "drizzle-orm";
 
 import { formatDate } from "@lib/date";
 import { formatSongKey } from "@lib/string/formatSongKey";
+import { db } from "@server/db";
+import { setSectionSongs } from "@server/db/schema";
 
 import { expectNoA11yViolations } from "../a11y";
 
@@ -33,6 +36,43 @@ const expectAddedSongInFullBandSection = async (
   await expect(fullBandSection).toContainText(song.name);
   await expect(fullBandSection).toContainText(formatSongKey(addSongToSet.key));
   await expect(fullBandSection).toContainText(addSongToSet.notes);
+};
+
+const getReplaceSongFixture = (projectName: TestInfo["project"]["name"]) =>
+  projectName.includes("mobile")
+    ? {
+        id: "abababab-abab-4bab-8bab-abababababab",
+        notes: "Mobile replacement fixture notes.",
+        position: 99,
+      }
+    : {
+        id: "acacacac-acac-4cac-8cac-acacacacacac",
+        notes: "Desktop replacement fixture notes.",
+        position: 98,
+      };
+
+type ReplaceSongFixture = ReturnType<typeof getReplaceSongFixture>;
+
+const deleteReplaceSongFixture = async (fixture: ReplaceSongFixture) => {
+  await db.delete(setSectionSongs).where(eq(setSectionSongs.id, fixture.id));
+};
+
+const resetReplaceSongFixture = async (fixture: ReplaceSongFixture) => {
+  await db.transaction(async (transaction) => {
+    await transaction
+      .delete(setSectionSongs)
+      .where(eq(setSectionSongs.id, fixture.id));
+
+    await transaction.insert(setSectionSongs).values({
+      id: fixture.id,
+      setSectionId: e2eIds.fullBandSectionId,
+      songId: e2eIds.firstSongId,
+      position: fixture.position,
+      key: "g",
+      notes: fixture.notes,
+      organizationId: e2eIds.organizationId,
+    });
+  });
 };
 
 const openGlobalSearch = async (page: Page, isMobileProject: boolean) => {
@@ -179,4 +219,69 @@ test("opens add-to-set from the search action menu without navigating", async ({
     page.getByRole("heading", { name: "Add to which set?" }),
   ).toBeVisible();
   await expect(page).toHaveURL(new RegExp(`${setDetailPath}$`));
+});
+
+test("replaces a set song through the unified picker", async ({
+  page,
+}, testInfo) => {
+  const replaceSongFixture = getReplaceSongFixture(testInfo.project.name);
+  await resetReplaceSongFixture(replaceSongFixture);
+
+  try {
+    await page.goto(`/${e2eIds.organizationId}/sets/${e2eIds.setId}`);
+
+    const fullBandSection = getSetSectionCard(
+      page,
+      e2eData.sectionTypes.fullBand,
+    );
+    const replacementFixtureSongRow = fullBandSection.locator("form").filter({
+      hasText: replaceSongFixture.notes,
+    });
+
+    await expect(replacementFixtureSongRow).toBeVisible();
+    await expect(replacementFixtureSongRow).toContainText(
+      e2eData.songs.first.name,
+    );
+    await replacementFixtureSongRow
+      .getByRole("button", { name: "Open actions menu" })
+      .click();
+    await page.getByRole("menuitem", { name: /Replace song/ }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog
+      .getByPlaceholder("Search songs or tags")
+      .fill(e2eData.songs.second.name);
+    await expect(
+      dialog.getByText(e2eData.songs.second.name, { exact: true }),
+    ).toBeVisible();
+    await dialog.getByText(e2eData.songs.second.name, { exact: true }).click();
+
+    await expect(
+      dialog.getByText("Current song", { exact: true }),
+    ).toBeVisible();
+    await expect(dialog.getByText("New song", { exact: true })).toBeVisible();
+    await expect(dialog.getByText(e2eData.songs.first.name)).toBeVisible();
+    await expect(dialog.getByText(e2eData.songs.second.name)).toBeVisible();
+    await dialog.getByRole("button", { name: "Replace song" }).click();
+
+    await expect(page.getByText("Song replaced")).toBeVisible();
+    await expect(dialog).toBeHidden();
+    await expect(replacementFixtureSongRow).toContainText(
+      e2eData.songs.second.name,
+    );
+    await expect(replacementFixtureSongRow).not.toContainText(
+      e2eData.songs.first.name,
+    );
+
+    await page.reload();
+    await expect(replacementFixtureSongRow).toContainText(
+      e2eData.songs.second.name,
+    );
+    await expect(replacementFixtureSongRow).not.toContainText(
+      e2eData.songs.first.name,
+    );
+  } finally {
+    await deleteReplaceSongFixture(replaceSongFixture);
+  }
 });


### PR DESCRIPTION
## Background

- Linear ticket: [SWY-193](https://linear.app/paranoid-android/issue/SWY-193/use-unified-song-search-ux-in-replace-song-picker)
- This updates the replace-song picker so it uses the same searchable song/tag result experience as the add-song flow while preserving the existing `SongSearch` component naming.
- It also cleans up awaited mutation success flows so post-mutation UI updates and cache refreshes are handled in straight-line async handlers.

## What's changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a song replacement flow in the set detail experience, including a unified picker and confirmation step.
  * Improved creation and configuration flows for sets, songs, and section types with clearer success feedback.

* **Bug Fixes**
  * Updated several save actions to provide more reliable error handling and user messages.
  * Refreshed related views immediately after changes so new items and replacements appear correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Updated `ReplaceSongDialog` to render the shared `SongSearch` result experience and added component tests for title matches, tag matches, self-replacement validation, mutation payloads, dialog close behavior, and set invalidation.
- Extended the shared tRPC test mock from SWY-169 with song search and replace-song mutation helpers used by the new dialog tests.
- Added Playwright coverage for replacing a set song through the unified picker using project-specific temporary fixture rows so authenticated desktop/mobile runs do not race over shared seeded data.
- Simplified `mutateAsync` success handling in create set/song/section flows by awaiting mutation results directly instead of nesting `onSuccess` callbacks.

## How to test

- Open a set detail page and choose Replace song from a set song's actions menu.
- Search by song title or tag, select a result, confirm the current/new song review screen, and click Replace song.
- Confirm the dialog closes, the set section shows the replacement song after the toast, and the replacement remains after reloading the set page.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `ReplaceSongDialog` into the shared `SongSearch` UX (title + tag matching) and simplifies four other mutation handlers by replacing nested `onSuccess`/`onError` callbacks with straight-line `try/catch` or inline `await` blocks.

- `ReplaceSongDialog` now renders `SongSearchContent`, gains a self-replacement guard, and is covered by new unit tests (title match, tag match, mutation payload, set invalidation, dialog close) plus a project-isolated Playwright E2E test.
- `CreateSetForm`, `CreateSongForm`, `ConfigureSongForSet`, and `SetSectionTypeCombobox` drop the callback pattern in favour of `try/catch` or inline destructuring; `CreateSongForm` incidentally fixes a pre-existing bug where `onSubmit()` was called even on error.
- The shared tRPC test mock (`trpc.ts`) is extended with `song.search.useQuery`, `setSectionSong.replaceSong.useMutation`, and `set.get.invalidate` stubs.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changed paths behave correctly and the new dialog is well tested.

The refactoring is clean and the new dialog works as intended. Two spots deserve a follow-up: `SetSectionTypeCombobox.handleCreateNewSetSectionType` still has no error handling around `mutateAsync`, so a failed section-type creation leaves the combobox open with stale input; and `resetMockTrpc` does not clear jest.fn call histories for the new mock exports, which could cause subtle bleed-through in future tests that omit `jest.clearAllMocks()`.

`SetSectionTypeCombobox.tsx` (no try/catch) and `src/testUtils/mocks/trpc.ts` (resetMockTrpc completeness).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx | Migrated to shared SongSearch UX; swapped DialogTitle for Text/h2 (accessible title preserved via CommandDialog prop); kept mutate+callbacks pattern; void-invalidation noted. |
| src/modules/songs/components/ReplaceSongDialog/__tests__/ReplaceSongDialog.test.tsx | New unit test file covering title/tag matches, self-replacement guard, mutation payload, invalidation, and dialog close; relies on jest.clearAllMocks() to compensate for resetMockTrpc not clearing jest.fn histories. |
| src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx | Refactored from onSuccess callback to inline await; missing try/catch means UI cleanup (close combobox, clear input) is skipped on mutation error. |
| src/testUtils/mocks/trpc.ts | Extended with song.search.useQuery, setSectionSong.replaceSong.useMutation, and set.get.invalidate mocks; resetMockTrpc does not reset jest.fn call histories for the new exports. |
| tests/e2e/sets/set-detail.authenticated.spec.ts | New E2E test for replace-song flow using per-project fixture rows (mobile/desktop) to avoid race conditions; reset in try/finally ensures cleanup even on test failure. |
| src/modules/sets/components/CreateSetForm/CreateSetForm.tsx | Clean refactor: onSuccess/onError callbacks replaced with try/catch; error message handling improved with instanceof guard; loading toast correctly replaced in both paths. |
| src/modules/sets/components/CreateSongForm/CreateSongForm.tsx | Clean refactor: onSuccess/onError callbacks replaced with try/catch; early return on error now prevents onSubmit() being called after a failed mutation (improvement over prior behavior). |
| src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx | Straightforward inline-await refactor for createSetSection and addSetSectionSong mutations; logic and sequencing are preserved. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant ReplaceSongDialog
    participant SongSearch
    participant tRPC as tRPC (replaceSong)
    participant Cache as tRPC Cache (set.get)

    User->>ReplaceSongDialog: Opens dialog (Replace song)
    ReplaceSongDialog->>SongSearch: Renders shared SongSearchContent
    User->>SongSearch: Types search query
    SongSearch->>tRPC: song.search.useQuery(...)
    tRPC-->>SongSearch: SearchSongResult[]
    User->>SongSearch: Selects a result
    SongSearch->>ReplaceSongDialog: onSongSelect(song)
    ReplaceSongDialog->>ReplaceSongDialog: setDialogStep("confirm")
    User->>ReplaceSongDialog: Clicks "Replace song"
    ReplaceSongDialog->>ReplaceSongDialog: "Guard: selectedSong.songId !== currentSong.songId"
    ReplaceSongDialog->>tRPC: setSectionSong.replaceSong.mutate(...)
    tRPC-->>ReplaceSongDialog: onSuccess()
    ReplaceSongDialog->>User: toast.success("Song replaced")
    ReplaceSongDialog->>ReplaceSongDialog: handleCloseDialog()
    ReplaceSongDialog->>Cache: "void set.get.invalidate({ setId })"
    Cache-->>User: Set view refreshes with new song
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant ReplaceSongDialog
    participant SongSearch
    participant tRPC as tRPC (replaceSong)
    participant Cache as tRPC Cache (set.get)

    User->>ReplaceSongDialog: Opens dialog (Replace song)
    ReplaceSongDialog->>SongSearch: Renders shared SongSearchContent
    User->>SongSearch: Types search query
    SongSearch->>tRPC: song.search.useQuery(...)
    tRPC-->>SongSearch: SearchSongResult[]
    User->>SongSearch: Selects a result
    SongSearch->>ReplaceSongDialog: onSongSelect(song)
    ReplaceSongDialog->>ReplaceSongDialog: setDialogStep("confirm")
    User->>ReplaceSongDialog: Clicks "Replace song"
    ReplaceSongDialog->>ReplaceSongDialog: "Guard: selectedSong.songId !== currentSong.songId"
    ReplaceSongDialog->>tRPC: setSectionSong.replaceSong.mutate(...)
    tRPC-->>ReplaceSongDialog: onSuccess()
    ReplaceSongDialog->>User: toast.success("Song replaced")
    ReplaceSongDialog->>ReplaceSongDialog: handleCloseDialog()
    ReplaceSongDialog->>Cache: "void set.get.invalidate({ setId })"
    Cache-->>User: Set view refreshes with new song
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx`, line 66-98 ([link](https://github.com/justaddcl/sanbi/blob/9480d1372f600da9cf09db8a5e31be92327f6391/src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx#L66-L98)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing error handling around `mutateAsync`**

   `handleCreateNewSetSectionType` now calls `mutateAsync` without a `try/catch`. If the mutation rejects, execution halts before reaching `setIsOpen(false)` and `setNewSetSectionInputValue("")`, leaving the combobox open with the stale input value and no error feedback to the user. Consider wrapping the mutation call in a try/catch to ensure cleanup always runs and a toast error is shown on failure.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx
   Line: 66-98

   Comment:
   **Missing error handling around `mutateAsync`**

   `handleCreateNewSetSectionType` now calls `mutateAsync` without a `try/catch`. If the mutation rejects, execution halts before reaching `setIsOpen(false)` and `setNewSetSectionInputValue("")`, leaving the combobox open with the stale input value and no error feedback to the user. Consider wrapping the mutation call in a try/catch to ensure cleanup always runs and a toast error is shown on failure.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx`, line 113-132 ([link](https://github.com/justaddcl/sanbi/blob/9480d1372f600da9cf09db8a5e31be92327f6391/src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx#L113-L132)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`void` for cache invalidation — error path leaves set data stale without any signal**

   `void apiUtils.set.get.invalidate({ setId })` fires the invalidation without waiting for the result and discards any rejection. The dialog has already been closed and the success toast shown, so in the happy path this is fine. If the invalidation call itself throws (e.g. a transient network issue), the set data will never be refreshed after the replacement and there is no feedback to the user. Worth considering `apiUtils.set.get.invalidate({ setId }).catch(() => { /* log or retry */ })` as a minimal safeguard.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx
   Line: 113-132

   Comment:
   **`void` for cache invalidation — error path leaves set data stale without any signal**

   `void apiUtils.set.get.invalidate({ setId })` fires the invalidation without waiting for the result and discards any rejection. The dialog has already been closed and the success toast shown, so in the happy path this is fine. If the invalidation call itself throws (e.g. a transient network issue), the set data will never be refreshed after the replacement and there is no feedback to the user. Worth considering `apiUtils.set.get.invalidate({ setId }).catch(() => { /* log or retry */ })` as a minimal safeguard.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/modules/sets/components/SetSectionTypeCombobox/SetSectionTypeCombobox.tsx:66-98
**Missing error handling around `mutateAsync`**

`handleCreateNewSetSectionType` now calls `mutateAsync` without a `try/catch`. If the mutation rejects, execution halts before reaching `setIsOpen(false)` and `setNewSetSectionInputValue("")`, leaving the combobox open with the stale input value and no error feedback to the user. Consider wrapping the mutation call in a try/catch to ensure cleanup always runs and a toast error is shown on failure.

### Issue 2 of 3
src/testUtils/mocks/trpc.ts:127-133
**`resetMockTrpc` leaves jest mock call histories intact**

`resetMockTrpc` resets module-level state variables (query results, created tag, etc.) but does not call `.mockReset()` or `.mockClear()` on any of the `jest.fn()` exports (`mockReplaceSongMutate`, `mockInvalidateSet`, `mockInvalidateSongTags`, etc.). The existing test file covers this with an explicit `jest.clearAllMocks()` in `beforeEach`, but future consumers of `resetMockTrpc` who omit that call may see stale call counts bleed across tests. Resetting the fn mocks inside `resetMockTrpc` would make the helper fully self-contained.

### Issue 3 of 3
src/modules/songs/components/ReplaceSongDialog/ReplaceSongDialog.tsx:113-132
**`void` for cache invalidation — error path leaves set data stale without any signal**

`void apiUtils.set.get.invalidate({ setId })` fires the invalidation without waiting for the result and discards any rejection. The dialog has already been closed and the success toast shown, so in the happy path this is fine. If the invalidation call itself throws (e.g. a transient network issue), the set data will never be refreshed after the replacement and there is no feedback to the user. Worth considering `apiUtils.set.get.invalidate({ setId }).catch(() => { /* log or retry */ })` as a minimal safeguard.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add isolated replace song E2E coverage"](https://github.com/justaddcl/sanbi/commit/9480d1372f600da9cf09db8a5e31be92327f6391) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40219402)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->