### PR TITLE
[SWY-200] Extract shared set-section creation flow

### DIFF
--- a/src/app/[organization]/sets/[setId]/page.tsx
+++ b/src/app/[organization]/sets/[setId]/page.tsx
@@ -2,25 +2,12 @@
 import { use, useCallback, useEffect, useState } from "react";
 import { redirect } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
-import { CaretDown, CaretUp } from "@phosphor-icons/react";
-import { Archive, Plus } from "@phosphor-icons/react/dist/ssr";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
-import { toast } from "sonner";
+import { Plus } from "@phosphor-icons/react/dist/ssr";
 import { validate as uuidValidate } from "uuid";
 
-import { Alert, AlertDescription, AlertTitle } from "@components/ui/alert";
 import { Button } from "@components/ui/button";
-import { type ComboboxOption } from "@components/ui/combobox";
 import { HStack } from "@components/HStack";
 import { PageContentContainer } from "@components/PageContentContainer";
-import {
-  ResponsiveDialog,
-  ResponsiveDialogContent,
-  ResponsiveDialogDescription,
-  ResponsiveDialogHeader,
-  ResponsiveDialogTitle,
-} from "@components/ResponsiveDialog";
-import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
 import { useSetQuery } from "@modules/sets/api";
 import { SetActionsMenu } from "@modules/sets/components/SetActionsMenu";
@@ -30,15 +17,13 @@ import { SetPageErrorState } from "@modules/sets/components/SetErrorState";
 import { SetPageLoadingState } from "@modules/sets/components/SetLoadingState";
 import { SetNotes } from "@modules/sets/components/SetNotes";
 import { SetSectionCard } from "@modules/sets/components/SetSectionCard";
-import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { SetSectionCreationDialog } from "@modules/sets/components/SetSectionCreationDialog";
 import { getSetSongNumbering } from "@modules/sets/utils/getSetSongNumbering";
 import { ArchivedBanner } from "@modules/shared/components";
 import { type ConfigureSongForSetProps } from "@modules/songs/components/ConfigureSongForSet/ConfigureSongForSet";
 import { SongSearchDialog } from "@modules/songs/components/SongSearchDialog";
 import { logger } from "@lib/loggers/logger";
 import { trpc } from "@lib/trpc";
-import { cn } from "@lib/utils";
-import { useResponsive } from "@/hooks/useResponsive";
 
 type SearchParamsRecord = Record<string, string | string[] | undefined>;
 
@@ -74,8 +59,6 @@ export default function SetListPage({
   const params = use(paramsPromise);
   const searchParams = use(searchParamsPromise);
 
-  const { textSize } = useResponsive();
-
   const [isEditingSetDetails, setIsEditingSetDetails] =
     useState<boolean>(false);
   const [prePopulatedSetSectionId, setPrePopulatedSetSectionId] =
@@ -85,13 +68,8 @@ export default function SetListPage({
   );
   const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] =
     useState<boolean>(false);
-  const [newSetSectionType, setNewSetSectionType] =
-    useState<ComboboxOption | null>(null);
   const [isAddSectionDialogOpen, setIsAddSectionDialogOpen] =
     useState<boolean>(false);
-
-  const createSetSectionMutation = trpc.setSection.create.useMutation();
-  const apiUtils = trpc.useUtils();
 
   useEffect(() => {
     const addSongDialogOpen = getSearchParamValue(
@@ -183,52 +161,6 @@ export default function SetListPage({
     setIsSongSearchDialogOpen(true);
   };
 
-  const handleAddSetSection = () => {
-    const toastId = toast.loading("Adding section to set...");
-
-    if (!newSetSectionType) {
-      toast.error("Please select a section type", { id: toastId });
-      return;
-    }
-
-    const setAlreadyHasSelectedSection = setData.sections.some(
-      (setSection) => setSection.sectionTypeId === newSetSectionType.id,
-    );
-
-    if (setAlreadyHasSelectedSection) {
-      toast.error("Section type already exists on this set", { id: toastId });
-      return;
-    }
-
-    const positionForNewSetSection = setData.sections.length;
-
-    createSetSectionMutation.mutate(
-      {
-        setId: setData.id,
-        organizationId: userMembership.organizationId,
-        sectionTypeId: newSetSectionType.id,
-        position: positionForNewSetSection,
-      },
-      {
-        async onSuccess() {
-          toast.success(`Section added to set!`, { id: toastId });
-
-          setNewSetSectionType(null);
-
-          await apiUtils.setSection.getSectionsForSet.refetch({
-            organizationId: userMembership.organizationId,
-            setId: setData.id,
-          });
-
-          await apiUtils.set.get.invalidate({
-            setId: setData.id,
-            organizationId: userMembership.organizationId,
-          });
-        },
-      },
-    );
-  };
-
   return (
     <PageContentContainer className="gap-8 lg:mb-16">
       <VStack className="gap-4">
@@ -301,66 +233,13 @@ export default function SetListPage({
           </Button>
         </VStack>
       )}
-      {/* TODO: extract to separate AddSectionDialog? */}
-      <ResponsiveDialog
+      <SetSectionCreationDialog
         open={isAddSectionDialogOpen}
-        onOpenChange={(isOpen) => {
-          setIsAddSectionDialogOpen(isOpen);
-          if (!isOpen) {
-            setNewSetSectionType(null);
-          }
-        }}
-        drawerProps={{ repositionInputs: true }}
-      >
-        <ResponsiveDialogContent className="p-6 lg:p-8">
-          <ResponsiveDialogHeader>
-            <ResponsiveDialogDescription asChild>
-              <VisuallyHidden.Root>
-                Dialog to add section to set
-              </VisuallyHidden.Root>
-            </ResponsiveDialogDescription>
-          </ResponsiveDialogHeader>
-          <ResponsiveDialogTitle
-            dialogProps={{ className: "flex-wrap text-xl" }}
-            drawerProps={{ className: "flex-wrap text-xl" }}
-          >
-            Add section to set
-          </ResponsiveDialogTitle>
-          <VStack className="mt-4 gap-4 lg:mt-0 lg:gap-8">
-            <SetSectionTypeCombobox
-              placeholder="Select a section type to add"
-              value={newSetSectionType}
-              onChange={setNewSetSectionType}
-              textStyles={cn("text-slate-700", textSize)}
-              organizationId={userMembership.organizationId}
-            />
-            <div className="mt-2 flex justify-end gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                className={cn(textSize)}
-                onClick={() => setIsAddSectionDialogOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => {
-                  setIsAddSectionDialogOpen(false);
-                  handleAddSetSection();
-                }}
-                disabled={
-                  !newSetSectionType?.id || createSetSectionMutation.isPending
-                }
-                isLoading={createSetSectionMutation.isPending}
-                className={cn(textSize)}
-              >
-                Add section to set
-              </Button>
-            </div>
-          </VStack>
-        </ResponsiveDialogContent>
-      </ResponsiveDialog>
+        onOpenChange={setIsAddSectionDialogOpen}
+        setId={setData.id}
+        organizationId={userMembership.organizationId}
+        existingSetSections={setData.sections}
+      />
 
       <SongSearchDialog
         open={isSongSearchDialogOpen}

--- a/src/modules/setSections/hooks/__tests__/useCreateSetSection.test.tsx
+++ b/src/modules/setSections/hooks/__tests__/useCreateSetSection.test.tsx
@@ -1,0 +1,217 @@
+import { act, renderHook } from "@testing-library/react";
+import { createSetSectionFixture } from "@testUtils/fixtures/setSections";
+import { createSetSectionTypeFixture } from "@testUtils/fixtures/setSectionTypes";
+import { createUuid } from "@testUtils/generators/createUuid";
+import {
+  mockCreateSetSectionMutateAsync,
+  mockInvalidateSet,
+  mockRefetchSetSections,
+  resetMockTrpc,
+  setMockCreatedSetSection,
+  type TrpcMockModule,
+} from "@testUtils/mocks/trpc";
+import { toast } from "sonner";
+
+import {
+  createSetSectionMessages,
+  useCreateSetSection,
+} from "../useCreateSetSection";
+
+jest.mock("@lib/trpc", () => {
+  const { mockTrpc } = jest.requireActual<TrpcMockModule>(
+    "@testUtils/mocks/trpc",
+  );
+
+  return { trpc: mockTrpc };
+});
+
+jest.mock("sonner", () => ({
+  toast: {
+    loading: jest.fn(() => "toast-id"),
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("useCreateSetSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockTrpc();
+    setMockCreatedSetSection(createSetSectionFixture({ id: createUuid() }));
+  });
+
+  it("creates a section at the next position and refreshes set queries", async () => {
+    const organizationId = createUuid();
+    const setId = createUuid();
+    const existingSectionType = createSetSectionTypeFixture({ organizationId });
+    const newSectionType = createSetSectionTypeFixture({ organizationId });
+    const existingSetSections = [
+      createSetSectionFixture({
+        organizationId,
+        setId,
+        sectionTypeId: existingSectionType.id,
+        position: 0,
+      }),
+    ];
+    const createdSetSection = createSetSectionFixture({
+      organizationId,
+      setId,
+      sectionTypeId: newSectionType.id,
+      position: existingSetSections.length,
+    });
+    setMockCreatedSetSection(createdSetSection);
+
+    const { result } = renderHook(() => useCreateSetSection());
+
+    let createResult: Awaited<
+      ReturnType<typeof result.current.createSetSection>
+    > | null = null;
+    await act(async () => {
+      createResult = await result.current.createSetSection({
+        organizationId,
+        setId,
+        sectionType: newSectionType,
+        existingSetSections,
+      });
+    });
+
+    expect(mockCreateSetSectionMutateAsync).toHaveBeenCalledWith({
+      organizationId,
+      setId,
+      sectionTypeId: newSectionType.id,
+      position: existingSetSections.length,
+    });
+    expect(mockRefetchSetSections).toHaveBeenCalledWith({
+      organizationId,
+      setId,
+    });
+    expect(mockInvalidateSet).toHaveBeenCalledWith({
+      organizationId,
+      setId,
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      createSetSectionMessages.success,
+      { id: "toast-id" },
+    );
+    expect(createResult).toEqual({
+      status: "created",
+      setSection: createdSetSection,
+    });
+  });
+
+  it("shows shared empty-selection validation before creating", async () => {
+    const { result } = renderHook(() => useCreateSetSection());
+
+    await act(async () => {
+      await result.current.createSetSection({
+        organizationId: createUuid(),
+        setId: createUuid(),
+        sectionType: null,
+        existingSetSections: [],
+      });
+    });
+
+    expect(mockCreateSetSectionMutateAsync).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      createSetSectionMessages.emptySelection,
+      { id: "toast-id" },
+    );
+  });
+
+  it("shows shared duplicate-section feedback before creating", async () => {
+    const organizationId = createUuid();
+    const setId = createUuid();
+    const existingSectionType = createSetSectionTypeFixture({ organizationId });
+    const existingSetSections = [
+      createSetSectionFixture({
+        organizationId,
+        setId,
+        sectionTypeId: existingSectionType.id,
+      }),
+    ];
+
+    const { result } = renderHook(() => useCreateSetSection());
+
+    await act(async () => {
+      await result.current.createSetSection({
+        organizationId,
+        setId,
+        sectionType: existingSectionType,
+        existingSetSections,
+      });
+    });
+
+    expect(mockCreateSetSectionMutateAsync).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(createSetSectionMessages.duplicate, {
+      id: "toast-id",
+    });
+  });
+
+  it("shows shared error feedback when the mutation fails", async () => {
+    const createError = new Error("database unavailable");
+    mockCreateSetSectionMutateAsync.mockRejectedValue(createError);
+
+    const { result } = renderHook(() => useCreateSetSection());
+
+    await act(async () => {
+      await result.current.createSetSection({
+        organizationId: createUuid(),
+        setId: createUuid(),
+        sectionType: createSetSectionTypeFixture(),
+        existingSetSections: [],
+      });
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      `${createSetSectionMessages.errorPrefix}: ${createError.message}`,
+      { id: "toast-id" },
+    );
+    expect(mockRefetchSetSections).not.toHaveBeenCalled();
+    expect(mockInvalidateSet).not.toHaveBeenCalled();
+  });
+
+  it("still returns the created section when refreshing set queries fails", async () => {
+    const organizationId = createUuid();
+    const setId = createUuid();
+    const createdSetSection = createSetSectionFixture({
+      organizationId,
+      setId,
+      position: 0,
+    });
+    setMockCreatedSetSection(createdSetSection);
+    const refreshError = new Error("network unavailable");
+    mockRefetchSetSections.mockRejectedValue(refreshError);
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const { result } = renderHook(() => useCreateSetSection());
+
+    let createResult: Awaited<
+      ReturnType<typeof result.current.createSetSection>
+    > | null = null;
+    await act(async () => {
+      createResult = await result.current.createSetSection({
+        organizationId,
+        setId,
+        sectionType: createSetSectionTypeFixture({ organizationId }),
+        existingSetSections: [],
+      });
+    });
+
+    expect(createResult).toEqual({
+      status: "created",
+      setSection: createdSetSection,
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      createSetSectionMessages.success,
+      { id: "toast-id" },
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to refresh set section data",
+      refreshError,
+    );
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/modules/setSections/hooks/index.ts
+++ b/src/modules/setSections/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useCreateSetSection";

--- a/src/modules/setSections/hooks/useCreateSetSection.ts
+++ b/src/modules/setSections/hooks/useCreateSetSection.ts
@@ -1,0 +1,116 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+
+import { type RouterOutputs, trpc } from "@lib/trpc";
+
+type ExistingSetSection = {
+  sectionTypeId: string;
+};
+
+type SelectedSetSectionType = {
+  id: string;
+} | null;
+
+type CreatedSetSection = NonNullable<
+  RouterOutputs["setSection"]["create"][number]
+>;
+
+type CreateSetSectionParams = {
+  setId: string;
+  organizationId: string;
+  sectionType: SelectedSetSectionType;
+  existingSetSections: readonly ExistingSetSection[];
+};
+
+type CreateSetSectionResult =
+  | { status: "created"; setSection: CreatedSetSection }
+  | { status: "duplicate" | "invalid" | "error" };
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : "Unknown error";
+
+export const createSetSectionMessages = {
+  loading: "Adding section to set...",
+  emptySelection: "Please select a section type",
+  duplicate: "Section type already exists on this set",
+  success: "Section added to set",
+  errorPrefix: "Could not add section to set",
+} as const;
+
+export const useCreateSetSection = () => {
+  const createSetSectionMutation = trpc.setSection.create.useMutation();
+  const apiUtils = trpc.useUtils();
+
+  const createSetSection = useCallback(
+    async ({
+      setId,
+      organizationId,
+      sectionType,
+      existingSetSections,
+    }: CreateSetSectionParams): Promise<CreateSetSectionResult> => {
+      const toastId = toast.loading(createSetSectionMessages.loading);
+
+      if (!sectionType?.id) {
+        toast.error(createSetSectionMessages.emptySelection, { id: toastId });
+        return { status: "invalid" };
+      }
+
+      const setAlreadyHasSelectedSection = existingSetSections.some(
+        (setSection) => setSection.sectionTypeId === sectionType.id,
+      );
+
+      if (setAlreadyHasSelectedSection) {
+        toast.error(createSetSectionMessages.duplicate, { id: toastId });
+        return { status: "duplicate" };
+      }
+
+      let newSetSection: CreatedSetSection;
+
+      try {
+        const [createdSetSection] = await createSetSectionMutation.mutateAsync({
+          setId,
+          organizationId,
+          sectionTypeId: sectionType.id,
+          position: existingSetSections.length,
+        });
+
+        if (!createdSetSection) {
+          throw new Error("No section was created");
+        }
+
+        newSetSection = createdSetSection;
+      } catch (error) {
+        toast.error(
+          `${createSetSectionMessages.errorPrefix}: ${getErrorMessage(error)}`,
+          { id: toastId },
+        );
+        return { status: "error" };
+      }
+
+      toast.success(createSetSectionMessages.success, { id: toastId });
+
+      try {
+        await Promise.all([
+          apiUtils.setSection.getSectionsForSet.refetch({
+            organizationId,
+            setId,
+          }),
+          apiUtils.set.get.invalidate({
+            organizationId,
+            setId,
+          }),
+        ]);
+      } catch (error) {
+        console.error("Failed to refresh set section data", error);
+      }
+
+      return { status: "created", setSection: newSetSection };
+    },
+    [apiUtils, createSetSectionMutation],
+  );
+
+  return {
+    createSetSection,
+    isPending: createSetSectionMutation.isPending,
+  };
+};

--- a/src/modules/sets/components/SetSectionCreationDialog/SetSectionCreationDialog.tsx
+++ b/src/modules/sets/components/SetSectionCreationDialog/SetSectionCreationDialog.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
+
+import { Button } from "@components/ui/button";
+import { type ComboboxOption } from "@components/ui/combobox";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@components/ResponsiveDialog";
+import { VStack } from "@components/VStack";
+import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { useCreateSetSection } from "@modules/setSections/hooks";
+import { type SetSectionWithSongs } from "@lib/types";
+import { cn } from "@lib/utils";
+import { useResponsive } from "@/hooks/useResponsive";
+
+type SetSectionCreationDialogProps = {
+  open: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  setId: string;
+  organizationId: string;
+  existingSetSections: SetSectionWithSongs[];
+};
+
+export const SetSectionCreationDialog: React.FC<
+  SetSectionCreationDialogProps
+> = ({
+  open,
+  onOpenChange,
+  setId,
+  organizationId,
+  existingSetSections,
+}) => {
+  const { textSize } = useResponsive();
+  const [newSetSectionType, setNewSetSectionType] =
+    useState<ComboboxOption | null>(null);
+  const { createSetSection, isPending } = useCreateSetSection();
+
+  const closeDialog = () => {
+    setNewSetSectionType(null);
+    onOpenChange(false);
+  };
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      setNewSetSectionType(null);
+    }
+    onOpenChange(isOpen);
+  };
+
+  const handleAddSetSection = async () => {
+    const result = await createSetSection({
+      setId,
+      organizationId,
+      sectionType: newSetSectionType,
+      existingSetSections,
+    });
+
+    if (result.status === "created") {
+      closeDialog();
+    }
+  };
+
+  return (
+    <ResponsiveDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      drawerProps={{ repositionInputs: true }}
+    >
+      <ResponsiveDialogContent className="p-6 lg:p-8">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogDescription asChild>
+            <VisuallyHidden.Root>Dialog to add section to set</VisuallyHidden.Root>
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <ResponsiveDialogTitle
+          dialogProps={{ className: "flex-wrap text-xl" }}
+          drawerProps={{ className: "flex-wrap text-xl" }}
+        >
+          Add section to set
+        </ResponsiveDialogTitle>
+        <VStack className="mt-4 gap-4 lg:mt-0 lg:gap-8">
+          <SetSectionTypeCombobox
+            placeholder="Select a section type to add"
+            value={newSetSectionType}
+            onChange={setNewSetSectionType}
+            textStyles={cn("text-slate-700", textSize)}
+            organizationId={organizationId}
+          />
+          <div className="mt-2 flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn(textSize)}
+              onClick={closeDialog}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleAddSetSection}
+              disabled={!newSetSectionType?.id || isPending}
+              isLoading={isPending}
+              className={cn(textSize)}
+            >
+              Add section to set
+            </Button>
+          </div>
+        </VStack>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+};

--- a/src/modules/sets/components/SetSectionCreationDialog/__tests__/SetSectionCreationDialog.test.tsx
+++ b/src/modules/sets/components/SetSectionCreationDialog/__tests__/SetSectionCreationDialog.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createSetSectionFixture } from "@testUtils/fixtures/setSections";
+import { createSetSectionTypeFixture } from "@testUtils/fixtures/setSectionTypes";
+import { createUuid } from "@testUtils/generators/createUuid";
+
+import { type SetSectionWithSongs } from "@lib/types";
+
+import { SetSectionCreationDialog } from "../SetSectionCreationDialog";
+
+const mockSelectedSetSectionType = createSetSectionTypeFixture();
+const mockCreateSetSection = jest.fn();
+
+jest.mock("@modules/setSections/hooks", () => ({
+  useCreateSetSection: jest.fn(() => ({
+    createSetSection: mockCreateSetSection,
+    isPending: false,
+  })),
+}));
+
+jest.mock("@modules/sets/components/SetSectionTypeCombobox", () => ({
+  SetSectionTypeCombobox: ({
+    onChange,
+  }: {
+    onChange: (option: typeof mockSelectedSetSectionType) => void;
+  }) => (
+    <button type="button" onClick={() => onChange(mockSelectedSetSectionType)}>
+      Select section type
+    </button>
+  ),
+}));
+
+jest.mock("@/hooks/useResponsive", () => ({
+  useResponsive: () => ({
+    isDesktop: true,
+    isMobile: false,
+    textSize: "text-base",
+  }),
+}));
+
+describe("SetSectionCreationDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateSetSection.mockResolvedValue({
+      status: "created",
+      setSection: createSetSectionFixture(),
+    });
+  });
+
+  it("uses the shared section creation path from the set detail dialog", async () => {
+    const setId = createUuid();
+    const organizationId = createUuid();
+    const existingSetSections = [
+      createSetSectionFixture({ setId, organizationId }),
+    ] as SetSectionWithSongs[];
+    const onOpenChange = jest.fn();
+
+    render(
+      <SetSectionCreationDialog
+        open
+        onOpenChange={onOpenChange}
+        setId={setId}
+        organizationId={organizationId}
+        existingSetSections={existingSetSections}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select section type" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add section to set" }));
+
+    await waitFor(() => {
+      expect(mockCreateSetSection).toHaveBeenCalledWith({
+        setId,
+        organizationId,
+        sectionType: mockSelectedSetSectionType,
+        existingSetSections,
+      });
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/modules/sets/components/SetSectionCreationDialog/index.ts
+++ b/src/modules/sets/components/SetSectionCreationDialog/index.ts
@@ -1,0 +1,1 @@
+export * from "./SetSectionCreationDialog";

--- a/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
+++ b/src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx
@@ -39,6 +39,7 @@ import { HStack } from "@components/HStack";
 import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { useCreateSetSection } from "@modules/setSections/hooks";
 import { SongListItem } from "@modules/songs/components/SongListItem";
 import { type SongSearchResult } from "@modules/songs/components/SongSearch";
 import { type SongSearchDialogSteps } from "@modules/songs/components/SongSearchDialog";
@@ -104,7 +105,6 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   const {
     formState: { isDirty, isSubmitting, isValid },
     setValue,
-    setError,
     clearErrors,
   } = addSongToSetForm;
 
@@ -120,7 +120,8 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   const shouldAddSongBeDisabled = !isDirty || !isValid || isSubmitting;
 
   const addSetSectionSongMutation = trpc.setSectionSong.create.useMutation();
-  const createSetSectionMutation = trpc.setSection.create.useMutation();
+  const { createSetSection, isPending: isCreateSetSectionPending } =
+    useCreateSetSection();
   const apiUtils = trpc.useUtils();
 
   const {
@@ -175,58 +176,22 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
   ) => {
     clickEvent.preventDefault();
 
-    if (!newSetSectionType) {
-      // TODO: this case shouldn't happen, but how would we properly handle it just in case?
-      return;
-    }
+    const result = await createSetSection({
+      setId,
+      organizationId: userMembership.organizationId,
+      sectionType: newSetSectionType,
+      existingSetSections: sectionsForSetData,
+    });
 
-    const setAlreadyHasSelectedSection = sectionsForSetData.some(
-      (setSection) => setSection.sectionTypeId === newSetSectionType.id,
-    );
-
-    if (!setAlreadyHasSelectedSection) {
-      const positionForNewSetSection = sectionsForSetData.length;
-
-      await createSetSectionMutation.mutateAsync(
-        {
-          setId,
-          organizationId: userMembership.organizationId,
-          sectionTypeId: newSetSectionType.id,
-          position: positionForNewSetSection,
-        },
-        {
-          async onSuccess(createSetSectionMutationResult) {
-            const [newSetSection] = createSetSectionMutationResult;
-
-            if (newSetSection) {
-              setValue("setSectionId", newSetSection.id, {
-                shouldValidate: true,
-                shouldDirty: true,
-                shouldTouch: true,
-              });
-
-              setNewSetSectionType(null);
-
-              toast.success(`Section added to set`);
-
-              await apiUtils.setSection.getSectionsForSet.refetch({
-                organizationId: userMembership.organizationId,
-                setId,
-              });
-
-              await apiUtils.set.get.invalidate({
-                setId,
-                organizationId: userMembership.organizationId,
-              });
-            }
-          },
-        },
-      );
-    } else {
-      setError("setSectionId", {
-        type: "custom",
-        message: "Section already exists on set",
+    if (result.status === "created") {
+      setValue("setSectionId", result.setSection.id, {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
       });
+
+      setNewSetSectionType(null);
+      clearErrors("setSectionId");
     }
   };
 
@@ -534,9 +499,9 @@ export const ConfigureSongForSet: React.FC<ConfigureSongForSetProps> = ({
                           disabled={
                             !newSetSectionType ||
                             newSetSectionType.id === "" ||
-                            createSetSectionMutation.isPending
+                            isCreateSetSectionPending
                           }
-                          isLoading={createSetSectionMutation.isPending}
+                          isLoading={isCreateSetSectionPending}
                           className={cn(textSize)}
                         >
                           Add section to set

--- a/src/modules/songs/forms/AddSongToSet/components/SetSectionSelectionStep.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/SetSectionSelectionStep.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Plus } from "@phosphor-icons/react";
-import { toast } from "sonner";
 
 import { Button } from "@components/ui/button";
 import { type ComboboxOption } from "@components/ui/combobox";
@@ -10,6 +9,7 @@ import { Text } from "@components/Text";
 import { VStack } from "@components/VStack";
 import { SongContent } from "@modules/SetListCard/components/SongContent";
 import { SetSectionTypeCombobox } from "@modules/sets/components/SetSectionTypeCombobox";
+import { useCreateSetSection } from "@modules/setSections/hooks";
 import { SelectedSetCard } from "@modules/songs/forms/AddSongToSet/components";
 import { type SelectedSet } from "@modules/songs/forms/AddSongToSet/components/addSongToSetWorkflow";
 import { useUserQuery } from "@modules/users/api/queries";
@@ -35,8 +35,8 @@ export const SetSectionSelectionStep: React.FC<
   const { textSize, isDesktop } = useResponsive();
   const { userMembership } = useUserQuery();
 
-  const createSetSectionMutation = trpc.setSection.create.useMutation();
-  const apiUtils = trpc.useUtils();
+  const { createSetSection, isPending: isCreateSetSectionPending } =
+    useCreateSetSection();
 
   const { data: setData } = trpc.set.get.useQuery(
     {
@@ -66,64 +66,16 @@ export const SetSectionSelectionStep: React.FC<
   ) => {
     clickEvent.preventDefault();
 
-    if (!newSetSectionType) {
-      // TODO: this case shouldn't happen, but how would we properly handle it just in case?
-      return;
-    }
+    const result = await createSetSection({
+      setId: setData.id,
+      organizationId: userMembership.organizationId,
+      sectionType: newSetSectionType,
+      existingSetSections: setData.sections,
+    });
 
-    const setAlreadyHasSelectedSection = setData?.sections.some(
-      (setSection) => setSection.sectionTypeId === newSetSectionType.id,
-    );
-
-    const toastId = toast.loading("Adding section to set...");
-
-    if (!setAlreadyHasSelectedSection) {
-      const positionForNewSetSection = setData.sections.length;
-
-      try {
-        const createSetSectionMutationResult =
-          await createSetSectionMutation.mutateAsync({
-            setId: setData.id,
-            organizationId: userMembership.organizationId,
-            sectionTypeId: newSetSectionType.id,
-            position: positionForNewSetSection,
-          });
-
-        const [newSetSection] = createSetSectionMutationResult;
-
-        if (newSetSection) {
-          setNewSetSectionType(null);
-
-          toast.success(`Section added to set`, { id: toastId });
-
-          try {
-            await apiUtils.setSection.getSectionsForSet.refetch({
-              organizationId: userMembership.organizationId,
-              setId: setData.id,
-            });
-
-            await apiUtils.set.get.invalidate({
-              setId: setData.id,
-              organizationId: userMembership.organizationId,
-            });
-          } catch (error) {
-            console.error("Failed to refresh set section data", error);
-          }
-
-          onSelectSetSection(newSetSection.id, 0);
-        }
-      } catch (createSetSectionError) {
-        const errorMessage =
-          createSetSectionError instanceof Error
-            ? createSetSectionError.message
-            : "Unknown error";
-
-        toast.error(`Could not add section to set: ${errorMessage}`, {
-          id: toastId,
-        });
-      }
-    } else {
-      toast.error("Section already exists on set", { id: toastId });
+    if (result.status === "created") {
+      setNewSetSectionType(null);
+      onSelectSetSection(result.setSection.id, 0);
     }
   };
 
@@ -226,9 +178,9 @@ export const SetSectionSelectionStep: React.FC<
                   disabled={
                     !newSetSectionType ||
                     newSetSectionType.id === "" ||
-                    createSetSectionMutation.isPending
+                    isCreateSetSectionPending
                   }
-                  isLoading={createSetSectionMutation.isPending}
+                  isLoading={isCreateSetSectionPending}
                   className={cn(textSize)}
                 >
                   Add section to set

--- a/src/modules/songs/forms/AddSongToSet/components/__tests__/SetSectionSelectionStep.test.tsx
+++ b/src/modules/songs/forms/AddSongToSet/components/__tests__/SetSectionSelectionStep.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createOrganizationMembershipWithOrganizationFixture } from "@testUtils/fixtures/organizations";
+import { createSetWithSectionsSongsAndEventTypeFixture } from "@testUtils/fixtures/sets";
+import { createSetSectionFixture } from "@testUtils/fixtures/setSections";
+import { createSetSectionTypeFixture } from "@testUtils/fixtures/setSectionTypes";
+
+import { useUserQuery } from "@modules/users/api/queries";
+import { trpc } from "@lib/trpc";
+
+import { SetSectionSelectionStep } from "../SetSectionSelectionStep";
+
+const mockSelectedSetSectionType = createSetSectionTypeFixture();
+const mockCreateSetSection = jest.fn();
+
+jest.mock("@modules/setSections/hooks", () => ({
+  useCreateSetSection: jest.fn(() => ({
+    createSetSection: mockCreateSetSection,
+    isPending: false,
+  })),
+}));
+
+jest.mock("@modules/sets/components/SetSectionTypeCombobox", () => ({
+  SetSectionTypeCombobox: ({
+    onChange,
+  }: {
+    onChange: (option: typeof mockSelectedSetSectionType) => void;
+  }) => (
+    <button type="button" onClick={() => onChange(mockSelectedSetSectionType)}>
+      Select section type
+    </button>
+  ),
+}));
+
+jest.mock("@modules/songs/forms/AddSongToSet/components", () => ({
+  SelectedSetCard: ({ set }: { set: { id: string } }) => (
+    <div>Selected set {set.id}</div>
+  ),
+}));
+
+jest.mock("@modules/users/api/queries", () => ({
+  useUserQuery: jest.fn(),
+}));
+
+jest.mock("@/hooks/useResponsive", () => ({
+  useResponsive: () => ({
+    isDesktop: true,
+    isMobile: false,
+    textSize: "text-base",
+  }),
+}));
+
+jest.mock("@lib/trpc", () => ({
+  trpc: {
+    set: {
+      get: {
+        useQuery: jest.fn(),
+      },
+    },
+  },
+}));
+
+const mockUseUserQuery = useUserQuery as jest.Mock;
+const mockSetGetUseQuery = trpc.set.get.useQuery as jest.Mock;
+
+describe("SetSectionSelectionStep", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateSetSection.mockResolvedValue({
+      status: "created",
+      setSection: createSetSectionFixture(),
+    });
+  });
+
+  it("uses the shared section creation path from the add-song section step", async () => {
+    const membership = createOrganizationMembershipWithOrganizationFixture();
+    const set = createSetWithSectionsSongsAndEventTypeFixture({
+      organizationId: membership.organizationId,
+    });
+    const createdSetSection = createSetSectionFixture({
+      setId: set.id,
+      organizationId: membership.organizationId,
+    });
+    const onSelectSetSection = jest.fn();
+    mockCreateSetSection.mockResolvedValue({
+      status: "created",
+      setSection: createdSetSection,
+    });
+    mockUseUserQuery.mockReturnValue({ userMembership: membership });
+    mockSetGetUseQuery.mockReturnValue({ data: set });
+
+    render(
+      <SetSectionSelectionStep
+        selectedSet={{ id: set.id, songCount: 0 }}
+        onSelectSetSection={onSelectSetSection}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /add another section/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Select section type" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add section to set" }));
+
+    await waitFor(() => {
+      expect(mockCreateSetSection).toHaveBeenCalledWith({
+        setId: set.id,
+        organizationId: membership.organizationId,
+        sectionType: mockSelectedSetSectionType,
+        existingSetSections: set.sections,
+      });
+    });
+    expect(onSelectSetSection).toHaveBeenCalledWith(createdSetSection.id, 0);
+  });
+});

--- a/src/testUtils/mocks/trpc.ts
+++ b/src/testUtils/mocks/trpc.ts
@@ -1,7 +1,7 @@
 import { createTagFixture } from "@testUtils/fixtures/tags";
 import { createUuid } from "@testUtils/generators/createUuid";
 
-import { type Tag } from "@lib/types";
+import { type SetSection, type Tag } from "@lib/types";
 
 export type SongTagResult = {
   songId: string;
@@ -33,6 +33,13 @@ type CreateTagInput = {
   tag: string;
 };
 
+type CreateSetSectionInput = {
+  organizationId: string;
+  setId: string;
+  sectionTypeId: string;
+  position: number;
+};
+
 const createQueryResult = <Data>(data: Data): QueryResult<Data> => ({
   data,
   error: null,
@@ -43,6 +50,24 @@ let mockOrganizationTagsQuery = createQueryResult<Tag[]>([]);
 let mockSongTagsQuery = createQueryResult<SongTagResult[]>([]);
 let mockCreatedTag: Tag | undefined;
 let mockCreateTagHookCallbacks: MutationCallbacks<Tag> | undefined;
+let mockCreatedSetSection: SetSection | undefined;
+
+const createSetSectionMutationResult = async (
+  input: unknown,
+): Promise<SetSection[]> => {
+  const createInput = input as Partial<CreateSetSectionInput>;
+  const createdSetSection =
+    mockCreatedSetSection ??
+    ({
+      id: createUuid(),
+      organizationId: createInput.organizationId ?? createUuid(),
+      setId: createInput.setId ?? createUuid(),
+      sectionTypeId: createInput.sectionTypeId ?? createUuid(),
+      position: createInput.position ?? 0,
+    } as SetSection);
+
+  return [createdSetSection];
+};
 
 export const mockCreateSongTagMutate = jest.fn(
   (_input: unknown, callbacks?: MutationCallbacks) => {
@@ -75,9 +100,15 @@ export const mockCreateTagMutate = jest.fn(
   },
 );
 
+export const mockCreateSetSectionMutateAsync = jest.fn(
+  createSetSectionMutationResult,
+);
+
 export const mockInvalidateSongTags = jest.fn();
 export const mockInvalidateSong = jest.fn();
 export const mockInvalidateOrganizationTags = jest.fn();
+export const mockRefetchSetSections = jest.fn();
+export const mockInvalidateSet = jest.fn();
 
 export const setMockOrganizationTagsQuery = (
   queryResult: QueryResult<Tag[]>,
@@ -95,14 +126,43 @@ export const setMockCreatedTag = (tag: Tag) => {
   mockCreatedTag = tag;
 };
 
+export const setMockCreatedSetSection = (setSection: SetSection) => {
+  mockCreatedSetSection = setSection;
+};
+
 export const resetMockTrpc = () => {
   mockOrganizationTagsQuery = createQueryResult([]);
   mockSongTagsQuery = createQueryResult([]);
   mockCreatedTag = undefined;
   mockCreateTagHookCallbacks = undefined;
+  mockCreatedSetSection = undefined;
+  mockCreateSetSectionMutateAsync.mockReset();
+  mockCreateSetSectionMutateAsync.mockImplementation(
+    createSetSectionMutationResult,
+  );
+  mockRefetchSetSections.mockReset();
+  mockRefetchSetSections.mockResolvedValue(undefined);
+  mockInvalidateSet.mockReset();
+  mockInvalidateSet.mockResolvedValue(undefined);
 };
 
 export const mockTrpc = {
+  set: {
+    get: {
+      invalidate: mockInvalidateSet,
+    },
+  },
+  setSection: {
+    create: {
+      useMutation: jest.fn(() => ({
+        mutateAsync: mockCreateSetSectionMutateAsync,
+        isPending: false,
+      })),
+    },
+    getSectionsForSet: {
+      refetch: mockRefetchSetSections,
+    },
+  },
   songTag: {
     create: {
       useMutation: jest.fn(() => ({
@@ -139,6 +199,16 @@ export const mockTrpc = {
     },
   },
   useUtils: jest.fn(() => ({
+    set: {
+      get: {
+        invalidate: mockInvalidateSet,
+      },
+    },
+    setSection: {
+      getSectionsForSet: {
+        refetch: mockRefetchSetSections,
+      },
+    },
     song: {
       get: {
         invalidate: mockInvalidateSong,


### PR DESCRIPTION
## Background
- Linear ticket: [SWY-200](https://linear.app/paranoid-android/issue/SWY-200/extract-shared-set-section-creation-flow).
- This extracts duplicated set-section creation behavior so the set detail page and add-song flows share validation, duplicate handling, loading feedback, and query refresh behavior.
- The goal is to keep the user-facing flows stable while making the creation behavior easier to test and reuse.

## What's changed
@coderabbitai summary
- Added `useCreateSetSection` to centralize mutation payload shaping, empty-selection and duplicate validation, success/error toasts, and post-create query refresh.
- Extracted `SetSectionCreationDialog` from the set detail page and wired it to the shared hook.
- Updated `ConfigureSongForSet` and `SetSectionSelectionStep` to call the shared creation path, with focused tests for the hook, set detail dialog, and add-song section selection.
- Extended the shared TRPC test mock with set-section mutation and cache utility helpers.

## How to test
- Open a set detail page, use the actions menu or “Add another section” control, add a new section type, and confirm the section appears with a success toast.
- In the add-song workflow, select a set, add a new section from the section-selection step, and confirm the wizard selects the newly created section.
- Try adding a duplicate section type from either surface and confirm the duplicate feedback is consistent.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts duplicated set-section creation logic from the set detail page, `ConfigureSongForSet`, and `SetSectionSelectionStep` into a shared `useCreateSetSection` hook and a new `SetSectionCreationDialog` component, keeping all three surfaces behaviorally consistent for validation, toast feedback, and post-create cache refresh.

- `useCreateSetSection` centralizes mutation payload shaping, empty-selection and duplicate validation, success/error toasts, and `refetch`/`invalidate` calls, returning a discriminated-union result that callers branch on.
- `SetSectionCreationDialog` is extracted from the set detail page's inline dialog and wired to the hook; `ConfigureSongForSet` and `SetSectionSelectionStep` replace their inline mutation code with calls to the same hook.
- Test coverage is added for the hook (all validation branches, mutation error, graceful refetch failure), the dialog (happy path), and the section-selection step (shared creation path).

<h3>Confidence Score: 3/5</h3>

The refactoring is clean and well-tested overall, but the hook exposes a loading flag that goes dark before the full async operation completes, leaving "Add section to set" buttons briefly re-enabled across all three surfaces while the cache refresh is still in flight.

The `isPending` value returned by `useCreateSetSection` reflects only whether `mutateAsync` is running, not the subsequent `Promise.all([refetch, invalidate])`. After the mutation resolves, React re-renders consumers at the next `await` yield, re-enabling every button guarded by `isPending` before `createSetSection` returns. During that window, the duplicate check still runs against the pre-refetch `existingSetSections` snapshot, so a rapid second click can create a second section of the same type at the same position. This affects all three call sites added in this PR.

src/modules/setSections/hooks/useCreateSetSection.ts — the `isPending` return value needs to cover the full async span, not just the mutation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/modules/setSections/hooks/useCreateSetSection.ts | New shared hook centralizing mutation, validation, toast feedback, and cache refresh — but `isPending` reflects only the mutation state, not the full async op including refetch/invalidate, creating a brief re-enable window on the "Add" button after each successful create. |
| src/modules/sets/components/SetSectionCreationDialog/SetSectionCreationDialog.tsx | Clean extraction of the inline dialog from page.tsx; correctly keeps dialog open on non-"created" results and resets combobox state on close. Inherits the isPending race window from the hook. |
| src/modules/songs/components/ConfigureSongForSet/ConfigureSongForSet.tsx | Migrated to shared hook cleanly; adds `clearErrors("setSectionId")` on success which is good defensive cleanup of the stale form error that could have been left by the now-removed `setError` call for duplicates. |
| src/modules/songs/forms/AddSongToSet/components/SetSectionSelectionStep.tsx | Migrated to shared hook; removes inline duplicate/error handling and delegates all feedback to `useCreateSetSection`. Inherits the isPending race window from the hook. |
| src/modules/setSections/hooks/__tests__/useCreateSetSection.test.tsx | Good coverage across validation, duplicate detection, mutation error, and the graceful-degradation path where refetch fails but the created section is still returned. |
| src/modules/sets/components/SetSectionCreationDialog/__tests__/SetSectionCreationDialog.test.tsx | Tests the success path and verifies `onOpenChange(false)` is called, but is missing coverage for the dialog-stays-open behavior on duplicate/error results. |
| src/testUtils/mocks/trpc.ts | Extended with `setSection.create` mutation mock and `set/setSection` cache utility helpers; `resetMockTrpc` correctly resets all new mocks between tests. |
| src/app/[organization]/sets/[setId]/page.tsx | Good cleanup — inline dialog, mutation, and combobox state removed; wired to the new `SetSectionCreationDialog` component with the same props the old dialog used. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant Dialog as SetSectionCreationDialog
    participant Hook as useCreateSetSection
    participant Mutation as trpc.setSection.create
    participant Cache as apiUtils (refetch/invalidate)

    User->>Dialog: clicks "Add section to set"
    Dialog->>Hook: "createSetSection({ setId, organizationId, sectionType, existingSetSections })"
    Hook->>Hook: validate (empty / duplicate check)
    Hook->>Mutation: "mutateAsync({ setId, organizationId, sectionTypeId, position })"
    Note over Hook,Mutation: isPending = true → button disabled
    Mutation-->>Hook: returns [createdSetSection]
    Note over Hook,Mutation: isPending = false ← ⚠️ button re-enables here
    Hook->>Hook: toast.success()
    Hook->>Cache: Promise.all([refetch getSectionsForSet, invalidate set.get])
    Note over Hook,Cache: button is enabled during this await window
    Cache-->>Hook: resolves
    Hook-->>Dialog: "{ status: "created", setSection }"
    Dialog->>Dialog: closeDialog() → onOpenChange(false), reset combobox
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant Dialog as SetSectionCreationDialog
    participant Hook as useCreateSetSection
    participant Mutation as trpc.setSection.create
    participant Cache as apiUtils (refetch/invalidate)

    User->>Dialog: clicks "Add section to set"
    Dialog->>Hook: "createSetSection({ setId, organizationId, sectionType, existingSetSections })"
    Hook->>Hook: validate (empty / duplicate check)
    Hook->>Mutation: "mutateAsync({ setId, organizationId, sectionTypeId, position })"
    Note over Hook,Mutation: isPending = true → button disabled
    Mutation-->>Hook: returns [createdSetSection]
    Note over Hook,Mutation: isPending = false ← ⚠️ button re-enables here
    Hook->>Hook: toast.success()
    Hook->>Cache: Promise.all([refetch getSectionsForSet, invalidate set.get])
    Note over Hook,Cache: button is enabled during this await window
    Cache-->>Hook: resolves
    Hook-->>Dialog: "{ status: "created", setSection }"
    Dialog->>Dialog: closeDialog() → onOpenChange(false), reset combobox
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/modules/sets/components/SetSectionCreationDialog/__tests__/SetSectionCreationDialog.test.tsx`, line 727-757 ([link](https://github.com/justaddcl/sanbi/blob/310482e9cd9b6356193b4b9da700071b1d680008/src/modules/sets/components/SetSectionCreationDialog/__tests__/SetSectionCreationDialog.test.tsx#L727-L757)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Only the success path is tested**

   The suite has a single test for the happy-path flow where `createSetSection` resolves to `"created"`. The component has distinct behavior for `"duplicate"` and `"error"` results — specifically, the dialog should stay open and preserve the selection so the user can correct it. Without tests for those paths, a future refactor that accidentally called `closeDialog()` on every result status would go undetected.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/modules/sets/components/SetSectionCreationDialog/__tests__/SetSectionCreationDialog.test.tsx
   Line: 727-757

   Comment:
   **Only the success path is tested**

   The suite has a single test for the happy-path flow where `createSetSection` resolves to `"created"`. The component has distinct behavior for `"duplicate"` and `"error"` results — specifically, the dialog should stay open and preserve the selection so the user can correct it. Without tests for those paths, a future refactor that accidentally called `closeDialog()` on every result status would go undetected.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/modules/setSections/hooks/useCreateSetSection.ts:112-115
**`isPending` flips to `false` before the full async operation completes**

`createSetSectionMutation.isPending` becomes `false` as soon as `mutateAsync` resolves — before `Promise.all([refetch, invalidate])` finishes. When React re-renders consumers at the first `await` yield inside `Promise.all`, every "Add section to set" button guarded by `isPending` becomes re-enabled while `createSetSection` is still executing. During this window, a user can click the button again: the duplicate-check will pass because `existingSetSections` still comes from the pre-refetch snapshot, allowing a second section of the same type to be created at `position = existingSetSections.length`.

The same exposure affects `SetSectionCreationDialog`, `ConfigureSongForSet`, and `SetSectionSelectionStep`. The fix is to track a separate boolean that spans the full async operation:

```ts
// inside useCreateSetSection
const [isCreating, setIsCreating] = useState(false);

const createSetSection = useCallback(async (...) => {
  setIsCreating(true);
  try {
    // ... existing logic ...
  } finally {
    setIsCreating(false);
  }
}, [apiUtils, createSetSectionMutation]);

return { createSetSection, isPending: isCreating };
```

### Issue 2 of 2
src/modules/sets/components/SetSectionCreationDialog/__tests__/SetSectionCreationDialog.test.tsx:727-757
**Only the success path is tested**

The suite has a single test for the happy-path flow where `createSetSection` resolves to `"created"`. The component has distinct behavior for `"duplicate"` and `"error"` results — specifically, the dialog should stay open and preserve the selection so the user can correct it. Without tests for those paths, a future refactor that accidentally called `closeDialog()` on every result status would go undetected.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Use shared section creation in add-song ..."](https://github.com/justaddcl/sanbi/commit/310482e9cd9b6356193b4b9da700071b1d680008) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40220120)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->